### PR TITLE
fix graphwrapper

### DIFF
--- a/src/airas/retrieve/retrieve_paper_from_query_subgraph/retrieve_paper_from_query_subgraph.py
+++ b/src/airas/retrieve/retrieve_paper_from_query_subgraph/retrieve_paper_from_query_subgraph.py
@@ -373,9 +373,6 @@ def main():
     ]
     llm_name = "o3-mini-2025-01-31"
     save_dir = "/workspaces/airas/data"
-    input = {
-        "base_queries": ["transformer"],
-    }
 
     parser = argparse.ArgumentParser(
         description="execute retrieve_paper_from_query_subgraph"
@@ -389,13 +386,12 @@ def main():
     base_paper_retriever = RetrievePaperFromQuery(
         github_repository=args.github_repository,
         branch_name=args.branch_name,
-        perform_download=False,
         llm_name=llm_name,
         save_dir=save_dir,
         scrape_urls=scrape_urls,
     )
 
-    result = base_paper_retriever.run(input)
+    result = base_paper_retriever.run()
     print(f"result: {json.dumps(result, indent=2)}")
 
 

--- a/src/airas/retrieve/retrieve_related_paper_subgraph/retrieve_related_paper_subgraph.py
+++ b/src/airas/retrieve/retrieve_related_paper_subgraph/retrieve_related_paper_subgraph.py
@@ -429,9 +429,6 @@ def main():
 
     llm_name = "o3-mini-2025-01-31"
     save_dir = "/workspaces/airas/data"
-    input = {
-        "add_queries": ["vision"],
-    }
 
     parser = argparse.ArgumentParser(
         description="execute retrieve_related_paper_subgraph"
@@ -451,7 +448,7 @@ def main():
         add_paper_num=add_paper_num,
     )
 
-    result = add_paper_retriever.run(input)
+    result = add_paper_retriever.run()
     print(f"result: {json.dumps(result, indent=2)}")
     return
 


### PR DESCRIPTION
Prevent GithubGraphWrapper from accepting direct user input.
Ensure user inputs are handled exclusively via GithubUploadSubgraph.
Accordingly, remove the perform_download and perform_upload arguments from GithubGraphWrapper.
#87 