### PR TITLE
Fix LaTeX escaping and workflow delay in HTML/Latex subgraphs

### DIFF
--- a/src/airas/publication/html_subgraph/html_subgraph.py
+++ b/src/airas/publication/html_subgraph/html_subgraph.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 import sys
+import time
 from typing import Any
 
 from langgraph.graph import END, START, StateGraph
@@ -120,6 +121,7 @@ class HtmlSubgraph:
     
     @html_timed
     def _dispatch_workflow(self, state: HtmlSubgraphState) -> dict[str, bool]:
+        time.sleep(3) 
         ok = dispatch_workflow(
             github_owner=state["github_owner"], 
             repository_name=state["repository_name"], 

--- a/src/airas/publication/latex_subgraph/latex_subgraph.py
+++ b/src/airas/publication/latex_subgraph/latex_subgraph.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 import sys
+import time
 from typing import Any
 
 from langgraph.graph import END, START, StateGraph
@@ -10,13 +11,13 @@ from langgraph.graph.graph import CompiledGraph
 from typing_extensions import TypedDict
 
 from airas.github.nodes.upload_files import upload_files
+from airas.publication.html_subgraph.nodes.dispatch_workflow import dispatch_workflow
 from airas.publication.latex_subgraph.input_data import latex_subgraph_input_data
 from airas.publication.latex_subgraph.nodes.assemble_latex import LatexNode
 from airas.publication.latex_subgraph.nodes.convert_to_latex import (
     convert_to_latex,
 )
 from airas.publication.latex_subgraph.nodes.generate_bib import generate_bib
-from airas.publication.html_subgraph.nodes.dispatch_workflow import dispatch_workflow
 from airas.publication.latex_subgraph.prompt.convert_to_latex_prompt import (
     convert_to_latex_prompt,
 )
@@ -140,6 +141,7 @@ class LatexSubgraph:
 
     @latex_timed
     def _dispatch_workflow(self, state: LatexSubgraphState) -> dict[str, bool]:
+        time.sleep(3)  
         ok = dispatch_workflow(
             github_owner=state["github_owner"], 
             repository_name=state["repository_name"], 

--- a/src/airas/publication/latex_subgraph/prompt/convert_to_latex_prompt.py
+++ b/src/airas/publication/latex_subgraph/prompt/convert_to_latex_prompt.py
@@ -48,8 +48,8 @@ Section: {{ section.name }}
     - Otherwise (default), use 0.7\\linewidth
 
 - **Escaping special characters**:
-    - LaTeX special characters (`#`, `$`, `%`, `&`, `~`, `_`, `^`, `{`, `}`, `\\`) must be escaped with a leading backslash when they appear in plain text (e.g., `data\_set`, `C\&C`).
-    - Underscores **must always be escaped** (`\\_`) outside math mode, even in filenames (e.g., memory\_profiler), code-style words, itemize lists, or citation contexts.
+    - LaTeX special characters (`#`, `$`, `%`, `&`, `~`, `_`, `^`, `{`, `}`, `\\`) must be escaped with a leading backslash when they appear in plain text (e.g., `data\\_set`, `C\\&C`).
+    - Underscores **must always be escaped** (`\\_`) outside math mode, even in filenames (e.g., memory\\_profiler), code-style words, itemize lists, or citation contexts.
     
 - Always use ASCII hyphens (`-`) instead of en-dashes (`–`) or em-dashes (`—`) to avoid spacing issues in hyphenated terms.
 - Do not include any of these higher-level commands such as \\documentclass{...}, \\begin{document}, and \\end{document}.

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ wheels = [
 
 [[package]]
 name = "airas"
-version = "0.0.11.dev38"
+version = "0.0.11.dev39"
 source = { editable = "." }
 dependencies = [
     { name = "feedparser" },


### PR DESCRIPTION
This PR makes the following minor fixes and improvements:
- Fixed incorrect LaTeX escape sequences in the prompt (\\_, \\&).
- Added `time.sleep(3)` before dispatching GitHub Actions workflow to improve stability.