### PR TITLE
Modified the external resources passed to CreateCode

### DIFF
--- a/src/airas/features/create/create_code_subgraph/nodes/generate_experiment_code.py
+++ b/src/airas/features/create/create_code_subgraph/nodes/generate_experiment_code.py
@@ -12,9 +12,6 @@ from airas.features.create.create_code_subgraph.prompt.generate_experiment_code_
 #     LLM_MODEL,
 #     LLMFacadeClient,
 # )
-from airas.features.create.fix_code_with_devin_subgraph.nodes.initial_session_fix_code_with_devin import (
-    _retrieve_huggingface_data,
-)
 from airas.services.api_client.llm_client.anthropic_client import CLAUDE_MODEL
 from airas.services.api_client.llm_client.openai_client import (
     OPENAI_MODEL,
@@ -37,7 +34,7 @@ def generate_experiment_code(
     full_experiment_validation: tuple[bool, str],
     github_repository_info: GitHubRepositoryInfo,
     feedback_text: str | None = None,
-    use_structured_outputs: bool = True,
+    use_structured_outputs: bool = False,
 ) -> str:
     # TODO: We will first verify openAI's reasoning.
     # client = LLMFacedeClient(llm_name=llm_name, reasoning_effort="high", thinking_budget=32768)
@@ -53,9 +50,6 @@ def generate_experiment_code(
         "runner_type_prompt": runner_info_dict[runner_type]["prompt"],
         "secret_names": secret_names,
         "consistency_feedback": feedback_text,
-        "huggingface_data": _retrieve_huggingface_data(
-            new_method.experimental_design.external_resources
-        ),
         "full_experiment_validation": full_experiment_validation,
     }
     messages = template.render(data)

--- a/src/airas/features/create/create_code_subgraph/nodes/validate_full_experiment_code.py
+++ b/src/airas/features/create/create_code_subgraph/nodes/validate_full_experiment_code.py
@@ -7,9 +7,6 @@ from pydantic import BaseModel
 from airas.features.create.create_code_subgraph.prompt.validate_full_experiment_prompt import (
     validate_full_experiment_prompt,
 )
-from airas.features.create.fix_code_with_devin_subgraph.nodes.initial_session_fix_code_with_devin import (
-    _retrieve_huggingface_data,
-)
 from airas.services.api_client.llm_client.llm_facade_client import (
     LLM_MODEL,
     LLMFacadeClient,
@@ -42,9 +39,6 @@ def validate_full_experiment_code(
     messages = template.render(
         {
             "new_method": new_method.model_dump(),
-            "huggingface_data": _retrieve_huggingface_data(
-                new_method.experimental_design.external_resources
-            ),
         }
     )
     output, _ = client.structured_outputs(message=messages, data_model=ValidationOutput)

--- a/src/airas/features/create/create_code_subgraph/prompt/generate_experiment_code_prompt.py
+++ b/src/airas/features/create/create_code_subgraph/prompt/generate_experiment_code_prompt.py
@@ -95,8 +95,24 @@ File names must follow the format: `<figure_topic>[_<condition>][_pairN].pdf`
 - Strategy: {{ new_method.experimental_design.experiment_strategy }}
 - Details: {{ new_method.experimental_design.experiment_details }}
 
-# Hugging Face code
-{{ huggingface_data }}
+# External Resources
+{% if new_method.experimental_design.external_resources and new_method.experimental_design.external_resources.hugging_face %}
+**HuggingFace Models:**
+{% for model in new_method.experimental_design.external_resources.hugging_face.models %}
+- ID: {{ model.id }}
+{% if model.extracted_code %}
+- Code: {{ model.extracted_code }}
+{% endif %}
+{% endfor %}
+
+**HuggingFace Datasets:**
+{% for dataset in new_method.experimental_design.external_resources.hugging_face.datasets %}
+- ID: {{ dataset.id }}
+{% if dataset.extracted_code %}
+- Code: {{ dataset.extracted_code }}
+{% endif %}
+{% endfor %}
+{% endif %}
 
 {% if consistency_feedback %}
 ## Consistency Feedback

--- a/src/airas/features/create/create_code_subgraph/prompt/validate_full_experiment_prompt.py
+++ b/src/airas/features/create/create_code_subgraph/prompt/validate_full_experiment_prompt.py
@@ -41,7 +41,13 @@ Respond with a JSON object containing:
 {{ new_method.experimental_design.experiment_code | tojson }}
 
 # External Resources
-{{ external_resources }}
-{{ new_method.experimental_design.external_resources }}
+{% if new_method.experimental_design.external_resources and new_method.experimental_design.external_resources.hugging_face %}
+**HuggingFace Models:**
+{% for model in new_method.experimental_design.external_resources.hugging_face.models %}
+- ID: {{ model.id }}
+{% if model.extracted_code %}
+- Code: {{ model.extracted_code }}
+{% endif %}
+{% endfor %}
 
 Analyze the code thoroughly and provide your validation result."""

--- a/src/airas/features/create/create_code_subgraph/prompt/validate_full_experiment_prompt.py
+++ b/src/airas/features/create/create_code_subgraph/prompt/validate_full_experiment_prompt.py
@@ -50,4 +50,13 @@ Respond with a JSON object containing:
 {% endif %}
 {% endfor %}
 
+**HuggingFace Datasets:**
+{% for dataset in new_method.experimental_design.external_resources.hugging_face.datasets %}
+- ID: {{ dataset.id }}
+{% if dataset.extracted_code %}
+- Code: {{ dataset.extracted_code }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
 Analyze the code thoroughly and provide your validation result."""


### PR DESCRIPTION
Summary:
- Limited `external_resources` passed to coding nodes to only include `id` and `extracted_code` fields
- Fixed validation prompt for full experiment code generation

Test plan:
- Verify code generation nodes receive only necessary external resource data
- Confirm validation prompt works correctly with updated resource structure
- Test end-to-end experiment code generation workflow

The changes focus on optimizing the data flow in the code generation subgraph by reducing the external resources payload and fixing a validation prompt issue.