### PR TITLE
Resolve Dev Container Build and Startup Failures

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,7 @@
 	"workspaceFolder": "/workspaces/airas",
     "overrideCommand": true,
     "mounts": [
-        "source=${localWorkspaceFolder}/..,target=/workspaces,type=bind",
-        "source=${env:HOME}/.gitconfig,target=/root/.gitconfig,type=bind,consistency=cached"
+        "source=${localWorkspaceFolder}/..,target=/workspaces,type=bind"
     ],
 	"customizations": {
 		"vscode": {
@@ -73,5 +72,6 @@
             }
         }
     },
-    "postCreateCommand": "bash .devcontainer/setup.sh"
+    "postCreateCommand": "bash .devcontainer/setup.sh",
+    "postStartCommand": "uv run uvicorn api.main:app --host 0.0.0.0 --port 8000 --log-level debug --reload"
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -x
 
 cd "${containerWorkspaceFolder:-/workspaces/airas}"
 uv python install 3.11
 uv python pin 3.11
 uv venv --python 3.11
 uv sync
+
+git config --global user.name "${GIT_USER_NAME:-Developer}"
+git config --global user.email "${GIT_USER_EMAIL:-developer@example.com}"
+git config --global init.defaultBranch main
+
 uv run pre-commit install
-uv run uvicorn api.main:app --host 0.0.0.0 --port 8000 --log-level debug --reload

--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ tmp/*
 .github/instructions/*
 .serena/*
 .mcp.json
+.claude


### PR DESCRIPTION
## Description

This pull request addresses critical issues that were preventing the Dev Container from building and starting correctly, ensuring a stable and reproducible development environment for all contributors.

**The Problem**

The Dev Container setup was failing due to two distinct issues:


1. `pre-commit` Installation Failure: The container build would halt during the `postCreateCommand` phase while trying to set up `pre-commit`. The process failed because the git command itself was not functioning correctly due to issues with mounting the host machine's `.gitconfig`. 



```bash
...
 + xxhash==3.5.0
 + yarl==1.18.0
 + zstandard==0.23.0
An error has occurred: FatalError: git failed. Is it installed, and are you in a
 Git repository directory?
Check the log at /root/.cache/pre-commit/pre-commit.log

Whats next:
    Try Docker Debug for seamless, persistent debugging tools in any container o
r image → docker debug 62348d9e293cd5a6b25ad6cdd9aa3b221caa0b1eddf6ec4e1f0f8728
75c7ec32
    Learn more at https://docs.docker.com/go/debug-cli/

# Here's the error message.
[218625 ms] postCreateCommand from devcontainer.json failed with exit code 1. Skipping any further user-provided commands.
```

2. Container Startup Hang: Even if the git issue were resolved, the container would not finish starting. A long-running process (`uvicorn`) was being initiated in `postCreateCommand`, which must exit completely for the VS Code UI to attach.

**The Solution**

This PR implements a two-part solution to address these problems:

1. Isolate Git Configuration within the Container:
  - Removed the bind-mount for the host's `~/.gitconfig` file from `devcontainer.json`.
  - The `setup.sh` script now initializes a clean git configuration inside the container using `git config --global`.
  - The user name and email are now sourced from environment variables (`GIT_USER_NAME`, `GIT_USER_EMAIL`), providing sensible defaults if they are not set. This makes the environment self-contained and independent of the host machine's configuration.
 
2. Correct Lifecycle for Server Process:
- Moved the `uvicorn` server startup command from the `postCreateCommand` property to the `postStartCommand` property in `devcontainer.json`.

This change aligns with the official Dev Container documentation, which specifies that `postCreateCommand` is for one-time setup commands that must exit, while `postStartCommand` is appropriate for starting services or long-running processes.
Reference: [Official VS Code Documentation](https://www.google.com/url?sa=E&q=https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fdevcontainers%2Fcreate-dev-container%23_rebuild)

```plain
The command needs to exit or the container won't start. 
For instance, if you add an application start to postCreateCommand, the command wouldn't exit.

There is also a postStartCommand that executes every time the container starts. 
The parameters behave exactly like postCreateCommand, but the commands execute on start rather than create.
```
