### PR TITLE
create semantic schloar and openalex node

### DIFF
--- a/src/airas/retrieve/retrieve_paper_from_query_subgraph/nodes/openalex_search_titles.py
+++ b/src/airas/retrieve/retrieve_paper_from_query_subgraph/nodes/openalex_search_titles.py
@@ -1,0 +1,75 @@
+import logging
+from time import sleep
+
+from airas.utils.api_client.openalex_client import OpenAlexClient
+
+logger = logging.getLogger(__name__)
+
+
+_EXCLUDE_KEYWORDS = ("survey", "review", "overview", "systematic review")
+
+
+def _is_excluded_title(title: str) -> bool:
+    lowered = title.lower()
+    return any(word in lowered for word in _EXCLUDE_KEYWORDS)
+
+def openalex_search_titles(
+    queries: list[str],
+    *,
+    year: str | None = None,
+    max_results: int = 20,
+    sleep_sec: float = 0.2,
+    client: OpenAlexClient | None = None,
+) -> list[str] | None:
+    if client is None:
+        client = OpenAlexClient()
+
+    collected: set[str] = set()
+
+    for q in queries:
+        logger.info(f"Searching ML works for query: '{q}'")
+        current_page = 1
+        per_page = min(max_results - len(collected), 200)
+
+        while per_page > 0:
+            try:
+                response = client.search_paper_titles(
+                    query=q,
+                    year=year,
+                    per_page=per_page,
+                    page=current_page,
+                )
+            except Exception as exc:
+                logger.warning(f"Search failed for '{q}' (page {current_page}): {exc}")
+                break
+
+            results = response.get("results", [])
+            if not results:
+                break
+
+            for item in results:
+                title = item.get("display_name", "").strip()
+                if title and not _is_excluded_title(title):
+                    collected.add(title)
+                    if len(collected) >= max_results:
+                        return sorted(collected)
+
+            current_page += 1
+            sleep(sleep_sec)
+            per_page = min(max_results - len(collected), 200)
+
+    if not collected:
+        logger.warning("No paper titles obtained for any query")
+        return None
+    
+    return sorted(collected)
+
+
+if __name__ == "__main__":
+    results = openalex_search_titles(
+        queries=["This study introduces a vision transformer model for image recognition tasks."],
+        year="2020-2024",
+        max_results=20,
+    )
+    for title in results:
+        print(f"- {title}")

--- a/src/airas/retrieve/retrieve_paper_from_query_subgraph/nodes/semantic_scholar_search_titles.py
+++ b/src/airas/retrieve/retrieve_paper_from_query_subgraph/nodes/semantic_scholar_search_titles.py
@@ -1,0 +1,59 @@
+import logging
+
+from airas.utils.api_client.semantic_scholar_client import SemanticScholarClient
+
+logger = logging.getLogger(__name__)
+
+
+def semantic_scholar_search_titles(
+    queries: list[str],
+    *,
+    limit: int = 20,
+    year: str | None = None,
+    publication_date_or_year: str | None = None,
+    client: SemanticScholarClient | None = None,
+) -> list[str]:
+    if client is None:
+        client = SemanticScholarClient()
+
+    logger.info("Executing Semantic Scholar API searches...")
+    collected: set[str] = set()
+
+    for q in queries:
+        logger.info(f"Searching papers for query: '{q}'")
+
+        try:
+            resp = client.search_paper_titles(
+                query=q,
+                fields=[],
+                year=year,
+                publication_date_or_year=publication_date_or_year,
+                limit=limit,
+            )
+        except Exception as exc:
+            logger.warning(f"Search failed for '{q}': {exc}")
+            continue
+
+        data = resp.get("data", [])
+        if not data:
+            logger.warning(f"No results for '{q}'")
+            continue
+
+        for item in data:
+            title = item.get("title", "").strip()
+            if title:
+                collected.add(title)
+
+    if not collected:
+        raise RuntimeError("No paper titles obtained for any query")
+
+    return sorted(collected)
+
+
+if __name__ == "__main__":
+    titles = semantic_scholar_search_titles(
+        queries=["neural network", "transformer"],
+        year="2020-2024",
+        limit=20,
+    )
+    print("\n".join(titles))

--- a/src/airas/retrieve/retrieve_paper_from_query_subgraph/nodes/web_scrape.py
+++ b/src/airas/retrieve/retrieve_paper_from_query_subgraph/nodes/web_scrape.py
@@ -1,12 +1,9 @@
-import os
 import urllib.parse
 from logging import getLogger
 
 from airas.utils.api_client.firecrawl_client import FireCrawlClient
 
 logger = getLogger(__name__)
-
-FIRE_CRAWL_API_KEY = os.getenv("FIRE_CRAWL_API_KEY")
 
 
 def web_scrape(


### PR DESCRIPTION
Close: #83 

Implemented LangGraph nodes for retrieving paper titles using both Semantic Scholar and OpenAlex clients. Each client was wrapped in a dedicated retrieval node for integration into the pipeline.

Note: The existing Semantic Scholar API key appears to be invalid or no longer accepted. Further investigation is needed to obtain a valid key.

