### PR TITLE
Fix/#436 bug fix remove nested asynciorun calls to prevent runtimeerror

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "dependency-injector>=4.48.2",
     "fastapi>=0.120.4",
     "uvicorn>=0.34.2",
+    "pytest-asyncio>=1.2.0",
 ]
 
 [project.urls]

--- a/tests/unit/api_client/test_anthropic_client.py
+++ b/tests/unit/api_client/test_anthropic_client.py
@@ -10,8 +10,9 @@ from airas.services.api_client.llm_client.anthropic_client import (
 ALL_CLAUDE_MODEL_NAMES = [t for t in CLAUDE_MODEL.__args__]
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", ALL_CLAUDE_MODEL_NAMES)
-def test_real_generate_all_models(model_name):
+async def test_real_generate_all_models(model_name):
     if "ANTHROPIC_API_KEY" not in os.environ:
         pytest.skip("ANTHROPIC_API_KEY is not set. Skipping real API test.")
 
@@ -19,7 +20,7 @@ def test_real_generate_all_models(model_name):
     message = "こんにちは、自己紹介をしてください。"
 
     try:
-        output, cost = client.generate(
+        output, cost = await client.generate(
             model_name=model_name,
             message=message,
         )

--- a/tests/unit/api_client/test_google_genai_client.py
+++ b/tests/unit/api_client/test_google_genai_client.py
@@ -12,8 +12,9 @@ ALL_VERTEXAI_MODEL_NAMES = [t for t in VERTEXAI_MODEL.__args__]
 ALL_VERTEXAI_MODEL_NAMES.remove("gemini-embedding-001")
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", ALL_VERTEXAI_MODEL_NAMES)
-def test_real_generate_all_models(model_name):
+async def test_real_generate_all_models(model_name):
     if "GEMINI_API_KEY" not in os.environ:
         pytest.skip("GEMINI_API_KEY is not set. Skipping real API test.")
 
@@ -21,7 +22,7 @@ def test_real_generate_all_models(model_name):
     message = "こんにちは、自己紹介をしてください。"
 
     try:
-        output, cost = client.generate(
+        output, cost = await client.generate(
             model_name=model_name,
             message=message,
         )
@@ -37,8 +38,9 @@ class DummyDataModel(BaseModel):
     description: str
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", ALL_VERTEXAI_MODEL_NAMES)
-def test_real_structured_outputs_all_models(model_name):
+async def test_real_structured_outputs_all_models(model_name):
     if "GEMINI_API_KEY" not in os.environ:
         pytest.skip("GEMINI_API_KEY is not set. Skipping real API test.")
 
@@ -50,7 +52,7 @@ def test_real_structured_outputs_all_models(model_name):
     )
 
     try:
-        output, cost = client.structured_outputs(
+        output, cost = await client.structured_outputs(
             model_name=model_name,
             message=message,
             data_model=DummyDataModel,

--- a/tests/unit/api_client/test_openai_client.py
+++ b/tests/unit/api_client/test_openai_client.py
@@ -11,8 +11,9 @@ from airas.services.api_client.llm_client.openai_client import (
 ALL_MODEL_NAMES = [t for t in OPENAI_MODEL.__args__]
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", ALL_MODEL_NAMES)
-def test_real_generate_all_models(model_name):
+async def test_real_generate_all_models(model_name):
     if "OPENAI_API_KEY" not in os.environ:
         pytest.skip("OPENAI_API_KEY is not set. Skipping real API test.")
 
@@ -20,7 +21,7 @@ def test_real_generate_all_models(model_name):
     message = "Hello, please introduce yourself."
 
     try:
-        output, cost = client.generate(
+        output, cost = await client.generate(
             model_name=model_name,
             message=message,
         )
@@ -38,8 +39,9 @@ class DummyDataModel(BaseModel):
     description: str
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", ALL_MODEL_NAMES)
-def test_real_structured_outputs_all_models(model_name):
+async def test_real_structured_outputs_all_models(model_name):
     if "OPENAI_API_KEY" not in os.environ:
         pytest.skip("OPENAI_API_KEY is not set. Skipping real API test.")
 
@@ -51,7 +53,7 @@ def test_real_structured_outputs_all_models(model_name):
     )
 
     try:
-        output, cost = client.structured_outputs(
+        output, cost = await client.structured_outputs(
             model_name=model_name,
             message=message,
             data_model=DummyDataModel,

--- a/uv.lock
+++ b/uv.lock
@@ -116,6 +116,7 @@ dependencies = [
     { name = "pymupdf" },
     { name = "pynacl" },
     { name = "pypdf" },
+    { name = "pytest-asyncio" },
     { name = "pytz" },
     { name = "semanticscholar" },
     { name = "tenacity" },
@@ -168,6 +169,7 @@ requires-dist = [
     { name = "pymupdf", specifier = ">=1.25.5" },
     { name = "pynacl", specifier = ">=1.6.0" },
     { name = "pypdf", specifier = ">=4.3.1" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "python-dotenv", marker = "extra == 'mcp'", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2025.2" },
     { name = "semanticscholar", specifier = ">=0.8.4" },
@@ -366,6 +368,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
+]
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
 ]
 
 [[package]]
@@ -2546,6 +2557,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919, upload-time = "2024-12-01T12:54:25.98Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083, upload-time = "2024-12-01T12:54:19.735Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This pull request introduces a significant refactoring to transition all LLMClient implementations (Anthropic, Google
GenAI, OpenAI) to be fully asynchronous. This change improves the flexibility, scalability, and prepares the codebase for
better performance in interactions with Large Language Models by leveraging Python's asyncio.

As part of this update, the `LLMFacadeClient` has been modified to accept an llm_name parameter during method execution,
allowing for more dynamic model selection at runtime. All corresponding unit tests have been updated to support these
asynchronous changes, including the addition of pytest-asyncio.

## Details

<details>
<summary><strong>Core Changes in <code>src/airas/services/api_client/llm_client/</code></strong></summary>

* `AnthropicClient`:
   * Switched from `anthropic.Anthropic` to `anthropic.AsyncAnthropic`.
   * All methods (`_truncate_prompt`, `generate`, `close`) are now async and use the aclient instance.
   * The `if __name__ == "__main__":` block was updated to use `asyncio.run(main())`.
* `GoogleGenAIClient`:
   * The generate method is now async and uses `await self.client.aio.models.generate_content`.
   * The synchronous `structured_outputs` method was removed; `structured_outputs_async` was renamed to `structured_outputs` and made async.
   * The `text_embedding` method is now async and uses `await self.client.aio.models.embed_content`.
   * The synchronous close method was removed, retaining only the aclose method.
* `OpenAIClient`:
   * Removed the synchronous `openai.OpenAI` client, exclusively using `openai.AsyncOpenAI`.
   * The synchronous `structured_outputs` method was removed; the existing `structured_outputs_async` was renamed to
     `structured_outputs` and made async.
   * All core interaction methods (`generate`, `structured_outputs`, `text_embedding`, `web_search`) are now async and use await
     `self.aclient.method(...)`.
   * The synchronous close method was removed, retaining only the aclose method.

</details>

<details>
<summary><strong>Changes in <code>src/airas/services/api_client/llm_client/llm_facade_client.py</code></strong></summary>

* The `__init__` method no longer requires `llm_name` at initialization, instead directly initializing all underlying LLM
 clients.
* Introduced a new private method `_get_client(self, llm_name)` to dynamically retrieve the correct client based on the
 provided `llm_name`.
* All public methods (`generate`, `structured_outputs`, `text_embedding`, `web_search`) are now async and accept `llm_name` as an argument, delegating calls to the appropriate asynchronous client.
* The `structured_outputs_async` method was removed, as `structured_outputs` is now fully asynchronous.

</details>

<details>
<summary><strong>Changes in <code>tests/unit/api_client/</code></strong></summary>

* `pyproject.toml` and `uv.lock`: Added `pytest-asyncio` as a new dependency to support asynchronous testing.
* All unit test files (`test_anthropic_client.py`, `test_google_genai_client.py`, `test_openai_client.py`) have been updated:
   * Test functions are now decorated with `@pytest.mark.asyncio`.
   * Test functions are defined as async def.
   * Calls to client methods within tests now use await.

</details>

## Anticipated Future Changes

* Refactor `api_client_container.py`:
   * With llm_name being passed at method invocation, the `LLMFacadeClient` can be refactored into a singleton instance.
     This will simplify the container setup and eliminate the need for complex synchronization logic.
* Full Asynchronous Integration:
   * All nodes that utilize the LLM will be updated to be fully asynchronous.
   * The approach for passing llm_name during method calls will be standardized across these nodes.
