### PR TITLE
Refactor GitHub API Usage and Fix 422 Error in Workflow Dispatch

### DIFF
--- a/src/airas/analysis/analytic_subgraph/analytic_subgraph.py
+++ b/src/airas/analysis/analytic_subgraph/analytic_subgraph.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 
 from langgraph.graph import END, START, StateGraph
@@ -96,11 +97,11 @@ def main():
         llm_name=llm_name,
     )
     result = an.run()
-    print(f"result: {result}")
+    print(f"result: {json.dumps(result, indent=2)}")
 
 if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        logger.error(f"Error running AnalyticSubgraph: {e}", exc_info=True)
+        logger.error(f"Error running AnalyticSubgraph: {e}")
         raise

--- a/src/airas/analysis/analytic_subgraph/nodes/analytic_node.py
+++ b/src/airas/analysis/analytic_subgraph/nodes/analytic_node.py
@@ -21,7 +21,11 @@ def analytic_node(
     verification_policy: str,
     experiment_code: str,
     output_text_data: str,
+    client: LLMFacadeClient | None = None, 
 ) -> str | None:
+    if client is None:
+        client = LLMFacadeClient(llm_name=llm_name)
+
     env = Environment()
     template = env.from_string(analytic_node_prompt)
     data = {
@@ -31,7 +35,7 @@ def analytic_node(
         "output_text_data": output_text_data,
     }
     messages = template.render(data)
-    output, cost = LLMFacadeClient(llm_name=llm_name).structured_outputs(
+    output, cost = client.structured_outputs(
         message=messages, data_model=LLMOutput
     )
     if output is None:

--- a/src/airas/create/create_experimental_design_subgraph/create_experimental_design_subgraph.py
+++ b/src/airas/create/create_experimental_design_subgraph/create_experimental_design_subgraph.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 
 from langgraph.graph import END, START, StateGraph
@@ -136,14 +137,12 @@ def main():
         branch_name=args.branch_name,
     )
     result = ced.run()
-    print(f"result: {result}")
+    print(f"result: {json.dumps(result, indent=2)}")
 
 
 if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        logger.error(
-            f"Error running CreateExperimentalDesignSubgraph: {e}", exc_info=True
-        )
+        logger.error(f"Error running CreateExperimentalDesignSubgraph: {e}")
         raise

--- a/src/airas/create/create_experimental_design_subgraph/nodes/generate_advantage_criteria.py
+++ b/src/airas/create/create_experimental_design_subgraph/nodes/generate_advantage_criteria.py
@@ -6,8 +6,14 @@ from airas.create.create_experimental_design_subgraph.prompt.generate_advantage_
 from airas.utils.api_client.llm_facade_client import LLM_MODEL, LLMFacadeClient
 
 
-def generate_advantage_criteria(llm_name: LLM_MODEL, new_method: str) -> str:
-    client = LLMFacadeClient(llm_name)
+def generate_advantage_criteria(
+    llm_name: LLM_MODEL, 
+    new_method: str, 
+    client: LLMFacadeClient | None = None, 
+) -> str:
+    if client is None:
+        client = LLMFacadeClient(llm_name=llm_name)
+        
     env = Environment()
     template = env.from_string(generate_advantage_criteria_prompt)
     data = {

--- a/src/airas/create/create_experimental_design_subgraph/nodes/generate_experiment_code.py
+++ b/src/airas/create/create_experimental_design_subgraph/nodes/generate_experiment_code.py
@@ -11,8 +11,11 @@ def generate_experiment_code(
     experiment_details: str,
     base_experimental_code: str,
     base_experimental_info: str,
+    client: LLMFacadeClient | None = None, 
 ) -> str:
-    client = LLMFacadeClient(llm_name)
+    if client is None:
+        client = LLMFacadeClient(llm_name=llm_name)
+        
     env = Environment()
     template = env.from_string(generate_experiment_code_prompt)
     data = {

--- a/src/airas/create/create_experimental_design_subgraph/nodes/generate_experiment_details.py
+++ b/src/airas/create/create_experimental_design_subgraph/nodes/generate_experiment_details.py
@@ -11,8 +11,11 @@ def generate_experiment_details(
     verification_policy: str,
     base_experimental_code: str,
     base_experimental_info: str,
+    client: LLMFacadeClient | None = None, 
 ) -> str:
-    client = LLMFacadeClient(llm_name)
+    if client is None:
+        client = LLMFacadeClient(llm_name=llm_name)
+        
     env = Environment()
     template = env.from_string(generate_experiment_details_prompt)
     data = {

--- a/src/airas/create/create_method_subgraph/create_method_subgraph.py
+++ b/src/airas/create/create_method_subgraph/create_method_subgraph.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 
 from langgraph.graph import END, START, StateGraph
@@ -90,12 +91,12 @@ def main():
         llm_name=llm_name,
     )
     result = cm.run()
-    print(f"result: {result}")
+    print(f"result: {json.dumps(result, indent=2)}")
 
 
 if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        logger.error(f"Error running CreateMethodSubgraph: {e}", exc_info=True)
+        logger.error(f"Error running CreateMethodSubgraph: {e}")
         raise

--- a/src/airas/create/create_method_subgraph/nodes/generator_node.py
+++ b/src/airas/create/create_method_subgraph/nodes/generator_node.py
@@ -15,8 +15,10 @@ def generator_node(
     llm_name: LLM_MODEL,
     base_method_text: CandidatePaperInfo,
     add_method_texts: list[CandidatePaperInfo],
+    client: LLMFacadeClient | None = None, 
 ) -> str:
-    client = LLMFacadeClient(llm_name)
+    if client is None:
+        client = LLMFacadeClient(llm_name=llm_name)
 
     env = Environment()
     template = env.from_string(generator_node_prompt)

--- a/src/airas/execution/executor_subgraph/executor_subgraph.py
+++ b/src/airas/execution/executor_subgraph/executor_subgraph.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 import os
 
@@ -87,11 +88,12 @@ class ExecutorSubgraph:
     @time_node("executor_subgraph", "_generate_code_with_devin_node")
     def _generate_code_with_devin_node(self, state: ExecutorSubgraphState) -> dict:
         logger.info("---ExecutorSubgraph---")
+        branch_name=state["branch_name"]
         experiment_session_id, experiment_devin_url = generate_code_with_devin(
             headers=self.headers,
             github_owner=state["github_owner"],
             repository_name=state["repository_name"],
-            branch_name=state["branch_name"],
+            branch_name=branch_name,
             new_method=state["new_method"],
             experiment_code=state["experiment_code"],
         )
@@ -99,7 +101,7 @@ class ExecutorSubgraph:
         return {
             "fix_iteration_count": 0,
             "experiment_session_id": experiment_session_id,
-            "branch_name": experiment_session_id,
+            "branch_name": branch_name,
             "experiment_devin_url": experiment_devin_url,
         }
 
@@ -260,13 +262,11 @@ def main():
         save_dir=save_dir, 
     )
     result = ex.run()
-    print(f"result: {result}")
+    print(f"result: {json.dumps(result, indent=2)}")
 
 if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        logger.error(
-            f"Error running ExecutorSubgraph: {e}", exc_info=True
-        )
+        logger.error(f"Error running ExecutorSubgraph: {e}")
         raise

--- a/src/airas/preparation/prepare_repository_subgraph/nodes/check_branch_existence.py
+++ b/src/airas/preparation/prepare_repository_subgraph/nodes/check_branch_existence.py
@@ -11,9 +11,14 @@ DEVICETYPE = Literal["cpu", "gpu"]
 
 
 def check_branch_existence(
-    github_owner: str, repository_name: str, branch_name: str
+    github_owner: str, 
+    repository_name: str, 
+    branch_name: str, 
+    client: GithubClient | None = None, 
 ) -> str | None:
-    client = GithubClient()
+    if client is None:
+        client = GithubClient()
+        
     sha = client.check_branch_existence(
         github_owner=github_owner,
         repository_name=repository_name,

--- a/src/airas/preparation/prepare_repository_subgraph/nodes/check_github_repository.py
+++ b/src/airas/preparation/prepare_repository_subgraph/nodes/check_github_repository.py
@@ -9,12 +9,13 @@ logger = getLogger(__name__)
 # https://docs.github.com/ja/rest/repos/repos?apiVersion=2022-11-28#get-a-repository
 
 
-def check_github_repository(github_owner: str, repository_name: str) -> bool | None:
+def check_github_repository(github_owner: str, repository_name: str) -> bool:
     client = GithubClient()
-    return client.check_repository_existence(
+    response = client.get_repository(
         github_owner=github_owner,
         repository_name=repository_name,
     )
+    return response is not None
 
 
 if __name__ == "__main__":

--- a/src/airas/preparation/prepare_repository_subgraph/nodes/check_github_repository.py
+++ b/src/airas/preparation/prepare_repository_subgraph/nodes/check_github_repository.py
@@ -9,8 +9,14 @@ logger = getLogger(__name__)
 # https://docs.github.com/ja/rest/repos/repos?apiVersion=2022-11-28#get-a-repository
 
 
-def check_github_repository(github_owner: str, repository_name: str) -> bool:
-    client = GithubClient()
+def check_github_repository(
+    github_owner: str, 
+    repository_name: str, 
+    client: GithubClient | None = None, 
+    ) -> bool:
+    if client is None:
+        client = GithubClient()
+
     response = client.get_repository(
         github_owner=github_owner,
         repository_name=repository_name,

--- a/src/airas/preparation/prepare_repository_subgraph/nodes/create_branch.py
+++ b/src/airas/preparation/prepare_repository_subgraph/nodes/create_branch.py
@@ -15,8 +15,11 @@ def create_branch(
     repository_name: str,
     branch_name: str,
     main_sha: str,
+    client: GithubClient | None = None, 
 ) -> Literal[True]:
-    client = GithubClient()
+    if client is None:
+        client = GithubClient()
+
     response = client.create_branch(
         github_owner=github_owner,
         repository_name=repository_name,

--- a/src/airas/preparation/prepare_repository_subgraph/nodes/create_branch.py
+++ b/src/airas/preparation/prepare_repository_subgraph/nodes/create_branch.py
@@ -15,14 +15,17 @@ def create_branch(
     repository_name: str,
     branch_name: str,
     main_sha: str,
-) -> bool:
+) -> Literal[True]:
     client = GithubClient()
-    return client.create_branch(
+    response = client.create_branch(
         github_owner=github_owner,
         repository_name=repository_name,
         branch_name=branch_name,
         from_sha=main_sha,
     )
+    if not response:
+        raise RuntimeError(f"Failed to create branch '{branch_name}' from '{main_sha}' in {github_owner}/{repository_name}")
+    return response
 
 
 if __name__ == "__main__":

--- a/src/airas/preparation/prepare_repository_subgraph/nodes/fork_repository.py
+++ b/src/airas/preparation/prepare_repository_subgraph/nodes/fork_repository.py
@@ -15,13 +15,16 @@ def fork_repository(
     # NOTE:Make it possible to respond simply by rewriting run_experiment.yml.
     device_type: DEVICETYPE,
     organization: str = "",
-) -> bool:
+) -> Literal[True]:
     client = GithubClient()
-    return client.fork_repository(
+    response = client.fork_repository(
         repository_name=repository_name,
         device_type=device_type,
         organization=organization,
     )
+    if not response:
+        raise RuntimeError("Fork of the repository failed")
+    return response
 
 
 if __name__ == "__main__":

--- a/src/airas/preparation/prepare_repository_subgraph/nodes/fork_repository.py
+++ b/src/airas/preparation/prepare_repository_subgraph/nodes/fork_repository.py
@@ -15,8 +15,11 @@ def fork_repository(
     # NOTE:Make it possible to respond simply by rewriting run_experiment.yml.
     device_type: DEVICETYPE,
     organization: str = "",
+    client: GithubClient | None = None, 
 ) -> Literal[True]:
-    client = GithubClient()
+    if client is None:
+        client = GithubClient()
+        
     response = client.fork_repository(
         repository_name=repository_name,
         device_type=device_type,

--- a/src/airas/preparation/prepare_repository_subgraph/nodes/retrieve_main_branch_sha.py
+++ b/src/airas/preparation/prepare_repository_subgraph/nodes/retrieve_main_branch_sha.py
@@ -13,13 +13,15 @@ DEVICETYPE = Literal["cpu", "gpu"]
 def retrieve_main_branch_sha(
     github_owner: str,
     repository_name: str,
-) -> str | None:
+) -> str:
     client = GithubClient()
     sha = client.check_branch_existence(
         github_owner=github_owner,
         repository_name=repository_name,
         branch_name="main",
     )
+    if sha is None:
+        raise RuntimeError(f"Failed to retrieve SHA for 'main' branch of {github_owner}/{repository_name}")
     return sha
 
 

--- a/src/airas/preparation/prepare_repository_subgraph/nodes/retrieve_main_branch_sha.py
+++ b/src/airas/preparation/prepare_repository_subgraph/nodes/retrieve_main_branch_sha.py
@@ -13,8 +13,11 @@ DEVICETYPE = Literal["cpu", "gpu"]
 def retrieve_main_branch_sha(
     github_owner: str,
     repository_name: str,
+    client: GithubClient | None = None, 
 ) -> str:
-    client = GithubClient()
+    if client is None:
+        client = GithubClient()
+
     sha = client.check_branch_existence(
         github_owner=github_owner,
         repository_name=repository_name,

--- a/src/airas/preparation/prepare_repository_subgraph/prepare_repository_subgraph.py
+++ b/src/airas/preparation/prepare_repository_subgraph/prepare_repository_subgraph.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 import time
 
@@ -207,13 +208,14 @@ def main():
     }
 
     result = subgraph.run(input)
-    print(f"result: {result}")
+    print(f"result: {json.dumps(result, indent=2)}")
 
 if __name__ == "__main__":
+    import sys
     try:
         main()
     except Exception as e:
         logger.error(
-            f"Error running PrepareRepository: {e}", exc_info=True
+            f"Error running PrepareRepository: {e}"
         )
-        raise
+        sys.exit(1)

--- a/src/airas/publication/html_subgraph/html_subgraph.py
+++ b/src/airas/publication/html_subgraph/html_subgraph.py
@@ -1,3 +1,5 @@
+import argparse
+import json
 import glob
 import logging
 import os
@@ -81,36 +83,50 @@ HtmlConvert = create_wrapped_subgraph(
 )
 
 
-if __name__ == "__main__":
+def main():
     llm_name = "o3-mini-2025-01-31"
-    save_dir = "/workspaces/researchgraph/data"
-    figures_dir = "/workspaces/researchgraph/data/images"
+    save_dir = "/workspaces/airas/data"
+    figures_dir = "/workspaces/airas/data/images"
     pdf_files = glob.glob(os.path.join(figures_dir, "*.pdf"))
 
-    github_repository = "auto-res2/experiment_script_matsuzawa"
-    branch_name = "base-branch"
-    # research_file_path = ".research/research_history.json"
+
+    parser = argparse.ArgumentParser(
+        description="Execute HtmlSubgraph"
+    )
+    parser.add_argument("github_repository", help="Your GitHub repository")
+    parser.add_argument(
+        "branch_name", help="Your branch name in your GitHub repository"
+    )
+    args = parser.parse_args()
+
+    branch_name = args.branch_name
 
     extra_files = [
         {
             "upload_branch": "gh-pages",
-            "upload_dir": "branches/{{ branch_name }}/",
+            "upload_dir": f"branches/{branch_name}/",
             "local_file_paths": [f"{save_dir}/index.html"],
         },
         {
             "upload_branch": "gh-pages",
-            "upload_dir": "branches/{{ branch_name }}/images/",
+            "upload_dir": f"branches/{branch_name}/images/",
             "local_file_paths": pdf_files,
         },
     ]
 
-    html_converter = HtmlConvert(
-        github_repository=github_repository,
-        branch_name=branch_name,
+    hc = HtmlConvert(
+        github_repository=args.github_repository,
+        branch_name=args.branch_name,
         extra_files=extra_files,
         llm_name=llm_name,
         save_dir=save_dir,
     )
+    result = hc.run()
+    print(f"result: {json.dumps(result, indent=2)}")
 
-    result = html_converter.run({})
-    print(f"result: {result}")
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logger.error(f"Error running HtmlSubgraph: {e}")
+        raise

--- a/src/airas/publication/html_subgraph/nodes/convert_to_html.py
+++ b/src/airas/publication/html_subgraph/nodes/convert_to_html.py
@@ -18,7 +18,11 @@ class LLMOutput(BaseModel):
 def convert_to_html(
     llm_name: LLM_MODEL,
     paper_content: dict[str, str],
+    client: LLMFacadeClient | None = None, 
 ) -> str:
+    if client is None:
+        client = LLMFacadeClient(llm_name=llm_name)
+
     data = {
         "sections": [
             {"name": section, "content": paper_content[section]}
@@ -29,9 +33,7 @@ def convert_to_html(
     env = Environment()
     template = env.from_string(convert_to_html_prompt)
     messages = template.render(data)
-    output, cost = LLMFacadeClient(
-        llm_name=llm_name,
-    ).structured_outputs(
+    output, cost = client.structured_outputs(
         message=messages,
         data_model=LLMOutput,
     )

--- a/src/airas/publication/latex_subgraph/latex_subgraph.py
+++ b/src/airas/publication/latex_subgraph/latex_subgraph.py
@@ -1,3 +1,5 @@
+import argparse
+import json
 import logging
 import os
 
@@ -95,27 +97,42 @@ LatexConvert = create_wrapped_subgraph(
 )
 
 
-if __name__ == "__main__":
+def main():
     llm_name = "o3-mini-2025-01-31"
-    save_dir = "/workspaces/researchgraph/data"
+    save_dir = "/workspaces/airas/data"
 
-    github_repository = "auto-res2/experiment_script_matsuzawa"
-    branch_name = "base-branch"
+    parser = argparse.ArgumentParser(
+        description="Execute LatexSubgraph"
+    )
+    parser.add_argument("github_repository", help="Your GitHub repository")
+    parser.add_argument(
+        "branch_name", help="Your branch name in your GitHub repository"
+    )
+    args = parser.parse_args()
+
+    branch_name = args.branch_name
+
     extra_files = [
         {
-            "upload_branch": "{{ branch_name }}",
+            "upload_branch": f"{branch_name}",
             "upload_dir": ".research/",
             "local_file_paths": [f"{save_dir}/paper.pdf"],
         }
     ]
 
-    latex_converter = LatexConvert(
-        github_repository=github_repository,
-        branch_name=branch_name,
+    lc = LatexConvert(
+        github_repository=args.github_repository,
+        branch_name=args.branch_name,
         extra_files=extra_files,
         llm_name=llm_name,
         save_dir=save_dir,
     )
+    result = lc.run()
+    print(f"result: {json.dumps(result, indent=2)}")
 
-    result = latex_converter.run({})
-    print(f"result: {result}")
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logger.error(f"Error running LatexSubgraph: {e}")
+        raise

--- a/src/airas/publication/readme_subgraph/readme_subgraph.py
+++ b/src/airas/publication/readme_subgraph/readme_subgraph.py
@@ -1,3 +1,5 @@
+import argparse
+import json
 import logging
 
 from langgraph.graph import END, START, StateGraph
@@ -69,14 +71,27 @@ ReadmeUpload = create_wrapped_subgraph(
     ReadmeSubgraphOutputState,
 )
 
-if __name__ == "__main__":
-    github_repository = "auto-res2/experiment_script_matsuzawa"
-    branch_name = "base-branch"
 
-    readme_uploader = ReadmeUpload(
-        github_repository=github_repository,
-        branch_name=branch_name,
+def main():
+    parser = argparse.ArgumentParser(
+        description="Execute ReadmeSubgraph"
     )
+    parser.add_argument("github_repository", help="Your GitHub repository")
+    parser.add_argument(
+        "branch_name", help="Your branch name in your GitHub repository"
+    )
+    args = parser.parse_args()
 
-    result = readme_uploader.run()
-    print(f"result: {result}")
+    pw = ReadmeUpload(
+        github_repository=args.github_repository,
+        branch_name=args.branch_name,
+    )
+    result = pw.run()
+    print(f"result: {json.dumps(result, indent=2)}")
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logger.error(f"Error running ReadmeSubgraph: {e}")
+        raise

--- a/src/airas/retrieve/retrieve_code_subgraph/retrieve_code_subgraph.py
+++ b/src/airas/retrieve/retrieve_code_subgraph/retrieve_code_subgraph.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 
 from langgraph.graph import END, START, StateGraph
@@ -119,12 +120,12 @@ def main():
   
     # result = rc.run(retrieve_code_subgraph_input_data)
     result = rc.run({})
-    print(f"result: {result}")
+    print(f"result: {json.dumps(result, indent=2)}")
 
 
 if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        logger.error(f"Error running RetrieveCodeSubgraph: {e}", exc_info=True)
+        logger.error(f"Error running RetrieveCodeSubgraph: {e}")
         raise

--- a/src/airas/retrieve/retrieve_paper_from_query_subgraph/retrieve_paper_from_query_subgraph.py
+++ b/src/airas/retrieve/retrieve_paper_from_query_subgraph/retrieve_paper_from_query_subgraph.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 import operator
 import os
@@ -382,8 +383,7 @@ def main():
     )
 
     result = base_paper_retriever.run(input)
-    print(f"result: {result}")
-    return
+    print(f"result: {json.dumps(result, indent=2)}")
 
 
 if __name__ == "__main__":

--- a/src/airas/retrieve/retrieve_related_paper_subgraph/retrieve_related_paper_subgraph.py
+++ b/src/airas/retrieve/retrieve_related_paper_subgraph/retrieve_related_paper_subgraph.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 import operator
 import os
@@ -438,7 +439,7 @@ def main():
     )
 
     result = add_paper_retriever.run(input)
-    print(f"result: {result}")
+    print(f"result: {json.dumps(result, indent=2)}")
     return
 
 

--- a/src/airas/utils/api_client/arxiv_client.py
+++ b/src/airas/utils/api_client/arxiv_client.py
@@ -63,4 +63,6 @@ class ArxivClient(BaseHTTPClient):
             "sortBy": sort_by,
             "sortOrder": sort_order,
         }
-        return self.get(path="query", params=params, timeout=timeout)
+        response = self.get(path="query", params=params, timeout=timeout)
+        # TODO: Enhance error handling
+        return self.parse_response(response)

--- a/src/airas/utils/api_client/base_http_client.py
+++ b/src/airas/utils/api_client/base_http_client.py
@@ -68,7 +68,6 @@ class BaseHTTPClient(ResponseParserMixIn, ABC):
         json: dict | None = None,
         stream: bool = False,
         timeout: float = 10.0,
-        parse: bool = True,
     ) -> dict | str | bytes | requests.Response | None:
         url = f"{self.base_url}/{path.lstrip('/')}"
         headers = {**self.default_headers, **(headers or {})}
@@ -83,8 +82,6 @@ class BaseHTTPClient(ResponseParserMixIn, ABC):
                 stream=stream,
                 timeout=timeout,
             )
-            if parse:
-                return self._parse_response(response)
             return response
         except Exception as e:
             logger.warning(f"[{self.__class__.__name__}] {method} {url}: {e}")
@@ -136,7 +133,6 @@ class AsyncBaseHTTPClient(ResponseParserMixIn, ABC):
         json: dict | None = None,
         stream: bool = False,
         timeout: float = 10.0,
-        parse: bool = True,
     ) -> dict | str | bytes | requests.Response | None:
         url = f"{self.base_url}/{path.lstrip('/')}"
         headers = {**self.default_headers, **(headers or {})}
@@ -151,8 +147,6 @@ class AsyncBaseHTTPClient(ResponseParserMixIn, ABC):
                 stream=stream,
                 timeout=timeout,
             )
-            if parse:
-                return self._parse_response(response)
             return response
         except Exception as e:
             logger.warning(f"[{self.__class__.__name__}] {method} {url}: {e}")

--- a/src/airas/utils/api_client/firecrawl_client.py
+++ b/src/airas/utils/api_client/firecrawl_client.py
@@ -70,7 +70,8 @@ class FireCrawlClient(BaseHTTPClient):
             "timeout": timeout_ms,
         }
         # NOTE: Enhance error handling
-        response = self.post(path="scrape", json=payload, timeout=timeout)
+        raw_response = self.post(path="scrape", json=payload, timeout=timeout)
+        response = self.parse_response(raw_response)
         if isinstance(response, dict):
             data = response.get("data") or {}
             markdown = data.get("markdown") or ""

--- a/src/airas/utils/api_client/github_client.py
+++ b/src/airas/utils/api_client/github_client.py
@@ -11,6 +11,7 @@ from tenacity import (
     wait_exponential,
 )
 from typing import Any
+from datetime import datetime, timezone
 
 from airas.utils.api_client.base_http_client import BaseHTTPClient
 from airas.utils.logging_utils import setup_logging
@@ -21,14 +22,24 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_RETRIES = 10
 DEFAULT_INITIAL_WAIT = 1.0
 
+
+class GithubClientError(RuntimeError):
+    ...
+
+class GithubClientRetryableError(GithubClientError):
+    ...
+
+class GithubClientFatalError(GithubClientError):
+    ...
+
 GITHUB_RETRY = retry(
     stop=stop_after_attempt(DEFAULT_MAX_RETRIES),
     wait=wait_exponential(multiplier=DEFAULT_INITIAL_WAIT),
     retry=(
-        retry_if_exception_type(requests.RequestException)
-        | retry_if_exception_type(RuntimeError)
+        retry_if_exception_type(GithubClientRetryableError)
+        | retry_if_exception_type(requests.RequestException)
     ),
-    before_sleep=before_sleep_log(logger, logging.INFO),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
 )
 
 
@@ -48,70 +59,100 @@ class GithubClient(BaseHTTPClient):
             default_headers={**auth_headers, **(default_headers or {})},
         )
 
+    @staticmethod
+    def _raise_for_status(response: requests.Response, path: str) -> None:
+        code = response.status_code
+
+        if 200 <= code < 300:
+            return
+        
+        if 300 <= code < 400:
+            location = response.headers.get("Location", "unknown")
+            logger.warning(f"Unexpected redirect ({code}) for {path} → {location}")
+            raise GithubClientRetryableError(
+                f"Redirect response ({code}) for {path}; check Location: {location}"
+            )
+
+        if code == 403:
+            if response.headers.get("X-RateLimit-Remaining") == "0":
+                reset_epoch = int(response.headers.get("X-RateLimit-Reset", "0"))
+                reset_dt = datetime.fromtimestamp(reset_epoch, tz=timezone.utc)
+                delay = max((reset_dt - datetime.now(tz=timezone.utc)).total_seconds(), 0)
+                logger.warning(f"GitHub rate limit exceeded; will retry after {delay:.0f} s (at {reset_dt.isoformat()})")
+                raise GithubClientRetryableError(
+                    f"Rate limit exceeded for {path}; retry after {delay:.0f} s"
+                )
+            else:
+                raise GithubClientFatalError(
+                    f"Access forbidden (403) for {path}: {response.text}"
+                )
+        
+        if 400 <= code < 500:
+            raise GithubClientFatalError(
+                f"Client error {code} for URL {path}: {response.text}"
+            )
+
+        if 500 <= code < 600:
+            raise GithubClientRetryableError(
+                f"Server error {code} for URL {path}: {response.text}"
+            )
+
+        if code >= 600 or code < 200:
+            raise GithubClientFatalError(
+                f"Unexpected HTTP status {code} for URL {path}: {response.text}"
+            )
+        
+        raise GithubClientRetryableError(
+            f"Unhandled status code {code} for URL: {path}"
+        )
+
     # --------------------------------------------------
     # Repository
     # --------------------------------------------------
 
     @GITHUB_RETRY
-    def check_repository_existence(
+    def get_repository(
         self, github_owner: str, repository_name: str
-    ) -> bool:
+    ) -> dict:
         # https://docs.github.com/ja/rest/repos/repos?apiVersion=2022-11-28#get-a-repository
         # For public repositories, no access token is required.
         path = f"/repos/{github_owner}/{repository_name}"
 
-        response = self.get(path=path, parse=False)
+        response = self.get(path=path)
         match response.status_code:
             case 200:
                 logger.info("A research repository exists (200).")
-                return True
+                return self.parse_response(response)
             case 404:
-                logger.info(f"Repository not found: {path} (404).")
-                return False
-            case 403:
-                raise RuntimeError(
-                    f"Access forbidden: {path} (403).\n"
-                    "The requested resource has been permanently moved to a new location."
-                )
-            case 301:
-                raise RuntimeError(
-                    f"Access forbidden: {path} (301).\n"
-                    "You do not have permission to access this resource."
-                )
+                logger.warning(f"Repository not found: {path} (404).")
+                return None  # NOTE: Returning None is intentional; a missing branch is an expected case.
             case _:
-                raise RuntimeError(
-                    f"Unhandled status code {response.status_code} for URL: {path}\n"
-                )
+                self._raise_for_status(response, path)
+                return self.parse_response
+
             
     @GITHUB_RETRY
     def get_repository_content(
         self, github_owner: str, repository_name: str, file_path: str
-    ) -> str | None:
+    ) -> bytes | None:
         # https://docs.github.com/ja/rest/repos/contents?apiVersion=2022-11-28#get-repository-content
         # For public repositories, no access token is required.
         path = f"/repos/{github_owner}/{repository_name}/contents/{file_path}"
         headers={"Accept": "application/vnd.github.raw+json"}
 
-        response = self.get(path=path, headers=headers, parse=False)
+        response = self.get(path=path, headers=headers)
         match response.status_code:
             case 200:
-                return response.text
+                return self.parse_response(response)
             case 302:
-                logger.warning("Resource not found (302).")
-                return None
+                logger.warning("Found (301).")
+                return None  # NOTE: Returning None is intentional; a missing branch is an expected case.
             case 304:
-                logger.warning("Not Modified (304).")
-                return None
-            case 403:
-                logger.warning("Forbidden (403).")
-                return None
-            case 404:
-                logger.warning("Resource not found (404).")
+                logger.warning("Not modified (304).")
                 return None
             case _:
-                raise RuntimeError(
-                    f"Unhandled status code {response.status_code} for URL: {path}\n"
-                )
+                self._raise_for_status(response, path)
+                return self.parse_response(response)
             
     @GITHUB_RETRY
     def fork_repository(
@@ -120,6 +161,7 @@ class GithubClient(BaseHTTPClient):
         device_type: str = "cpu",
         organization: str = "",
     ) -> bool:
+        # https://docs.github.com/ja/rest/repos/forks?apiVersion=2022-11-28#create-a-fork
         if device_type == "cpu":
             source = "auto-res/cpu-repository"
         elif device_type == "gpu":
@@ -140,23 +182,23 @@ class GithubClient(BaseHTTPClient):
                 "default_branch_only": "true",
             }
 
-        response = self.post(path=path, json=json, parse=False)
+        response = self.post(path=path, json=json)
         match response.status_code:
             case 202:
                 logger.info("Fork of the repository was successful (202).")
                 return True
             case 400:
-                raise RuntimeError(f"Bad request (400): {path}")
-            case 403:
-                raise RuntimeError(f"Access forbidden (403): {path}")
+                logger.error(f"Bad Request (400): {path}")
+                raise GithubClientFatalError(f"Bad Request (400): {path}")
             case 404:
-                raise RuntimeError(f"Resource not found (404): {path}")
+                logger.error(f"Resource not found (404): {path}")
+                raise GithubClientFatalError(f"Resource not found (404): {path}")
             case 422:
-                raise RuntimeError(f"Validation failed (422): {path}")
+                logger.error(f"Validation failed, or the endpoint has been spammed (422): {path}")
+                raise GithubClientFatalError(f"Validation failed, or the endpoint has been spammed (422): {path}")
             case _:
-                raise RuntimeError(
-                    f"Unhandled status code {response.status_code} for URL: {path}\n"
-                )
+                self._raise_for_status(response, path)
+                return False
 
     # --------------------------------------------------
     # Branch
@@ -168,26 +210,26 @@ class GithubClient(BaseHTTPClient):
         github_owner: str,
         repository_name: str,
         branch_name: str,
-    ) -> str:
+    ) -> str | None:
         # https://docs.github.com/ja/rest/branches/branches?apiVersion=2022-11-28#get-a-branch
         # For public repositories, no access token is required.
         path = f"/repos/{github_owner}/{repository_name}/branches/{branch_name}"
 
