### PR TITLE
waittime update

### DIFF
--- a/backend/src/airas/services/api_client/llm_client/retry.py
+++ b/backend/src/airas/services/api_client/llm_client/retry.py
@@ -51,7 +51,7 @@ def _is_transient(e: BaseException) -> bool:
     )
 
 
-_fallback_wait = wait_exponential(multiplier=1.0, max=180.0)
+_fallback_wait = wait_exponential(multiplier=1.0, max=600.0)
 
 
 def wait_server_hint_or_exponential(retry_state) -> float:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- API clientのリトライの最大時間を伸ばす

#### Description
- LLM_RETRYの最大待機時間は21行目のWAIT_POLICYではなく54行目の_fallback_waitで決まっているようなのでそちらを変更した