### PR TITLE
Improve error handling for FireCrawl API and simplify state structure in related paper retrieval

### DIFF
--- a/src/airas/retrieve/retrieve_paper_from_query_subgraph/nodes/web_scrape_node.py
+++ b/src/airas/retrieve/retrieve_paper_from_query_subgraph/nodes/web_scrape_node.py
@@ -23,15 +23,21 @@ def web_scrape_node(
 
             try:
                 response = client.scrape(full_url)
-                markdown = (
-                    (response.get("data") or {}).get("markdown") if response else None
-                )
-                if markdown:
-                    scraped_results.append(markdown)
-                else:
-                    logger.warning("'markdown' not found in response data")
             except Exception as e:
                 logger.error(f"Error with FireCrawl API: {e}")
+                raise RuntimeError(f"FireCrawl API error for URL: {full_url}") from e
+            data = response.get("data") if isinstance(response, dict) else None
+            if not data:
+                logger.warning(f"No data returned for URL: {full_url}")
+                continue
+            markdown = data.get("markdown")
+            if not markdown:
+                logger.warning(f"'markdown' missing in data for URL: {full_url}")
+                continue
+            scraped_results.append(markdown)
+
+    if not scraped_results:
+        raise RuntimeError("No markdown obtained for any URL")
     return scraped_results
 
 

--- a/src/airas/retrieve/retrieve_related_paper_subgraph/retrieve_related_paper_subgraph.py
+++ b/src/airas/retrieve/retrieve_related_paper_subgraph/retrieve_related_paper_subgraph.py
@@ -1,5 +1,4 @@
 import os
-import json
 import shutil
 import operator
 import argparse
@@ -118,9 +117,9 @@ class RetrieveRelatedPaperSubgraph:
         )
 
     def _initialize_state(self, state: RetrieveRelatedPaperState) -> dict:
-        selected_base_paper_info = json.loads(state["base_method_text"])
+        # selected_base_paper_info = json.loads(state["base_method_text"])
         selected_base_paper_info = TypeAdapter(CandidatePaperInfo).validate_python(
-            selected_base_paper_info
+            state["base_method_text"]
         )
         return {
             "selected_base_paper_info": selected_base_paper_info,
@@ -271,7 +270,7 @@ class RetrieveRelatedPaperSubgraph:
     @time_node("retrieve_add_paper_subgraph", "_select_best_paper_node")
     def _select_best_paper_node(self, state: RetrieveRelatedPaperState) -> dict:
         candidate_papers_info_list = state["candidate_add_papers_info_list"]
-        base_arxiv_id = state["selected_base_paper_info"].arxiv_id
+        base_arxiv_id = state["selected_base_paper_info"]["arxiv_id"]
         filtered_candidates = [
             paper_info
             for paper_info in candidate_papers_info_list
@@ -290,7 +289,7 @@ class RetrieveRelatedPaperSubgraph:
         selected_paper_info_list = [
             paper_info
             for paper_info in candidate_papers_info_list
-            if paper_info.arxiv_id in selected_arxiv_ids
+            if paper_info["arxiv_id"] in selected_arxiv_ids
         ]
         # 選択された論文を別のディレクトリにコピーする
         for paper_info in selected_paper_info_list:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- Something else!

#### Description

- Closes 
  - #36
  - #37 
- What does this PR change? Give us a brief description.
---
## Description

# Background & Purpose
The current implementation lacks proper error handling for the FireCrawl API, and it relies on unnecessary JSON parsing and object-based access in state handling.
This Pull Request (PR) implements refactoring and enhancements to improve robustness. 

Details of the implementation are described below:

<details>
<summary><code>1. src/airas/retrieve/retrieve_paper_from_query_subgraph/nodes/web_scrape_node.py</code></summary>

 **Implementation Overview**
- Previously: Wrapped both scraping and result parsing in a broad `try-except`; failures silently skipped.
- Now: Only `client.scrape()` is wrapped. If it fails, logs error and raises `RuntimeError` with context.
- Added detailed log messages for missing `data` or `markdown`.
- Added final check: if `scraped_results` is empty, raise `RuntimeError`.

</details>

<details>
<summary><code>2. src/airas/retrieve/retrieve_related_paper_subgraph/retrieve_related_paper_subgraph.py</code></summary>

 **Implementation Overview**
- Previously: Parsed `state["base_method_text"]` using `json.loads()` and validated it into a `CandidatePaperInfo` object, using dot access (`.arxiv_id`).
- Now: Assumes `base_method_text` is already a Python object (e.g., `dict`), and validates it directly with `validate_python()`.
- Updated all references to `CandidatePaperInfo` fields from object-style to dict-style access (`["arxiv_id"]`).

</details>