### PR TITLE
Add gpt-5-codex

### DIFF
--- a/src/airas/services/api_client/llm_client/openai_client.py
+++ b/src/airas/services/api_client/llm_client/openai_client.py
@@ -45,6 +45,12 @@ OPENAI_MODEL_INFO = {
         "output_token_cost": 60.00 * 1 / 1000000,
     },
     # Flagship chat models
+    "gpt-5-codex": {
+        "max_input_tokens": 400_000 - 128_000,
+        "max_output_tokens": 128_000,
+        "input_token_cost": 1.25 * 1 / 1_000_000,
+        "output_token_cost": 10.00 * 1 / 1_000_000,
+    },
     "gpt-5-2025-08-07": {
         "max_input_tokens": 400_000 - 128_000,
         "max_output_tokens": 128_000,
@@ -90,6 +96,7 @@ OPENAI_MODEL = Literal[
     "o3-mini-2025-01-31",
     "o1-pro-2025-03-19",
     "o1-2024-12-17",
+    "gpt-5-codex",
     "gpt-5-2025-08-07",
     "gpt-5-mini-2025-08-07",
     "gpt-5-nano-2025-08-07",


### PR DESCRIPTION
## Summary
- Added configuration for the new `gpt-5-codex` model to the OpenAI client
- Configured token limits and pricing information for the model

### Changes
- Model Configuration: Added `gpt-5-codex` to `OPENAI_MODEL_INFO` with:
  - Max input tokens: 272,000 (400,000 - 128,000)
  - Max output tokens: 128,000
  - Input token cost: $1.25 per 1M tokens
  - Output token cost: $10.00 per 1M tokens
- Type Definition: Added `gpt-5-codex` to the `OPENAI_MODEL` literal type