-        response = self.get(path=path, parse=False)
+        response = self.get(path=path)
         match response.status_code:
             case 200:
                 logger.info("The specified branch exists (200).")
-                response = response.json()
+                response = self.parse_response(response)
                 return response["commit"]["sha"]
-            case 404:
-                logger.info(f"Branch not found: {path} (404).")
-                return ""
             case 301:
-                raise RuntimeError(f"Moved permanently: {path} (301).")
+                logger.warning(f"Moved permanently: {path} (301).")
+                return None  # NOTE: Returning None is intentional; a missing branch is an expected case.
+            case 404:
+                logger.error(f"Branch not found: {path} (404).")
+                return None
             case _:
-                raise RuntimeError(
-                    f"Unhandled status code {response.status_code} for URL: {path}\n"
-                )
+                self._raise_for_status(response, path)
+                return self.parse_response(response)
 
     @GITHUB_RETRY
     def create_branch(
@@ -197,26 +239,24 @@ class GithubClient(BaseHTTPClient):
         branch_name: str,
         from_sha: str,
     ) -> bool:
+        # https://docs.github.com/ja/rest/git/refs?apiVersion=2022-11-28#create-a-reference
         path = f"/repos/{github_owner}/{repository_name}/git/refs"
         payload = {"ref": f"refs/heads/{branch_name}", "sha": from_sha}
 
