### PR TITLE
refactor(github): PrepareRepositorySubgraph

### DIFF
--- a/backend/src/airas/features/github/prepare_repository_subgraph/input_data.py
+++ b/backend/src/airas/features/github/prepare_repository_subgraph/input_data.py
@@ -1,7 +1,0 @@
-prepare_repository_subgraph_input_data = {
-    "github_owner": "auto-res2",
-    "repository_name": "test24",
-    "branch_name": "test",
-    "device_type": "gpu",
-    "organization": "auto-res2",
-}

--- a/backend/src/airas/features/github/prepare_repository_subgraph/nodes/check_branch_existence.py
+++ b/backend/src/airas/features/github/prepare_repository_subgraph/nodes/check_branch_existence.py
@@ -1,23 +1,23 @@
 from logging import getLogger
 
 from airas.services.api_client.github_client import GithubClient
-from airas.types.github import GitHubRepositoryInfo
+from airas.types.github import GitHubConfig
 
 logger = getLogger(__name__)
 
 
 def check_branch_existence(
-    github_repository_info: GitHubRepositoryInfo,
+    github_config: GitHubConfig,
     github_client: GithubClient,
 ) -> str | None:
     response = github_client.get_branch(
-        github_owner=github_repository_info.github_owner,
-        repository_name=github_repository_info.repository_name,
-        branch_name=github_repository_info.branch_name,
+        github_owner=github_config.github_owner,
+        repository_name=github_config.repository_name,
+        branch_name=github_config.branch_name,
     )
     if response is None:
         logger.warning(
-            f"Branch '{github_repository_info.branch_name}' not found in repository '{github_repository_info.repository_name}'."
+            f"Branch '{github_config.branch_name}' not found in repository '{github_config.repository_name}'."
         )
         return None
 
@@ -28,12 +28,3 @@ def check_branch_existence(
             f"Unexpected response format: missing 'commit.sha'. Response: {response}"
         )
         return None
-
-
-if __name__ == "__main__":
-    # Example usage
-    github_repository_info = GitHubRepositoryInfo(
-        github_owner="auto-res2", repository_name="test-branch", branch_name="test"
-    )
-    output = check_branch_existence(github_repository_info)
-    print(output)

--- a/backend/src/airas/features/github/prepare_repository_subgraph/nodes/check_repository_from_template.py
+++ b/backend/src/airas/features/github/prepare_repository_subgraph/nodes/check_repository_from_template.py
@@ -1,21 +1,21 @@
 from logging import getLogger
 
 from airas.services.api_client.github_client import GithubClient, GithubClientError
-from airas.types.github import GitHubRepositoryInfo
+from airas.types.github import GitHubConfig
 
 logger = getLogger(__name__)
 
 
 def check_repository_from_template(
-    github_repository_info: GitHubRepositoryInfo,
+    github_config: GitHubConfig,
     github_client: GithubClient,
     template_owner: str,
     template_repo: str,
 ) -> bool:
     try:
         response = github_client.get_repository(
-            github_owner=github_repository_info.github_owner,
-            repository_name=github_repository_info.repository_name,
+            github_owner=github_config.github_owner,
+            repository_name=github_config.repository_name,
         )
     except GithubClientError as e:
         logger.warning(f"Repository does not exist or cannot be accessed: {e}")
