### PR TITLE
Add new gpu label

### DIFF
--- a/src/airas/config/runner_type_info.py
+++ b/src/airas/config/runner_type_info.py
@@ -1,6 +1,8 @@
 from typing import Literal
 
-RunnerType = Literal["ubuntu-latest", "Tesla_T4", "A100_80GM×1", "A100_80GM×8"]
+RunnerType = Literal[
+    "ubuntu-latest", "Tesla_T4", "A100_80GM×1", "A100_80GM×8", "gpu-runner"
+]
 
 runner_info_dict = {
     "ubuntu-latest": {
@@ -29,5 +31,12 @@ RAM：2048 GB""",
 NVIDIA A100×8
 VRAM：80GB×8
 RAM：2048 GB""",
+    },
+    "gpu-runner": {
+        "runner_setting": '["self-hosted", "gpu-runner"]',
+        "prompt": """\
+NVIDIA A100 or H200
+VRAM: 80 GB or more
+RAM: 2048 GB or more""",
     },
 }

--- a/src/airas/scripts/settings.py
+++ b/src/airas/scripts/settings.py
@@ -114,7 +114,7 @@ class Settings(BaseSettings):
     profile: Literal["test", "prod"] = "test"
 
     # 実行基盤
-    runner_type: RunnerType = "A100_80GM×1"
+    runner_type: RunnerType = "gpu-runner"
     # TODO: From the perspective of research consistency,
     # we should probably not have ClaudeCode make changes to HuggingFace resources.
     # This change includes prompt modifications in `run_experiment_with_claude_code.yml``.


### PR DESCRIPTION
If you want to use all GPUs on the self-hosted runner as your execution environment, please select "gpu-runner".