### PR TITLE
Add gemini-3-pro-preview and fix previous models

### DIFF
--- a/backend/src/airas/services/api_client/llm_client/google_genai_client.py
+++ b/backend/src/airas/services/api_client/llm_client/google_genai_client.py
@@ -17,6 +17,16 @@ setup_logging()
 
 # https://ai.google.dev/gemini-api/docs/models?hl=ja
 VERTEXAI_MODEL_INFO: dict[str, dict[str, Any]] = {
+    "gemini-3-pro-preview": {
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "cost_fn": lambda input_tokens, output_tokens: (
+            (2.00 / 1000000 if input_tokens <= 200000 else 4.00 / 1000000)
+            * input_tokens
+            + (12.00 / 1000000 if input_tokens <= 200000 else 18.00 / 1000000)
+            * output_tokens
+        ),
+    },
     "gemini-2.5-pro": {
         "max_input_tokens": 1048576,
         "max_output_tokens": 65536,
@@ -33,19 +43,31 @@ VERTEXAI_MODEL_INFO: dict[str, dict[str, Any]] = {
         "input_token_cost": 0.30 * 1 / 1000000,
         "output_token_cost": 2.50 * 1 / 1000000,
     },
-    "gemini-2.5-flash-lite-preview-06-17": {
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 64000,
+    "gemini-2.5-flash-preview-09-2025": {
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "input_token_cost": 0.30 * 1 / 1000000,
+        "output_token_cost": 2.50 * 1 / 1000000,
+    },
+    "gemini-2.5-flash-lite": {
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
         "input_token_cost": 0.10 * 1 / 1000000,
         "output_token_cost": 0.40 * 1 / 1000000,
     },
-    "gemini-2.0-flash-001": {
+    "gemini-2.5-flash-lite-preview-09-2025": {
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "input_token_cost": 0.10 * 1 / 1000000,
+        "output_token_cost": 0.40 * 1 / 1000000,
+    },
+    "gemini-2.0-flash": {
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "input_token_cost": 0.10 * 1 / 1000000,
         "output_token_cost": 0.40 * 1 / 1000000,
     },
-    "gemini-2.0-flash-lite-001": {
+    "gemini-2.0-flash-lite": {
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "input_token_cost": 0.075 * 1 / 1000000,
@@ -54,11 +76,14 @@ VERTEXAI_MODEL_INFO: dict[str, dict[str, Any]] = {
 }
 
 VERTEXAI_MODEL = Literal[
+    "gemini-3-pro-preview",
     "gemini-2.5-pro",
     "gemini-2.5-flash",
-    "gemini-2.5-flash-lite-preview-06-17",
-    "gemini-2.0-flash-001",
-    "gemini-2.0-flash-lite-001",
+    "gemini-2.5-flash-preview-09-2025",
+    "gemini-2.5-flash-lite",
+    "gemini-2.5-flash-lite-preview-09-2025",
+    "gemini-2.0-flash",
+    "gemini-2.0-flash-lite",
     "gemini-embedding-001",
 ]
 


### PR DESCRIPTION
This PR adds support for the new `gemini-3-pro-preview` model and introduces several updates to the existing Gemini model definitions  for consistency and accuracy. 

https://ai.google.dev/gemini-api/docs/pricing?hl=ja#gemini-3-pro-preview

**Key Changes:**
                                                   
 - Added `gemini-3-pro-preview`:                                                                                                       
   - Integrated the new model with its corresponding token limits and a tiered pricing function based on input token count.            
  
 - Updated and Added Model Definitions:                                                                                                
   - Renamed `gemini-2.0-flash-001` to `gemini-2.0-flash`.
   - Renamed `gemini-2.0-flash-lite-001` to `gemini-2.0-flash-lite`. 
   - Added several new and preview models, including:
     - `gemini-2.5-flash-preview-09-2025`
     - `gemini-2.5-flash-lite`
     - `gemini-2.5-flash-lite-preview-09-2025`
                              
- Updated `VERTEXAI_MODEL` Literal:                                                                                                   
   - The Literal type hint has been updated to include all new and renamed models, ensuring type safety across the application.
  
These changes ensure that our application supports the latest models and uses standardized naming conventions.