### PR TITLE
Fix RetrieveHuggingFaceSubgraph

### DIFF
--- a/src/airas/config/llm_config.py
+++ b/src/airas/config/llm_config.py
@@ -53,7 +53,7 @@ DEFAULT_NODE_LLMS: LLM_CONFIG_TYPE = {
 
     # --- features/retrieve ---
     # RetrieveHuggingFaceSubgraph
-    "select_resources": BASE_MODEL,
+    "select_resources": "gemini-2.5-flash",
 
     # --- features/evaluate ---
     # JudgeExecutionSubgraph

--- a/src/airas/features/retrieve/retrieve_hugging_face_subgraph/nodes/select_resources.py
+++ b/src/airas/features/retrieve/retrieve_hugging_face_subgraph/nodes/select_resources.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class SelectedResource(BaseModel):
-    title: str
+    id: str
 
 
 class LLMOutput(BaseModel):
@@ -49,16 +49,12 @@ def select_resources(
         }
     )
 
-    logger.info("Selecting relevant resources using LLM...")
-
     output, _cost = client.structured_outputs(message=messages, data_model=LLMOutput)
     if output is None:
         raise ValueError("Error: No response from LLM in select_resources.")
 
-    selected_model_ids = {resource["title"] for resource in output["selected_models"]}
-    selected_dataset_ids = {
-        resource["title"] for resource in output["selected_datasets"]
-    }
+    selected_model_ids = {resource["id"] for resource in output["selected_models"]}
+    selected_dataset_ids = {resource["id"] for resource in output["selected_datasets"]}
 
     selected_models = [
         model

--- a/src/airas/features/retrieve/retrieve_hugging_face_subgraph/retrieve_hugging_face_subgraph.py
+++ b/src/airas/features/retrieve/retrieve_hugging_face_subgraph/retrieve_hugging_face_subgraph.py
@@ -34,9 +34,7 @@ def retrieve_hugging_face_timed(f):
 
 
 class RetrieveHuggingFaceLLMMapping(BaseModel):
-    select_resources: LLM_MODEL = DEFAULT_NODE_LLMS.get(
-        "select_resources", "o3-2025-04-16"
-    )
+    select_resources: LLM_MODEL = DEFAULT_NODE_LLMS["select_resources"]
 
 
 class RetrieveHuggingFaceInputState(TypedDict):


### PR DESCRIPTION
## Description
This PR addresses an issue in the select_resources node where Hugging Face datasets were not being selected correctly.

### Problem:
The prompt sent to the LLM, containing extensive lists of models and datasets, was too long for the previous OpenAI model. This led to prompt truncation, causing the model to receive incomplete information and fail to select datasets accurately.

Additionally, a related bug was present where the node was incorrectly parsing the title of a resource instead of its id, leading to matching failures.

Solution:

 1. Switch to Gemini Model: The select_resources node has been updated to use gemini-2.5-flash. This model supports a larger context window, ensuring the full prompt is
    processed without truncation, leading to more reliable and accurate resource selection.
 2. Fix ID Parsing: The logic has been corrected to consistently use the resource id for both parsing the LLM response and matching against the search results.
 3. Refactor Configuration: The model for the node is now correctly sourced from the central llm_config.py, improving maintainability.