@@ -24,7 +24,7 @@ def check_repository_from_template(
     template_info = response.get("template_repository")
     if not template_info:
         raise ValueError(
-            f"Repository '{github_repository_info.github_owner}/{github_repository_info.repository_name}' exists but is not created from a template."
+            f"Repository '{github_config.github_owner}/{github_config.repository_name}' exists but is not created from a template."
         )
 
     is_template_match = (
@@ -34,7 +34,7 @@ def check_repository_from_template(
 
     if not is_template_match:
         raise ValueError(
-            f"Repository '{github_repository_info.github_owner}/{github_repository_info.repository_name}' is created from a different template "
+            f"Repository '{github_config.github_owner}/{github_config.repository_name}' is created from a different template "
             f"({template_info.get('owner', {}).get('login')}/{template_info.get('name')}) "
             f"than expected ({template_owner}/{template_repo})."
         )

--- a/backend/src/airas/features/github/prepare_repository_subgraph/nodes/create_repository_from_template.py
+++ b/backend/src/airas/features/github/prepare_repository_subgraph/nodes/create_repository_from_template.py
@@ -2,13 +2,13 @@ from logging import getLogger
 from typing import Literal
 
 from airas.services.api_client.github_client import GithubClient
-from airas.types.github import GitHubRepositoryInfo
+from airas.types.github import GitHubConfig
 
 logger = getLogger(__name__)
 
 
 def create_repository_from_template(
-    github_repository_info: GitHubRepositoryInfo,
+    github_config: GitHubConfig,
     github_client: GithubClient,
     template_owner: str,
     template_repo: str,
@@ -17,8 +17,8 @@ def create_repository_from_template(
 ) -> Literal[True]:
     try:
         result = github_client.create_repository_from_template(
-            github_owner=github_repository_info.github_owner,
-            repository_name=github_repository_info.repository_name,
+            github_owner=github_config.github_owner,
+            repository_name=github_config.repository_name,
             template_owner=template_owner,
             template_repo=template_repo,
             include_all_branches=include_all_branches,
@@ -33,7 +33,7 @@ def create_repository_from_template(
             raise RuntimeError(error)
 
         print(
-            f"Repository created from template: {template_owner}/{template_repo} -> {github_repository_info.github_owner}/{github_repository_info.repository_name}"
+            f"Repository created from template: {template_owner}/{template_repo} -> {github_config.github_owner}/{github_config.repository_name}"
         )
         return True
 

--- a/backend/src/airas/features/github/prepare_repository_subgraph/nodes/retrieve_main_branch_sha.py
+++ b/backend/src/airas/features/github/prepare_repository_subgraph/nodes/retrieve_main_branch_sha.py
@@ -1,43 +1,34 @@
 from logging import getLogger
 
 from airas.services.api_client.github_client import GithubClient
-from airas.types.github import GitHubRepositoryInfo
+from airas.types.github import GitHubConfig
 
 logger = getLogger(__name__)
 
 
 def retrieve_main_branch_sha(
-    github_repository_info: GitHubRepositoryInfo,
+    github_config: GitHubConfig,
     github_client: GithubClient,
 ) -> str:
     response = github_client.get_branch(
-        github_owner=github_repository_info.github_owner,
-        repository_name=github_repository_info.repository_name,
+        github_owner=github_config.github_owner,
+        repository_name=github_config.repository_name,
         branch_name="main",
     )
 
     if not response or not isinstance(response, dict):
         raise RuntimeError(
-            f"Failed to retrieve branch info for 'main' branch of {github_repository_info.github_owner}/{github_repository_info.repository_name}"
+            f"Failed to retrieve branch info for 'main' branch of {github_config.github_owner}/{github_config.repository_name}"
         )
 
     try:
         sha = response["commit"]["sha"]
     except (TypeError, KeyError):
-        msg = f"Invalid response format for 'main' branch of {github_repository_info.github_owner}/{github_repository_info.repository_name}"
+        msg = f"Invalid response format for 'main' branch of {github_config.github_owner}/{github_config.repository_name}"
         raise RuntimeError(msg)  # noqa: B904
 
     if not sha:
         raise RuntimeError(
-            f"Empty SHA for 'main' branch of {github_repository_info.github_owner}/{github_repository_info.repository_name}"
+            f"Empty SHA for 'main' branch of {github_config.github_owner}/{github_config.repository_name}"
         )
     return sha
-
-
-if __name__ == "__main__":
-    # Example usage
-    github_repository_info = GitHubRepositoryInfo(
-        github_owner="auto-res2", repository_name="test-branch", branch_name="test"
-    )
-    output = retrieve_main_branch_sha(github_repository_info)
-    print(output)

--- a/backend/src/airas/features/github/prepare_repository_subgraph/prepare_repository_subgraph.py
+++ b/backend/src/airas/features/github/prepare_repository_subgraph/prepare_repository_subgraph.py
@@ -4,6 +4,7 @@ import time
 from typing import Literal
 
 from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command
 from typing_extensions import TypedDict
 
 from airas.core.base import BaseSubgraph
@@ -23,7 +24,7 @@ from airas.features.github.prepare_repository_subgraph.nodes.retrieve_main_branc
     retrieve_main_branch_sha,
 )
 from airas.services.api_client.github_client import GithubClient
-from airas.types.github import GitHubRepositoryInfo
+from airas.types.github import GitHubConfig
 from airas.utils.check_api_key import check_api_key
 from airas.utils.execution_timers import ExecutionTimeState, time_node
 from airas.utils.logging_utils import setup_logging
@@ -31,11 +32,11 @@ from airas.utils.logging_utils import setup_logging
 setup_logging()
 logger = logging.getLogger(__name__)
 
-prepare_repository_timed = lambda f: time_node("prepare_repository")(f)  # noqa: E731
+recode_execution_time = lambda f: time_node("prepare_repository")(f)  # noqa: E731
 
 
 class PrepareRepositoryInputState(TypedDict):
-    github_repository_info: GitHubRepositoryInfo
+    github_config: GitHubConfig
 
 
 class PrepareRepositoryHiddenState(TypedDict):
@@ -79,24 +80,34 @@ class PrepareRepositorySubgraph(BaseSubgraph):
         self.template_repo = template_repo
         self.is_private = is_private
 
-    @prepare_repository_timed
+    @recode_execution_time
     def _check_repository_from_template(
         self, state: PrepareRepositoryState
-    ) -> dict[str, bool]:
+    ) -> Command[Literal["create_repository_from_template", "check_branch_existence"]]:
         is_repository_from_template = check_repository_from_template(
-            github_repository_info=state["github_repository_info"],
+            github_config=state["github_config"],
             github_client=self.github_client,
             template_owner=self.template_owner,
             template_repo=self.template_repo,
         )
-        return {"is_repository_from_template": is_repository_from_template}
 
-    @prepare_repository_timed
+        goto: Literal["create_repository_from_template", "check_branch_existence"] = (
+            "create_repository_from_template"
+            if not is_repository_from_template
+            else "check_branch_existence"
+        )
+
+        return Command(
+            update={"is_repository_from_template": is_repository_from_template},
+            goto=goto,
+        )
+
+    @recode_execution_time
     def _create_repository_from_template(
         self, state: PrepareRepositoryState
     ) -> dict[str, Literal[True]]:
         is_repository_from_template = create_repository_from_template(
-            github_repository_info=state["github_repository_info"],
+            github_config=state["github_config"],
             github_client=self.github_client,
             template_owner=self.template_owner,
             template_repo=self.template_repo,
@@ -104,40 +115,51 @@ class PrepareRepositorySubgraph(BaseSubgraph):
         )
         return {"is_repository_from_template": is_repository_from_template}
 
-    @prepare_repository_timed
+    @recode_execution_time
     def _check_branch_existence(
         self, state: PrepareRepositoryState
-    ) -> dict[str, str | bool]:
+    ) -> Command[Literal["retrieve_main_branch_sha", "finalize_state"]]:
         time.sleep(5)
         target_branch_sha = check_branch_existence(
-            github_repository_info=state["github_repository_info"],
+            github_config=state["github_config"],
             github_client=self.github_client,
         )
-        return {
-            "target_branch_sha": target_branch_sha,
-            "is_branch_already_exists": bool(target_branch_sha),
-        }
+        is_branch_already_exists = bool(target_branch_sha)
 
-    @prepare_repository_timed
+        goto: Literal["retrieve_main_branch_sha", "finalize_state"] = (
+            "retrieve_main_branch_sha"
+            if not is_branch_already_exists
+            else "finalize_state"
+        )
+
+        return Command(
+            update={
+                "target_branch_sha": target_branch_sha,
+                "is_branch_already_exists": is_branch_already_exists,
+            },
+            goto=goto,
+        )
+
+    @recode_execution_time
     def _retrieve_main_branch_sha(
         self, state: PrepareRepositoryState
     ) -> dict[str, str]:
         main_branch_sha = retrieve_main_branch_sha(
-            github_repository_info=state["github_repository_info"],
+            github_config=state["github_config"],
             github_client=self.github_client,
         )
         return {"main_branch_sha": main_branch_sha}
 
-    @prepare_repository_timed
+    @recode_execution_time
     def _create_branch(self, state: PrepareRepositoryState) -> dict[str, bool]:
         is_branch_created = create_branch(
-            github_repository_info=state["github_repository_info"],
+            github_config=state["github_config"],
             github_client=self.github_client,
             sha=state["main_branch_sha"],
         )
         return {"is_branch_created": is_branch_created}
 
-    @prepare_repository_timed
+    @recode_execution_time
     def _finalize_state(self, state: PrepareRepositoryState) -> dict[str, bool]:
         is_repository_ready = state.get("is_repository_from_template", False)
         is_branch_ready = state.get("is_branch_already_exists", False) or state.get(
@@ -147,18 +169,6 @@ class PrepareRepositorySubgraph(BaseSubgraph):
             "is_repository_ready": is_repository_ready,
             "is_branch_ready": is_branch_ready,
         }
-
-    def _should_create_from_template(self, state: PrepareRepositoryState) -> str:
-        if not state["is_repository_from_template"]:
-            return "Create"
-        else:
-            return "Skip"
-
-    def _should_create_branch(self, state: PrepareRepositoryState) -> str:
-        if not state["is_branch_already_exists"]:
-            return "Create"
-        else:
-            return "Skip"
 
     def build_graph(self):
         graph_builder = StateGraph(PrepareRepositoryState)
@@ -177,24 +187,8 @@ class PrepareRepositorySubgraph(BaseSubgraph):
         graph_builder.add_node("finalize_state", self._finalize_state)
 
         graph_builder.add_edge(START, "check_repository_from_template")
-        graph_builder.add_conditional_edges(
-            "check_repository_from_template",
-            self._should_create_from_template,
-            {
-                "Create": "create_repository_from_template",
-                "Skip": "check_branch_existence",
-            },
-        )
         graph_builder.add_edge(
             "create_repository_from_template", "check_branch_existence"
-        )
-        graph_builder.add_conditional_edges(
-            "check_branch_existence",
-            self._should_create_branch,
-            {
-                "Create": "retrieve_main_branch_sha",
-                "Skip": "finalize_state",
-            },
         )
         graph_builder.add_edge("retrieve_main_branch_sha", "create_branch")
         graph_builder.add_edge("create_branch", "finalize_state")
@@ -202,28 +196,42 @@ class PrepareRepositorySubgraph(BaseSubgraph):
         return graph_builder.compile()
 
 
-def main():
+async def main():
+    from airas.core.container import container
+
     parser = argparse.ArgumentParser(description="PrepareRepositorySubgraph")
-    parser.add_argument("github_repository", help="Your GitHub repository")
-    parser.add_argument("branch_name", help="Your Branch name")
+    parser.add_argument(
+        "--github-owner",
+        default="auto-res2",
+        help="Your GitHub owner (default: auto-res2)",
+    )
+    parser.add_argument("repository_name", help="Your repository name")
+    parser.add_argument("branch_name", help="Your branch name")
     args = parser.parse_args()
 
-    github_repository_info = GitHubRepositoryInfo(
-        github_owner=args.github_repository.split("/")[0],
-        repository_name=args.github_repository.split("/")[1],
+    github_config = GitHubConfig(
+        github_owner=args.github_owner,
+        repository_name=args.repository_name,
         branch_name=args.branch_name,
     )
-    state = {
-        "github_repository_info": github_repository_info,
-    }
-    PrepareRepositorySubgraph().run(state)
+
+    container.wire(modules=[__name__])
+
+    try:
+        result = await PrepareRepositorySubgraph(
+            github_client=container.github_client,
+        ).arun({"github_config": github_config})
+        print(f"Result: {result}")
+    finally:
+        await container.shutdown_resources()
 
 
 if __name__ == "__main__":
+    import asyncio
     import sys
 
     try:
-        main()
+        asyncio.run(main())
     except Exception as e:
         logger.error(f"Error running PrepareRepository: {e}")
         sys.exit(1)

--- a/backend/src/airas/types/github.py
+++ b/backend/src/airas/types/github.py
@@ -1,7 +1,10 @@
 from pydantic import BaseModel, Field
 
 
-class GitHubRepositoryInfo(BaseModel):
+class GitHubConfig(BaseModel):
     github_owner: str = Field(..., description="GitHub owner of the repository")
     repository_name: str = Field(..., description="Name of the repository")
     branch_name: str = Field(..., description="Branch name")
+
+
+GitHubRepositoryInfo = GitHubConfig


### PR DESCRIPTION
## 背景と目的

現在のPrepareRepositoryサブグラフは、条件分岐ロジックが個別のメソッドとして分散しており、グラフの構造を理解しにくい状態でした。このPRは、LangGraphの`Command`パターンを導入してサブグラフをリファクタリングし、コードの可読性と保守性を向上させます。

親Issue: https://github.com/airas-org/airas/issues/485

## 変更内容

以下の機能が変更されました：
1. PrepareRepositoryサブグラフのリファクタリング: `Command`パターンを導入し、条件分岐を簡潔化
2. 型定義の統一: `GitHubRepositoryInfo` を `GitHubConfig` に変更
3. 不要なコードの削除: テストデータとデバッグコードを削除

実装の詳細は以下の通りです：

<details>
<summary><code>1. PrepareRepositoryサブグラフのリファクタリング</code></summary>

**実装概要**

`backend/src/airas/features/github/prepare_repository_subgraph/prepare_repository_subgraph.py` を更新

- **Commandパターンの導入**:
  - `_check_repository_from_template()` ノード:
    - 戻り値を `Command[Literal["create_repository_from_template", "check_branch_existence"]]` に変更
    - リポジトリが存在しない場合は `create_repository_from_template` へ、存在する場合は `check_branch_existence` へ遷移する条件分岐をノード内で実装
  - `_check_branch_existence()` ノード:
    - 戻り値を `Command[Literal["retrieve_main_branch_sha", "finalize_state"]]` に変更
    - ブランチが存在しない場合は `retrieve_main_branch_sha` へ、存在する場合は `finalize_state` へ遷移する条件分岐をノード内で実装
  - これにより、グラフの流れがノード定義から直接理解できるようになり、可読性が向上

- **条件分岐メソッドの削除**:
  - `_should_create_from_template()` メソッドを削除
  - `_should_create_branch()` メソッドを削除
  - 条件分岐ロジックを各ノード内に統合することで、コードの分散を解消

- **グラフ構築の簡潔化**:
  - `add_conditional_edges()` の使用を削減
  - `add_edge()` のみで構成されるシンプルなグラフ定義に変更
  - ノード間の遷移ロジックが `Command` で明示的に表現されるため、グラフ構造が理解しやすくなる

- **非同期処理への対応**:
  - `main()` 関数を `async def` に変更
  - `PrepareRepositorySubgraph.run()` を `arun()` に変更して非同期実行に対応
  - `asyncio.run(main())` でエントリーポイントを実行

- **依存性注入の改善**:
  - `container.wire(modules=[__name__])` で依存性を注入
  - `container.shutdown_resources()` でリソースを適切にクリーンアップ
  - `PrepareRepositorySubgraph` のインスタンス化時に `github_client` を明示的に注入

- **CLIインターフェースの改善**:
  - `--github-owner` オプションを追加（デフォルト: "auto-res2"）
  - 引数を `github_repository`（`owner/repo` 形式）から `repository_name` と `branch_name` に分離
  - より明確なCLI引数構造に変更

</details>

<details>
<summary><code>2. 型定義の統一</code></summary>

**実装概要**

`backend/src/airas/types/github.py` および各ノードファイルを更新

- **型名の変更**:
  - `GitHubRepositoryInfo` → `GitHubConfig` にクラス名を変更
    - 設定情報を保持する役割をより明確に表現
  - 後方互換性のため、`GitHubRepositoryInfo = GitHubConfig` として型エイリアスを追加

- **パラメータ名の統一**:
  - 全ノード関数およびサブグラフで `github_repository_info` → `github_config` に変更
  - 状態定義 `PrepareRepositoryInputState` のフィールド名も同様に更新
  - 以下のノードファイルを更新:
    - `backend/src/airas/features/github/prepare_repository_subgraph/nodes/check_branch_existence.py`
    - `backend/src/airas/features/github/prepare_repository_subgraph/nodes/check_repository_from_template.py`
    - `backend/src/airas/features/github/prepare_repository_subgraph/nodes/create_repository_from_template.py`
    - `backend/src/airas/features/github/prepare_repository_subgraph/nodes/retrieve_main_branch_sha.py`

</details>

<details>
<summary><code>3. 不要なコードの削除</code></summary>

**実装概要**

- **テストデータの削除**:
  - `backend/src/airas/features/github/prepare_repository_subgraph/input_data.py` を削除
    - ハードコードされたテスト用入力データが含まれていたファイル
    - 本番コードには不要

- **デバッグコードの削除**:
  - `check_branch_existence.py` から `if __name__ == "__main__"` ブロックを削除
  - `retrieve_main_branch_sha.py` から `if __name__ == "__main__"` ブロックを削除
  - 各ノードのスタンドアロン実行用コードを削除し、コードベースをクリーンアップ

</details>
