### PR TITLE
Add ReviewPaperScores

### DIFF
--- a/src/airas/features/review/review_paper_subgraph/nodes/review_paper.py
+++ b/src/airas/features/review/review_paper_subgraph/nodes/review_paper.py
@@ -7,7 +7,7 @@ from airas.services.api_client.llm_client.llm_facade_client import (
     LLM_MODEL,
     LLMFacadeClient,
 )
-from airas.types.paper import PaperContent
+from airas.types.paper import PaperContent, PaperReviewScores
 
 logger = getLogger(__name__)
 
@@ -24,7 +24,7 @@ def review_paper(
     prompt_template: str,
     paper_content: PaperContent,
     client: LLMFacadeClient | None = None,
-) -> dict[str, int]:
+) -> dict[str, PaperReviewScores]:
     client = client or LLMFacadeClient(llm_name=llm_name)
 
     env = Environment()
@@ -42,9 +42,11 @@ def review_paper(
     if output is None:
         raise ValueError("No response from LLM in paper_review_node.")
 
-    return {
-        "novelty_score": output["novelty_score"],
-        "significance_score": output["significance_score"],
-        "reproducibility_score": output["reproducibility_score"],
-        "experimental_quality_score": output["experimental_quality_score"],
-    }
+    paper_review_scores = PaperReviewScores(
+        novelty_score=output["novelty_score"],
+        significance_score=output["significance_score"],
+        reproducibility_score=output["reproducibility_score"],
+        experimental_quality_score=output["experimental_quality_score"],
+    )
+
+    return {"paper_review_scores": paper_review_scores}

--- a/src/airas/features/review/review_paper_subgraph/review_paper_subgraph.py
+++ b/src/airas/features/review/review_paper_subgraph/review_paper_subgraph.py
@@ -16,7 +16,7 @@ from airas.features.review.review_paper_subgraph.prompts.review_paper_prompt imp
     review_paper_prompt,
 )
 from airas.services.api_client.llm_client.llm_facade_client import LLM_MODEL
-from airas.types.paper import PaperContent
+from airas.types.paper import PaperContent, PaperReviewScores
 from airas.utils.check_api_key import check_api_key
 from airas.utils.execution_timers import ExecutionTimeState, time_node
 from airas.utils.logging_utils import setup_logging
@@ -36,10 +36,7 @@ class ReviewPaperSubgraphHiddenState(TypedDict):
 
 
 class ReviewPaperSubgraphOutputState(TypedDict):
-    novelty_score: int
-    significance_score: int
-    reproducibility_score: int
-    experimental_quality_score: int
+    paper_review_scores: PaperReviewScores
 
 
 class ReviewPaperSubgraphState(
@@ -65,7 +62,9 @@ class ReviewPaperSubgraph(BaseSubgraph):
         check_api_key(llm_api_key_check=True)
 
     @review_paper_timed
-    def _review_paper(self, state: ReviewPaperSubgraphState) -> dict[str, int]:
+    def _review_paper(
+        self, state: ReviewPaperSubgraphState
+    ) -> dict[str, PaperReviewScores]:
         review_result = review_paper(
             llm_name=self.llm_name,
             prompt_template=self.prompt_template,

--- a/src/airas/types/paper.py
+++ b/src/airas/types/paper.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel
+from typing import Optional
+
+from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
 
@@ -17,6 +19,20 @@ class CandidatePaperInfo(TypedDict):
     experimental_setup: str
     limitations: str
     future_research_directions: str
+
+
+# TODO: Move to ResearchStudy or ResearchHypothesis
+class PaperReviewScores(BaseModel):
+    novelty_score: Optional[int] = Field(None, description="Paper novelty score")
+    significance_score: Optional[int] = Field(
+        None, description="Paper significance score"
+    )
+    reproducibility_score: Optional[int] = Field(
+        None, description="Paper reproducibility score"
+    )
+    experimental_quality_score: Optional[int] = Field(
+        None, description="Paper experimental quality score"
+    )
 
 
 class PaperContent(BaseModel):

--- a/src/airas/types/research_history.py
+++ b/src/airas/types/research_history.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 
 from airas.types.devin import DevinInfo
 from airas.types.github import GitHubRepositoryInfo
-from airas.types.paper import PaperContent
+from airas.types.paper import PaperContent, PaperReviewScores
 from airas.types.research_hypothesis import ResearchHypothesis
 from airas.types.research_study import ResearchStudy
 
@@ -46,6 +46,10 @@ class ResearchHistory(BaseModel):
     github_pages_url: Optional[str] = Field(None, description="GitHub Pages URL")
     readme_upload_result: Optional[bool] = Field(
         None, description="README upload success status"
+    )
+
+    paper_review_scores: Optional[PaperReviewScores] = Field(
+        None, description="Review scores from ReviewPaperSubgraph"
     )
 
     additional_data: Optional[dict[str, Any]] = Field(


### PR DESCRIPTION
In order to upload review scores to GitHub, it is necessary to add a new field to ResearchHistory. This time, we defined a type class in `paper.py` on a provisional basis.