### PR TITLE
Add optional branching to GithubUploadSubgraph

### DIFF
--- a/src/airas/github/github_download_subgraph.py
+++ b/src/airas/github/github_download_subgraph.py
@@ -14,7 +14,6 @@ from airas.utils.execution_timers import ExecutionTimeState, time_node
 class GithubDownloadInputState(TypedDict):
     github_repository: str
     branch_name: str
-    research_file_path: str | None
 
 class GithubDownloadHiddenState(TypedDict):
     github_owner: str
@@ -35,8 +34,10 @@ class GithubDownloadSubgraphState(
 class GithubDownloadSubgraph:
     def __init__(
         self,
+        research_file_path: str = ".research/research_history.json", 
     ):
         check_api_key(llm_api_key_check=True)
+        self.research_file_path = research_file_path
 
     def _init(self, state: GithubDownloadSubgraphState) -> dict[str, Any]:
         github_repository = state["github_repository"]
@@ -55,7 +56,7 @@ class GithubDownloadSubgraph:
             github_owner=state["github_owner"],
             repository_name=state["repository_name"],
             branch_name=state["branch_name"],
-            file_path=state.get("research_file_path") or ".research/research_history.json",
+            file_path=self.research_file_path,
         )
         return {"research_history": research_history}
 
@@ -82,11 +83,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="GithubDownloadSubgraph")
     parser.add_argument("github_repository", help="Your GitHub repository")
     parser.add_argument("branch_name", help="Your branch name in your GitHub repository")
-    parser.add_argument(
-        "--research_file_path", 
-        help="Your branch name in your GitHub repository", 
-        default=".research/research_history.json"
-    )
+
     args = parser.parse_args()
 
     subgraph = GithubDownloadSubgraph()
@@ -94,7 +91,6 @@ if __name__ == "__main__":
     initial_state = {
         "github_repository":       args.github_repository,
         "branch_name":        args.branch_name,
-        "research_file_path": args.research_file_path,
     }
 
     result = subgraph.run(initial_state)

--- a/src/airas/github/github_download_subgraph.py
+++ b/src/airas/github/github_download_subgraph.py
@@ -86,12 +86,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    subgraph = GithubDownloadSubgraph()
-
-    initial_state = {
+    state = {
         "github_repository":       args.github_repository,
         "branch_name":        args.branch_name,
     }
 
-    result = subgraph.run(initial_state)
+    result = GithubDownloadSubgraph().run(state)
     print(json.dumps(result, indent=2))

--- a/src/airas/github/nodes/github_upload.py
+++ b/src/airas/github/nodes/github_upload.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import logging
 import os
+import time
 from typing import Any
 
 from typing_extensions import TypedDict
@@ -56,6 +57,7 @@ def github_upload(
     file_path: str | None = ".research/research_history.json",
     extra_files: list[ExtraFileConfig] | None = None,
     commit_message: str = "Update history via github_upload",
+    wait_seconds: float = 3.0, 
     client: GithubClient | None = None,
 ) -> bool:
     if client is None:
@@ -80,14 +82,12 @@ def github_upload(
             client,
             commit_message=commit_message,
         )
-
+    if wait_seconds > 0:
+        time.sleep(wait_seconds)
     return ok_json and ok_assets
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Merge and upload research history and assets to GitHub."
-    )
     parser = argparse.ArgumentParser(description="github_download")
     parser.add_argument("github_owner", help="Your github owner")
     parser.add_argument("repository_name", help="Your repository name")

--- a/src/airas/github/nodes/prepare_branch.py
+++ b/src/airas/github/nodes/prepare_branch.py
@@ -1,36 +1,20 @@
 import logging
 from datetime import datetime, timezone
-from typing import Any
 
 from airas.utils.api_client.github_client import GithubClient
 
 logger = logging.getLogger(__name__)
 
 
-def _dict_conflict(old: Any, new: Any) -> bool:
-    if isinstance(old, dict) and isinstance(new, dict):
-        for key in old.keys() & new.keys():
-            if _dict_conflict(old[key], new[key]):
-                return True
-        return False
-    return old != new
-
-
 def prepare_branch(
     github_owner: str,
     repository_name: str,
     branch_name: str,
-    research_history: dict[str, Any],
-    new_output: dict[str, Any],
     subgraph_name: str | None, 
     client: GithubClient | None = None,
 ) -> str:
     if client is None:
         client = GithubClient()
-
-    if not _dict_conflict(research_history, new_output):
-        logger.info(f"No overwrite conflict – keeping branch '{branch_name}'")
-        return branch_name
 
     base_info = client.get_branch(
         github_owner, repository_name, branch_name
@@ -47,5 +31,5 @@ def prepare_branch(
     client.create_branch(
         github_owner, repository_name, new_branch, from_sha=sha
     )
-    logger.info(f"Conflict detected – created branch '{new_branch}' from '{branch_name}'")
+    print(f"Created new branch '{new_branch}' from '{branch_name}'")
     return new_branch

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ wheels = [
 
 [[package]]
 name = "airas"
-version = "0.0.11.dev21"
+version = "0.0.11.dev29"
 source = { editable = "." }
 dependencies = [
     { name = "feedparser" },


### PR DESCRIPTION
- Closes
  - #107 
  - #109  
---
## Description:
This PR implements an optional branching feature for the `GithubUploadSubgraph`. The update ensures greater flexibility when managing `research_history.json` uploads to GitHub.

## Changes:
- Optional branching control 
  Introduced a `create_branch: bool` flag to switch between:
    - Creating a new branch (`prepare_branch`)
    - Directly merging (`merge_history`)
      Branching logic is now handled via `add_conditional_edges`.
- Simplified `prepare_branch`
  The function now only creates a branch. Decision-making logic (`dict_conflict()`) has been removed. 
- The parameters `subgraph_name`, `create_branch`, and `extra_files` are intended to be used as instance variables, like the following:
```python
state = GithubUploadSubgraph(
    subgraph_name="retrieve_paper_from_query",
    create_branch=True,
).run(state)

```
- Constructor cleanup
  `research_file_path` is now passed via the constructor (not the state) for both upload and download subgraphs.
  It defaults to `.research/research_history.json`.