-        response = self.post(path=path, json=payload, parse=False)
+        response = self.post(path=path, json=payload)
         match response.status_code:
             case 201:
                 logger.info(f"Branch created (201): {branch_name}")
                 return True
             case 409:
-                raise RuntimeError(f"Conflict creating branch (409): {path}")
+                logger.error(f"Conflict creating branch (409): {path}")
+                raise GithubClientFatalError(f"Conflict creating branch (409): {path}")
             case 422:
-                error_message = response.json()
-                raise RuntimeError(
-                    f"Validation failed, or the endpoint has been spammed (422): {path}\n"
-                    f"Error message: {error_message}"
-                )
+                logger.error(f"Validation failed, or the endpoint has been spammed (422): {path}")
+                raise GithubClientFatalError(f"Validation failed, or the endpoint has been spammed (422): {path}")
             case _:
-                raise RuntimeError(
-                    f"Unhandled status code {response.status_code} for URL: {path}\n"
-                )
+                self._raise_for_status(response, path)
+                return False
 
     # --------------------------------------------------
     # Tree
@@ -225,32 +265,29 @@ class GithubClient(BaseHTTPClient):
     @GITHUB_RETRY
     def get_a_tree(
         self, github_owner: str, repository_name: str, tree_sha: str
-    ) -> dict | None:
+    ) -> dict:
         # https://docs.github.com/ja/rest/git/trees?apiVersion=2022-11-28#get-a-tree
         # For public repositories, no access token is required.
         path = f"/repos/{github_owner}/{repository_name}/git/trees/{tree_sha}"
