### PR TITLE
fix_7 github_download logic

### DIFF
--- a/src/airas/features/github/nodes/github_download.py
+++ b/src/airas/features/github/nodes/github_download.py
@@ -1,7 +1,8 @@
-import base64
 import json
 import logging
 from typing import Any
+
+import requests
 
 from airas.services.api_client.github_client import GithubClient
 from airas.types.github import GitHubRepositoryInfo
@@ -27,8 +28,35 @@ def github_download(
             file_path=file_path,
             branch_name=github_repository_info.branch_name,
         )
-        raw = base64.b64decode(blob["content"])
-        return json.loads(raw) if raw else {}
+
+        download_url = blob.get("download_url")
+        if not download_url:
+            logger.error("No download_url available for file")
+            return {}
+
+        logger.info(f"Downloading file directly: {download_url}")
+        response = requests.get(download_url)
+        response.raise_for_status()
+        raw = response.content
+
+        if not raw:
+            logger.warning("Raw content is empty, returning empty dict")
+            return {}
+
+        decoded_content = json.loads(raw)
+        return decoded_content
+
     except FileNotFoundError as e:
         logger.error(f"State file not found – start with empty dict: {e}")
         raise
+
+
+if __name__ == "__main__":
+    github_repository_info = GitHubRepositoryInfo(
+        github_owner="auto-res2",
+        repository_name="experiment_matsuzawa_colab_2",
+        branch_name="develop_3",
+    )
+
+    result = github_download(github_repository_info)
+    print(f"result: {result.keys()}")

--- a/src/airas/services/api_client/github_client.py
+++ b/src/airas/services/api_client/github_client.py
@@ -400,7 +400,6 @@ class GithubClient(BaseHTTPClient):
     def download_repository_zip(
         self, github_owner: str, repository_name: str, ref: str = "master"
     ) -> bytes:
-        """Download repository as ZIP archive"""
         # https://docs.github.com/en/rest/repos/contents#download-a-repository-archive-zip
         path = f"/repos/{github_owner}/{repository_name}/zipball/{ref}"
 


### PR DESCRIPTION
`src/airas/features/github/nodes/github_download.py`
- The size of `research_history.json` is too large, so the content becomes empty when retrieved directly from the GitHub API.
- Therefore, we changed the logic to obtain `download_url` from the meta information and request it directly.