-        headers={"Accept": "application/vnd.github.raw+json"}
+        headers={"Accept": "application/vnd.github+json"}
         params = {"recursive": "true"}
 
-        response = self.get(path=path, headers=headers, params=params, parse=False)
+        response = self.get(path=path, headers=headers, params=params)
         match response.status_code:
             case 200:
-                return response.json()
+                return self.parse_response(response)
             case 404:
-                logger.warning("Resource not found (404).")
-                return None
+                logger.error("Resource not found (404).")
+                raise GithubClientFatalError(f"Resource not found (404): {path}")
             case 409:
-                logger.warning("Conflict (409).")
-                return None
+                logger.error("Conflict (409).")
+                raise GithubClientFatalError("Conflict (409).")
             case 422:
-                logger.warning(
-                    "Validation failed, or the endpoint has been spammed (422)."
-                )
-                return None
+                logger.error("Validation failed, or the endpoint has been spammed (422).")
+                raise GithubClientFatalError("Validation failed, or the endpoint has been spammed (422).")
             case _:
-                raise RuntimeError(
-                    f"Unhandled status code {response.status_code} for URL: {path}\n"
-                )
+                self._raise_for_status(response, path)
+                return self.parse_response(response)
             
     # --------------------------------------------------
     # Content I/O
@@ -263,20 +300,28 @@ class GithubClient(BaseHTTPClient):
         repository_name: str,
         branch_name: str,
         repository_path: str,
-    ) -> bytes:
+    ) -> dict:
         path = f"/repos/{github_owner}/{repository_name}/contents/{repository_path}"
         params = {"ref": branch_name}
         
         response = self.get(path=path, params=params)
-        if isinstance(response, dict) and "content" in response:
-            return base64.b64decode(response["content"])
-        raise RuntimeError(f"[GitHub] read_file_bytes: content field not found ({path})")
-        
+        match response.status_code:
+            case 200:
+                logger.info(f"Success (200): {path}")
+                return self.parse_response(response)
+            case 404:
+                logger.error(f"Resource not found (404): {path}")
+                raise GithubClientFatalError(f"Resource not found (404): {path}")
+            case 403:
+                logger.error(f"Access forbidden (403): {path}")
+                raise GithubClientFatalError(f"Access forbidden (403): {path}")
+            case _:
+                self._raise_for_status(response, path)
+                return self.parse_response(response)
 
     @GITHUB_RETRY
     def write_file_bytes(
         self,
-        *,
         github_owner: str,
         repository_name: str,
         branch_name: str,
@@ -288,7 +333,9 @@ class GithubClient(BaseHTTPClient):
         params = {"ref": branch_name}
         sha: str | None = None
 
-        response = self.get(path=path, params=params, parse=False)
+        response = self.get(path=path, params=params)
+        # TODO: Set the condition of status code
+
         if response.status_code == 200 and "sha" in response.json():
             sha = response.json()["sha"]
 
@@ -300,7 +347,7 @@ class GithubClient(BaseHTTPClient):
         if sha:
             payload["sha"] = sha
 
-        response = self.put(path=path, json=payload, parse=False)
+        response = self.put(path=path, json=payload)
         if response.status_code in (200, 201):
             logger.info(f"[GitHub] {repository_path} uploaded/updated → branch {branch_name}")
             return True
@@ -309,3 +356,120 @@ class GithubClient(BaseHTTPClient):
             f"[GitHub] Failed to upload {repository_path} → {response.status_code}: {response.text}"
         )
         return False
+    
+    # --------------------------------------------------
+    # Github Actions
+    # --------------------------------------------------
+
+    @GITHUB_RETRY
+    def dispatch_workflow(
+        self, 
+        github_owner: str, 
+        repository_name: str, 
+        workflow_file_name: str, 
+        ref: str, 
+        inputs: dict | None = None, 
+    ) -> bool:
+        # https://docs.github.com/ja/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
+        path = f"/repos/{github_owner}/{repository_name}/actions/workflows/{workflow_file_name}/dispatches"
+        json = {"ref": ref}
+        if inputs:
+            json["inputs"] = inputs
+        
+        response = self.post(path=path, json=json)
+        match response.status_code:
+            case 204:
+                logger.info("Workflow dispatch accepted.")
+                return True
+            case 403:
+                logger.error(f"Access forbidden (403): {path}")
+                raise GithubClientFatalError(f"Access forbidden (403): {path}")
+            case 404:
+                logger.error(f"Workflow or repository not found (404): {path}")
+                raise GithubClientFatalError(f"Workflow or repository not found (404): {path}")
+            case 422:
+                logger.warning(f"Validation failed, or the endpoint has been spammed (422): {path}")
+                raise GithubClientRetryableError(f"Validation failed, or the endpoint has been spammed (422): {path}")
+            case _:
+                self._raise_for_status(response, path)
+                return False
+            
+    @GITHUB_RETRY
+    def list_workflow_runs(
+        self,
+        github_owner: str, 
+        repository_name: str, 
+        branch_name: str, 
+        event: str = "workflow_dispatch", 
+    ) -> dict:
+        # https://docs.github.com/ja/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository
+        path = f"/repos/{github_owner}/{repository_name}/actions/runs"
+        params = {"branch": branch_name, "event": event}
+        response = self.get(path=path, params=params)
+        match response.status_code:
+            case 200:
+                logger.info(f"Success (200): {path}")
+                return self.parse_response(response)
+            case 403:
+                logger.error(f"Access forbidden (403): {path}")
+                raise GithubClientFatalError(f"Access forbidden (403): {path}")
+            case 404:
+                logger.error(f"Workflow or repository not found (404): {path}")
+                raise GithubClientFatalError(f"Workflow or repository not found (404): {path}")
+            case 422:
+                logger.error(f"Validation failed, or the endpoint has been spammed (422): {path}")
+                raise GithubClientFatalError(f"Validation failed, or the endpoint has been spammed (422): {path}")
+            case _:
+                self._raise_for_status(response, path)
+                return self.parse_response(response)
+            
+    @GITHUB_RETRY
+    def list_repository_artifacts(
+        self, 
+        github_owner: str, 
+        repository_name: str, 
+    ) -> dict:
+        # https://docs.github.com/ja/rest/actions/artifacts?apiVersion=2022-11-28#list-artifacts-for-a-repository
+        path = f"/repos/{github_owner}/{repository_name}/actions/artifacts"
+        response = self.get(path=path)
+        match response.status_code:
+            case 200:
+                logger.info(f"Success (200): {path}")
+                return self.parse_response(response)
+            case 403:
+                logger.error(f"Access forbidden (403): {path}")
+                raise GithubClientFatalError(f"Access forbidden (403): {path}")
+            case 404:
+                logger.error(f"Workflow or repository not found (404): {path}")
+                raise GithubClientFatalError(f"Workflow or repository not found (404): {path}")
+            case 422:
+                logger.error(f"Validation failed, or the endpoint has been spammed (422): {path}")
+                raise GithubClientFatalError(f"Validation failed, or the endpoint has been spammed (422): {path}")
+            case _:
+                self._raise_for_status(response, path)
+                return self.parse_response(response)
+    
+    @GITHUB_RETRY
+    def download_artifact_archive(
+        self, 
+        github_owner: str, 
+        repository_name: str, 
+        artifact_id: int, 
+    ) -> bytes:
+        # https://docs.github.com/ja/rest/actions/artifacts?apiVersion=2022-11-28#download-an-artifact
+        path = f"/repos/{github_owner}/{repository_name}/actions/artifacts/{artifact_id}/zip"
+        
+        response = self.get(path=path, stream=True)
+        match response.status_code:
+            case 200:
+                logger.info(f"Success (200): {path}")
+                return self.parse_response(response)
+            case 302:
+                logger.info(f"Found (302): {path}")
+                return self.parse_response(response)
+            case 404:
+                logger.error(f"Artifact not found: {artifact_id} (404)")
+                raise GithubClientFatalError(f"Artifact not found: {artifact_id} (404)")
+            case _:
+                self._raise_for_status(response, path)
+                return self.parse_response(response)

--- a/src/airas/utils/api_client/github_client.py
+++ b/src/airas/utils/api_client/github_client.py
@@ -388,8 +388,8 @@ class GithubClient(BaseHTTPClient):
                 logger.error(f"Workflow or repository not found (404): {path}")
                 raise GithubClientFatalError(f"Workflow or repository not found (404): {path}")
             case 422:
-                logger.warning(f"Validation failed, or the endpoint has been spammed (422): {path}")
-                raise GithubClientRetryableError(f"Validation failed, or the endpoint has been spammed (422): {path}")
+                logger.error(f"Validation failed, or the endpoint has been spammed (422): {path}")
+                raise GithubClientFatalError(f"Validation failed, or the endpoint has been spammed (422): {path}")
             case _:
                 self._raise_for_status(response, path)
                 return False

--- a/src/airas/utils/api_client/parser_mixin.py
+++ b/src/airas/utils/api_client/parser_mixin.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 class ResponseParserMixIn:
     @staticmethod
-    def _parse_response(resp: requests.Response) -> dict | str | bytes | None:
+    def parse_response(resp: requests.Response) -> dict | str | bytes | None:
         content_type = resp.headers.get("Content-Type", "").lower()
         # JSON -> dict
         if "application/json" in content_type:

--- a/src/airas/utils/github_utils/github_file_io.py
+++ b/src/airas/utils/github_utils/github_file_io.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import logging
 import os
@@ -26,12 +27,13 @@ def download_from_github(
 ) -> dict[str, Any]:
     client = client or GithubClient()
     logger.info(f"[GitHub I/O] Downloading input from: {input_path}")
-    file_bytes = client.read_file_bytes(
+    data = client.read_file_bytes(
         github_owner,
         repository_name,
         branch_name,
         input_path,
     )
+    file_bytes = base64.b64decode(data.get("content"))
     if not file_bytes:
         msg = f"Github file not found: {input_path}"
         logger.error(msg)

--- a/src/airas/utils/github_utils/graph_wrapper.py
+++ b/src/airas/utils/github_utils/graph_wrapper.py
@@ -66,7 +66,7 @@ class GithubGraphWrapper:
         self._validate_repo_and_branch()
 
     def _validate_repo_and_branch(self) -> None:
-        if not self.client.check_repository_existence(
+        if not self.client.get_repository(
             github_owner=self.github_owner,
             repository_name=self.repository_name,
         ):
@@ -135,9 +135,7 @@ class GithubGraphWrapper:
         for file_config in formatted_extra_files:
             if file_config["upload_branch"].lower() == self.public_branch.lower():
                 target_path = file_config["upload_dir"]
-                if not target_path.endswith("/"):
-                    target_path += "/"
-                github_pages_url = f"https://{self.github_owner}.github.io/{self.repository_name}/{target_path}"
+                github_pages_url = f"https://{self.github_owner}.github.io/{self.repository_name}/{target_path}/index.html"
                 logger.info(f"Uploaded HTML available at: {github_pages_url}")
                 break
 

--- a/src/airas/write/writer_subgraph/nodes/paper_writing.py
+++ b/src/airas/write/writer_subgraph/nodes/paper_writing.py
@@ -29,11 +29,16 @@ class WritingNode:
         refine_round: int = 2,
         refine_only: bool = False,
         target_sections: list[str] | None = None,
+        client: LLMFacadeClient | None = None, 
     ):
         if target_sections is None:
             target_sections = []
 
         self.llm_name = llm_name
+        self.client = client
+        if self.client is None:
+            self.client = LLMFacadeClient(llm_name=self.llm_name)
+
         self.refine_round = refine_round
         self.refine_only = refine_only
         self.target_sections = target_sections or [
@@ -178,7 +183,7 @@ Pay particular attention to fixing any errors such as:
 
     def _call_llm(self, prompt: str, system_prompt: str) -> dict[str, str]:
         messages = system_prompt + prompt
-        output, cost = LLMFacadeClient(llm_name=self.llm_name).structured_outputs(
+        output, cost = self.client.structured_outputs(
             message=messages, data_model=PaperContent
         )
         if output is None:

--- a/src/airas/write/writer_subgraph/writer_subgraph.py
+++ b/src/airas/write/writer_subgraph/writer_subgraph.py
@@ -1,3 +1,5 @@
+import argparse
+import json
 import logging
 import os
 
@@ -93,30 +95,33 @@ PaperWrite = create_wrapped_subgraph(
 )
 
 
-if __name__ == "__main__":
+def main():
     llm_name = "o3-mini-2025-01-31"
     save_dir = "/workspaces/researchgraph/data"
     refine_round = 1
 
-    github_repository = "auto-res2/experiment_script_matsuzawa"
-    branch_name = "base-branch"
+    parser = argparse.ArgumentParser(
+        description="Execute WriterSubgraph"
+    )
+    parser.add_argument("github_repository", help="Your GitHub repository")
+    parser.add_argument(
+        "branch_name", help="Your branch name in your GitHub repository"
+    )
+    args = parser.parse_args()
 
-    subgraph = WriterSubgraph(
-        save_dir=save_dir,
-        llm_name=llm_name,
-        refine_round=refine_round,
-    ).build_graph()
+    pw = PaperWrite(
+        github_repository=args.github_repository,
+        branch_name=args.branch_name,
+        save_dir=save_dir, 
+        llm_name=llm_name, 
+        refine_round=refine_round
+    )
+    result = pw.run()
+    print(f"result: {json.dumps(result, indent=2)}")
 
-    output = subgraph.invoke(writer_subgraph_input_data)
-    print(f"output: {output}")
-
-    # paper_writer = PaperWriter(
-    #     github_repository=github_repository,
-    #     branch_name=branch_name,
-    #     llm_name=llm_name,
-    #     save_dir=save_dir,
-    #     refine_round=refine_round,
-    # )
-
-    # result = paper_writer.run({})
-    # print(f"result: {result}")
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logger.error(f"Error running WriterSubgraph: {e}")
+        raise

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,44 @@ class DummyLLMFacadeClient:
             return self._next_return, 0.0
         return None, 0.0
 
-
 @pytest.fixture
 def dummy_llm_facade_client():
     return DummyLLMFacadeClient
+
+
+class DummyGithubClient:
+    _next_return: Any = None
+
+    def __init__(self):
+        pass
+
+    def check_branch_existence(
+        self, github_owner: str, repository_name: str, branch_name: str
+    ) -> Any:
+        return self._next_return
+
+    def get_repository(
+        self, github_owner: str, repository_name: str
+    ) -> Any:
+        return self._next_return
+    
+    def create_branch(
+        self, 
+        github_owner: str, 
+        repository_name: str, 
+        branch_name: str, 
+        from_sha: str, 
+    ) -> Any:
+        return self._next_return
+    
+    def fork_repository(
+        self, 
+        repository_name: str, 
+        device_type: str, 
+        organization: str, 
+    ) -> Any:
+        return self._next_return
+
+@pytest.fixture
+def dummy_github_client():
+    return DummyGithubClient

--- a/tests/unit/analysis/analytic_subgraph/test_analytic_node.py
+++ b/tests/unit/analysis/analytic_subgraph/test_analytic_node.py
@@ -1,6 +1,5 @@
 import pytest
 
-import airas.analysis.analytic_subgraph.nodes.analytic_node as mod
 from airas.analysis.analytic_subgraph.nodes.analytic_node import analytic_node
 
 
@@ -16,7 +15,7 @@ def sample_inputs() -> dict[str, str]:
 
 
 @pytest.mark.parametrize(
-    "structured_return, expected",
+    "dummy_return, expected",
     [
         ({"analysis_report": "This is a report."}, "This is a report."),
         (None, None),
@@ -24,13 +23,13 @@ def sample_inputs() -> dict[str, str]:
     ],
 )
 def test_analytic_node(
-    monkeypatch: pytest.MonkeyPatch,
     sample_inputs: dict[str, str],
-    structured_return: dict[str, str],
+    dummy_return: dict[str, str],
     expected: None | str,
     dummy_llm_facade_client,
 ):
-    dummy_llm_facade_client._next_return = structured_return
-    monkeypatch.setattr(mod, "LLMFacadeClient", dummy_llm_facade_client)
-    result = analytic_node(**sample_inputs)
+    client = dummy_llm_facade_client(sample_inputs["llm_name"])
+    client._next_return = dummy_return
+
+    result = analytic_node(**sample_inputs, client=client)
     assert result == expected

--- a/tests/unit/create/create_experimental_design_subgraph/test_generate_advantage_criteria.py
+++ b/tests/unit/create/create_experimental_design_subgraph/test_generate_advantage_criteria.py
@@ -15,29 +15,28 @@ def sample_inputs() -> dict[str, str]:
 
 
 @pytest.mark.parametrize(
-    "facade_return, expected, mode",
+    "dummy_return, expected, mode",
     [
         (("criteria result", 0.01), "criteria result", "success"),
         ((None, 0.01), None, "ValueError"),
     ],
 )
 def test_generate_advantage_criteria(
-    monkeypatch: pytest.MonkeyPatch,
-    dummy_llm_facade_client,
     sample_inputs: dict[str, str],
-    facade_return,
+    dummy_return,
     expected,
     mode,
+    dummy_llm_facade_client,
 ):
-    dummy_llm_facade_client._next_return = facade_return
-    monkeypatch.setattr(mod, "LLMFacadeClient", dummy_llm_facade_client)
+    client = dummy_llm_facade_client(sample_inputs["llm_name"])
+    client._next_return = dummy_return
 
     match mode:
         case "success":
-            result = generate_advantage_criteria(**sample_inputs)
+            result = generate_advantage_criteria(**sample_inputs, client=client)
             assert result == expected
         case "ValueError":
             with pytest.raises(ValueError):
-                generate_advantage_criteria(**sample_inputs)
+                generate_advantage_criteria(**sample_inputs, client=client)
         case _:
             raise NotImplementedError(f"Unsupported mode: {mode}")

--- a/tests/unit/create/create_experimental_design_subgraph/test_generate_experiment_code.py
+++ b/tests/unit/create/create_experimental_design_subgraph/test_generate_experiment_code.py
@@ -17,29 +17,28 @@ def sample_inputs():
 
 
 @pytest.mark.parametrize(
-    "facade_return, expected, mode",
+    "dummy_return, expected, mode",
     [
         (("code result", 0.01), "code result", "success"),
         ((None, 0.01), None, "ValueError"),
     ],
 )
 def test_generate_experiment_code_success_and_failure(
-    monkeypatch,
-    dummy_llm_facade_client,
     sample_inputs,
-    facade_return,
+    dummy_return,
     expected,
     mode,
+    dummy_llm_facade_client,
 ):
-    dummy_llm_facade_client._next_return = facade_return
-    monkeypatch.setattr(mod, "LLMFacadeClient", dummy_llm_facade_client)
+    client = dummy_llm_facade_client(sample_inputs["llm_name"])
+    client._next_return = dummy_return
 
     match mode:
         case "success":
-            result = generate_experiment_code(**sample_inputs)
+            result = generate_experiment_code(**sample_inputs, client=client)
             assert result == expected
         case "ValueError":
             with pytest.raises(ValueError):
-                generate_experiment_code(**sample_inputs)
+                generate_experiment_code(**sample_inputs, client=client)
         case _:
             raise NotImplementedError(f"Unsupported mode: {mode}")

--- a/tests/unit/create/create_method_subgraph/test_generator_node.py
+++ b/tests/unit/create/create_method_subgraph/test_generator_node.py
@@ -1,42 +1,93 @@
 import pytest
 
-import airas.create.create_method_subgraph.nodes.generator_node as mod
-from airas.create.create_method_subgraph.nodes.generator_node import generator_node
+from typing import Any
 
+from airas.create.create_method_subgraph.nodes.generator_node import generator_node
+from airas.typing.paper import CandidatePaperInfo
 
 @pytest.fixture
-def sample_inputs():
+def sample_inputs() -> dict[str, Any]:
+    base: CandidatePaperInfo = {
+        "arxiv_id": "2001.00001",
+        "arxiv_url": "https://arxiv.org/abs/2001.00001",
+        "title": "Base Paper Title",
+        "authors": ["Alice", "Bob"],
+        "published_date": "2020-01-01",
+        "journal": "Journal of Testing",
+        "doi": "10.1000/j.jt.2020.01",
+        "summary": "This is a summary of the base paper.",
+        "github_url": "https://github.com/example/base-paper",
+        "main_contributions": "Contribution A, Contribution B",
+        "methodology": "We used method X.",
+        "experimental_setup": "Setup details here.",
+        "limitations": "Some limitations.",
+        "future_research_directions": "Future work here.",
+    }
+
+    add1: CandidatePaperInfo = {
+        "arxiv_id": "2001.00002",
+        "arxiv_url": "https://arxiv.org/abs/2001.00002",
+        "title": "Additional Paper 1",
+        "authors": ["Carol"],
+        "published_date": "2021-02-02",
+        "journal": "Journal of Extras",
+        "doi": "10.1000/j.je.2021.02",
+        "summary": "Summary of additional paper 1.",
+        "github_url": "https://github.com/example/additional-1",
+        "main_contributions": "Contribution C",
+        "methodology": "Method Y.",
+        "experimental_setup": "Experimental setup details.",
+        "limitations": "Limitations here.",
+        "future_research_directions": "Next steps.",
+    }
+
+    add2: CandidatePaperInfo = {
+        "arxiv_id": "2001.00003",
+        "arxiv_url": "https://arxiv.org/abs/2001.00003",
+        "title": "Additional Paper 2",
+        "authors": ["Dave", "Eve"],
+        "published_date": "2022-03-03",
+        "journal": "Journal of More Extras",
+        "doi": "10.1000/j.jme.2022.03",
+        "summary": "Summary of additional paper 2.",
+        "github_url": "https://github.com/example/additional-2",
+        "main_contributions": "Contribution D, Contribution E",
+        "methodology": "Method Z.",
+        "experimental_setup": "Setup details here.",
+        "limitations": "Known limitations.",
+        "future_research_directions": "Future directions.",
+    }
+
     return {
-        "llm_name": "dummy-model",
-        "base_method_text": "base method",
-        "add_method_text_list": ["add1", "add2"],
+        "llm_name": "dummy-llm",
+        "base_method_text": base,
+        "add_method_texts": [add1, add2],
     }
 
 
 @pytest.mark.parametrize(
-    "facade_return, expected, mode",
+    "dummy_return, expected, mode",
     [
         (("output result", 0.1), "output result", "success"),
         ((None, 0.1), None, "ValueError"),
     ],
 )
 def test_generator_node_success_and_failure(
-    monkeypatch,
-    dummy_llm_facade_client,
     sample_inputs,
-    facade_return,
+    dummy_return,
     expected,
     mode,
+    dummy_llm_facade_client,
 ):
-    dummy_llm_facade_client._next_return = facade_return
-    monkeypatch.setattr(mod, "LLMFacadeClient", dummy_llm_facade_client)
+    client = dummy_llm_facade_client(sample_inputs["llm_name"])
+    client._next_return = dummy_return
 
     match mode:
         case "success":
-            result = generator_node(**sample_inputs)
+            result = generator_node(**sample_inputs, client=client)
             assert result == expected
         case "ValueError":
             with pytest.raises(ValueError):
-                generator_node(**sample_inputs)
+                generator_node(**sample_inputs, client=client)
         case _:
             raise NotImplementedError(f"Unsupported mode: {mode}")

--- a/tests/unit/execution/executor_subgraph/test_execute_github_actions_workflow.py
+++ b/tests/unit/execution/executor_subgraph/test_execute_github_actions_workflow.py
@@ -1,56 +1,169 @@
-from unittest.mock import patch
-
 import pytest
 
-from airas.execution.executor_subgraph.nodes.execute_github_actions_workflow import (
-    execute_github_actions_workflow,
-)
+import airas.execution.executor_subgraph.nodes.execute_github_actions_workflow as mod
 
 
-# Normal case: All external dependencies are mocked and a workflow_run_id is returned
-@patch(
-    "airas.execution.executor_subgraph.nodes.execute_github_actions_workflow._parse_workflow_run_id",
-    return_value=12345,
-)
-@patch(
-    "airas.execution.executor_subgraph.nodes.execute_github_actions_workflow._request_github_actions_workflow_info_after_execution",
-    return_value={
+@pytest.fixture
+def before_runs() -> dict:
+    return {
         "workflow_runs": [
-            {"id": 12345, "status": "completed", "created_at": "2024-01-01T00:00:00Z"}
+            {"id": 1, "created_at": "2025-05-07T00:00:00Z", "status": "completed"},
         ]
-    },
-)
-@patch(
-    "airas.execution.executor_subgraph.nodes.execute_github_actions_workflow._request_github_actions_workflow_execution"
-)
-@patch(
-    "airas.execution.executor_subgraph.nodes.execute_github_actions_workflow._request_github_actions_workflow_info_before_execution",
-    return_value={
+    }
+
+@pytest.fixture
+def after_runs() -> dict:
+    return {
         "workflow_runs": [
-            {"id": 12344, "status": "completed", "created_at": "2023-12-31T00:00:00Z"}
+            {"id": 1, "created_at": "2025-05-07T00:00:00Z", "status": "completed"},
+            {"id": 2, "created_at": "2025-05-07T00:01:00Z", "status": "completed"},
         ]
-    },
+    }
+
+
+@pytest.fixture
+def dummy_success_client(before_runs, after_runs):
+    class DummyClient:
+        def __init__(self):
+            self.calls = []
+
+        def list_workflow_runs(self, github_owner, repository_name, branch_name):
+            self.calls.append("list")
+            return before_runs if self.calls.count("list") == 1 else after_runs
+
+        def dispatch_workflow(self, github_owner, repository_name, workflow_file, ref):
+            self.calls.append("dispatch")
+
+    return DummyClient()
+
+
+def test_count_workflow_runs():
+    resp = {"workflow_runs": [1, 2, 3]}
+    assert mod._count_github_actions_workflow_runs(resp) == 3
+
+
+def test_parse_workflow_run_id():
+    resp = {
+        "workflow_runs": [
+            {"id": 10, "created_at": "2025-05-06T12:00:00Z"},
+            {"id": 20, "created_at": "2025-05-07T08:30:00Z"},
+            {"id": 15, "created_at": "2025-05-05T23:59:59Z"},
+        ]
+    }
+    assert mod._parse_workflow_run_id(resp) == 20
+
+
+@pytest.mark.parametrize(
+    "runs, expected",
+    [
+        ([{"status": "completed"}, {"status": "completed"}], True),
+        ([{"status": "completed"}, {"status": "in_progress"}], False),
+    ],
 )
-@patch("os.makedirs")
-def test_execute_github_actions_workflow_success(
-    mock_makedirs, mock_info_before, mock_execute, mock_info_after, mock_parse_id
-):
-    result = execute_github_actions_workflow(
-        github_owner="owner", repository_name="repo", branch_name="main"
+def test_check_confirmation_of_execution_completion(runs, expected):
+    resp = {"workflow_runs": runs}
+    assert mod._check_confirmation_of_execution_completion(resp) is expected
+
+
+def test_execute_success_with_client_arg(dummy_success_client):
+    run_id = mod.execute_github_actions_workflow(
+        "github_owner", "repository_name", "branch_name", client=dummy_success_client
     )
-    assert result == 12345
+    assert dummy_success_client.calls == ["list", "dispatch", "list"]
+    assert run_id == 2
+
+def test_execute_success_with_default_client(monkeypatch, dummy_success_client):
+    monkeypatch.setattr(mod, "GithubClient", lambda: dummy_success_client)
+    monkeypatch.setattr(mod.time, "sleep", lambda s: None)
+
+    run_id = mod.execute_github_actions_workflow("github_owner", "repository_name", "branch_name")
+    assert dummy_success_client.calls == ["list", "dispatch", "list"]
+    assert run_id == 2
 
 
-# Abnormal case: _request_github_actions_workflow_info_before_execution returns None
-@patch(
-    "airas.execution.executor_subgraph.nodes.execute_github_actions_workflow._request_github_actions_workflow_info_before_execution",
-    return_value=None,
-)
-@patch("os.makedirs")
-def test_execute_github_actions_workflow_info_before_fail(
-    mock_makedirs, mock_info_before
-):
+@pytest.mark.parametrize("initial_response", [None, {}])
+def test_execute_raises_runtime_error_when_no_initial_runs(initial_response):
+    class DummyClientNoInitial:
+        def list_workflow_runs(self, *args, **kwargs):
+            return initial_response
+        def dispatch_workflow(self, *args, **kwargs):
+            pytest.skip("dispatch should not be called")
+
     with pytest.raises(RuntimeError):
-        execute_github_actions_workflow(
-            github_owner="owner", repository_name="repo", branch_name="main"
-        )
+        mod.execute_github_actions_workflow("github_owner", "repository_name", "branch_name", client=DummyClientNoInitial())
+
+
+def test_execute_timeout(monkeypatch, before_runs):
+    class DummyClientNever:
+        def __init__(self):
+            self.calls = []
+        def list_workflow_runs(self, *args, **kwargs):
+            self.calls.append("list")
+            return before_runs
+        def dispatch_workflow(self, *args, **kwargs):
+            self.calls.append("dispatch")
+
+    dummy = DummyClientNever()
+
+    timeout = mod._TIMEOUT_SEC
+    class FakeTime:
+        _t = 0
+        @classmethod
+        def time(cls):
+            return cls._t
+        @staticmethod
+        def sleep(sec):
+            FakeTime._t += timeout + 1
+
+    monkeypatch.setattr(mod, "time", FakeTime)
+    monkeypatch.setattr(mod, "GithubClient", lambda: dummy)
+
+    with pytest.raises(TimeoutError):
+        mod.execute_github_actions_workflow("owner", "repo", "branch")
+
+
+def test_execute_retries_until_completion(monkeypatch):
+    before_runs = {
+        "workflow_runs": [
+            {"id": 1, "created_at": "2025-05-07T00:00:00Z", "status": "completed"},
+        ]
+    }
+    incomplete_runs = {
+        "workflow_runs": [
+            {"id": 1, "created_at": "2025-05-07T00:00:00Z", "status": "completed"},
+            {"id": 2, "created_at": "2025-05-07T00:01:00Z", "status": "in_progress"},
+        ]
+    }
+    complete_runs = {
+        "workflow_runs": [
+            {"id": 1, "created_at": "2025-05-07T00:00:00Z", "status": "completed"},
+            {"id": 2, "created_at": "2025-05-07T00:01:00Z", "status": "completed"},
+        ]
+    }
+
+    class DummyClientRetries:
+        def __init__(self):
+            self.list_calls = 0
+            self.calls = []
+
+        def list_workflow_runs(self, github_owner, repository_name, branch_name):
+            self.calls.append("list")
+            self.list_calls += 1
+            if self.list_calls == 1:
+                return before_runs
+            elif self.list_calls == 2:
+                return incomplete_runs
+            else:
+                return complete_runs
+
+        def dispatch_workflow(self, github_owner, repository_name, workflow_file, ref):
+            self.calls.append("dispatch")
+
+    client = DummyClientRetries()
+
+    monkeypatch.setattr(mod.time, "sleep", lambda s: None)
+
+    run_id = mod.execute_github_actions_workflow("github_owner", "repository_name", "branch_name", client=client)
+
+    assert client.calls == ["list", "dispatch", "list", "list"]
+    assert run_id == 2

--- a/tests/unit/execution/executor_subgraph/test_retrieve_github_actions_artifacts.py
+++ b/tests/unit/execution/executor_subgraph/test_retrieve_github_actions_artifacts.py
@@ -1,104 +1,77 @@
-from unittest.mock import MagicMock, patch
-
 import pytest
+import io
+import zipfile
 
-from airas.execution.executor_subgraph.nodes.retrieve_github_actions_artifacts import (
-    retrieve_github_actions_artifacts,
-)
+import airas.execution.executor_subgraph.nodes.retrieve_github_actions_artifacts as mod
 
 
-# Normal case: All external dependencies are mocked, and the contents of output.txt/error.txt are returned
-@patch(
-    "airas.execution.executor_subgraph.nodes.retrieve_github_actions_artifacts._copy_images_to_latest_dir"
-)
-@patch(
-    "airas.execution.executor_subgraph.nodes.retrieve_github_actions_artifacts.open",
-    create=True,
-)
-@patch(
-    "airas.execution.executor_subgraph.nodes.retrieve_github_actions_artifacts._request_download_artifacts"
-)
-@patch(
-    "airas.execution.executor_subgraph.nodes.retrieve_github_actions_artifacts._parse_artifacts_info",
-    return_value={"artifact1": "url"},
-)
-@patch(
-    "airas.execution.executor_subgraph.nodes.retrieve_github_actions_artifacts._request_github_actions_artifacts",
-    return_value={
-        "artifacts": [
-            {
-                "workflow_run": {"id": "runid"},
-                "name": "artifact1",
-                "archive_download_url": "url",
-            }
-        ]
-    },
-)
-@patch("os.makedirs")
-def test_retrieve_github_actions_artifacts_success(
-    mock_makedirs,
-    mock_request_artifacts,
-    mock_parse_info,
-    mock_download,
-    mock_open,
-    mock_copy_images,
-):
-    # The mock for open is set to be used as a context manager and called twice
-    mock_file = MagicMock()
-    mock_file.read.side_effect = ["output content", "error content"]
-    mock_open.side_effect = [
-        MagicMock(
-            __enter__=lambda s: mock_file,
-            __exit__=lambda s, exc_type, exc_val, exc_tb: None,
-        ),
-        MagicMock(
-            __enter__=lambda s: mock_file,
-            __exit__=lambda s, exc_type, exc_val, exc_tb: None,
-        ),
-    ]
-    result = retrieve_github_actions_artifacts(
-        github_owner="owner",
-        repository_name="repo",
-        workflow_run_id="runid",
-        save_dir="/tmp",
-        fix_iteration_count=0,
+@pytest.fixture
+def zip_bytes() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as z:
+        z.writestr('output.txt', 'OUT')
+        z.writestr('error.txt', 'ERR')
+        z.writestr('doc.pdf', b'%PDF')
+    return buf.getvalue()
+
+
+@pytest.fixture
+def dummy_client(zip_bytes):
+    class DummyClient:
+        def __init__(self):
+            self.infos = {"artifacts":[{"name":"artifact","id":1,"workflow_run":{"id":"run"}}]}
+            self.downloaded = []
+        def list_repository_artifacts(self, github_owner, repository_name):
+            return self.infos
+        def download_artifact_archive(self, github_owner, repository_name, aid):
+            self.downloaded.append(aid)
+            return zip_bytes
+    return DummyClient()
+
+
+@pytest.mark.parametrize("infos, run_id", [
+    (None, "run"),
+    ({}, "run"),
+    ({"artifacts": []}, "run"),
+])
+def test_retrieve_errors(tmp_path, infos, run_id):
+    class C:
+        def list_repository_artifacts(self, *args, **kwargs): return infos
+        def download_artifact_archive(self, *args, **kwargs): pytest.skip()
+    with pytest.raises(RuntimeError):
+        mod.retrieve_github_actions_artifacts("o","r", run_id, str(tmp_path), 0, client=C())
+
+
+@pytest.mark.parametrize("infos, target, expected", [
+    ({"artifacts":[{"name":"a","id":10,"workflow_run":{"id":"x"}}]}, "x", {"a":10}),
+    ({"artifacts":[]}, "x", {}),
+])
+def test_parse_artifacts_id(infos, target, expected):
+    assert mod._parse_artifacts_id(infos, target) == expected
+
+
+def test_save_and_copy(tmp_path, zip_bytes):
+    save_dir = tmp_path / "iter"
+    save_dir.mkdir()
+    mod._save_zip_and_extract(zip_bytes, str(save_dir), "artifact")
+    assert (save_dir/"output.txt").read_text() == "OUT"
+    assert not (save_dir/"artifact.zip").exists()
+
+    pdf = save_dir/"test.pdf"
+    pdf.write_bytes(b'%PDF')
+    dest = tmp_path/"images"
+    mod._copy_images_to_latest_dir(str(save_dir), str(dest))
+    assert (dest/"test.pdf").exists()
+
+
+def test_retrieve_success(tmp_path, dummy_client):
+    out, err = mod.retrieve_github_actions_artifacts(
+        "owner","repo","run", str(tmp_path), fix_iteration_count=1,
+        client=dummy_client
     )
-    assert result == ("output content", "error content")
-
-
-# Abnormal case: _request_github_actions_artifacts returns None
-@patch(
-    "airas.execution.executor_subgraph.nodes.retrieve_github_actions_artifacts._copy_images_to_latest_dir"
-)
-@patch(
-    "airas.execution.executor_subgraph.nodes.retrieve_github_actions_artifacts.open",
-    create=True,
-)
-@patch(
-    "airas.execution.executor_subgraph.nodes.retrieve_github_actions_artifacts._request_download_artifacts"
-)
-@patch(
-    "airas.execution.executor_subgraph.nodes.retrieve_github_actions_artifacts._parse_artifacts_info",
-    return_value={},
-)
-@patch(
-    "airas.execution.executor_subgraph.nodes.retrieve_github_actions_artifacts._request_github_actions_artifacts",
-    return_value=None,
-)
-@patch("os.makedirs")
-def test_retrieve_github_actions_artifacts_api_fail(
-    mock_makedirs,
-    mock_request_artifacts,
-    mock_parse_info,
-    mock_download,
-    mock_open,
-    mock_copy_images,
-):
-    with pytest.raises(Exception):
-        retrieve_github_actions_artifacts(
-            github_owner="owner",
-            repository_name="repo",
-            workflow_run_id="runid",
-            save_dir="/tmp",
-            fix_iteration_count=0,
-        )
+    assert out == "OUT" and err == "ERR"
+    assert dummy_client.downloaded == [1]
+    iter_dir = tmp_path / 'iteration_1'
+    assert not (iter_dir / 'artifact.zip').exists()
+    imgs = list((tmp_path / 'images').glob('*.pdf'))
+    assert imgs and imgs[0].name == 'doc.pdf'

--- a/tests/unit/publication/html_subgraph/test_render_html.py
+++ b/tests/unit/publication/html_subgraph/test_render_html.py
@@ -1,25 +1,42 @@
-from pathlib import Path
-
 import pytest
 
 from airas.publication.html_subgraph.nodes.render_html import (
-    _save_index_html,
     _wrap_in_html_template,
+    _save_index_html,
+    render_html,
 )
 
 
-def test_wrap_in_html_template() -> None:
-    test_content = "<p>Hello, world!</p>"
-    result = _wrap_in_html_template(test_content)
-    assert test_content in result
+@pytest.fixture
+def sample_content() -> str:
+    return "<h1>Hello, World!</h1>"
 
+def test_wrap_in_html_template_contains_structure_and_content(sample_content):
+    wrapped = _wrap_in_html_template(sample_content)
 
-@pytest.mark.parametrize("subpath", ["", "missing_dir"])
-def test_save_index_html_creates_file(tmp_path: Path, subpath: str) -> None:
-    test_full_html = "<html><body>Test</body></html>"
-    save_dir = tmp_path / subpath
-    _save_index_html(test_full_html, str(save_dir))
+    assert wrapped.lstrip().startswith("<!DOCTYPE html>")
+    assert "<html" in wrapped and "</html>" in wrapped
+    assert "<head>" in wrapped and "</head>" in wrapped
+    assert "<body>" in wrapped and "</body>" in wrapped
+    assert sample_content in wrapped
 
-    index_file = save_dir / "index.html"
+def test_save_index_html_creates_file_and_writes_content(tmp_path, sample_content):
+    save_dir = tmp_path / "output"
+    _save_index_html(sample_content, str(save_dir))
+
+    index_path = save_dir / "index.html"
+    assert index_path.exists()
+
+    written = index_path.read_text(encoding="utf-8")
+    assert written == sample_content
+
+def test_render_html_returns_full_html_and_saves_file(tmp_path, sample_content):
+    full_html = render_html(sample_content, str(tmp_path))
+    assert full_html.lstrip().startswith("<!DOCTYPE html>")
+    assert sample_content in full_html
+
+    index_file = tmp_path / "index.html"
     assert index_file.exists()
-    assert index_file.read_text(encoding="utf-8") == test_full_html
+
+    file_text = index_file.read_text(encoding="utf-8")
+    assert file_text == full_html

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ wheels = [
 
 [[package]]
 name = "airas"
-version = "0.0.11.dev16"
+version = "0.0.11.dev17"
 source = { editable = "." }
 dependencies = [
     { name = "feedparser" },


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- New or updated content
- Translated content
- Something else!

#### Description

- Closes 
  - #50 
  - #59  

This change has been verified across all modules. (Note: retrieval of images generated during experiments is not yet implemented and will be addressed in future updates.)
Reference:
https://github.com/auto-res2/experiment_script_matsuzawa/blob/base-branch-retrievepaperfromquerysubgraph-20250507-121037/.research/research_history.json

--- 
# Changes
The following features have been modified:
1. Migrated GitHub API usage in `execution/` modules to `GithubClient`
2. Resolved `422 Unprocessable Entity` error in workflow dispatch
3. Correctly retrieves SHA from the default branch, even when it's not `main`
4. Pretty-prints final results in `main()` using `json.dumps(..., indent=2)`
5. Update `tests/`


Details of the implementation are described below:

<details>
<summary><code>1. src/airas/utils/api_client/github_client.py, src/airas/execution/executor_subgraph/executor_subgraph.py</code></summary>

 **Implementation Overview**
- Replaced direct GitHub API usage in execution/ modules (e.g., `execute_github_actions_workflow.py`, `retrieve_github_actions_artifacts.py`) with `GithubClient`
- Fixed 422 error caused by `branch_name` incorrectly being set to `experiment_session_id` in `_generate_code_with_devin_node()` → corrected to use `branch_name` (#50)

- Introduced `GithubClientRetryableError` and `GithubClientFatalError`; only retry on the former using *Tenacity*. The latter is raised for unrecoverable errors.
- Improved error handling by explicitly validating unexpected status codes via `_raise_for_status()`
- Adjusted response parsing to occur only after status code checks, using `return self.parse_response(response)`

</details>

<details>
<summary><code>2. src/airas/retrieve/retrieve_code_subgraph/node/retrieve_repository_contents.py</code></summary>

 **Implementation Overview**
- Migrated GitHub API logic into `GithubClient`
- Fixed issue where SHA couldn't be retrieved if the default branch wasn't `main` by explicitly fetching the SHA of the actual default branch (#59)

</details>

<details>
<summary><code>3. all subgraph</code></summary>

 **Implementation Overview**
- Changed `main()` result output to `json.dumps(result, indent=2)` for improved readability

</details>