### PR TITLE
feat(experiments): 実験サブグラフのAPIエンドポイントを追加する

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -7,6 +7,7 @@ from api.routes.v1 import (
     code,
     datasets,
     experimental_settings,
+    experiments,
     hypotheses,
     latex,
     models,
@@ -35,6 +36,7 @@ app.include_router(models.router, prefix="/airas/v1")
 app.include_router(datasets.router, prefix="/airas/v1")
 app.include_router(hypotheses.router, prefix="/airas/v1")
 app.include_router(experimental_settings.router, prefix="/airas/v1")
+app.include_router(experiments.router, prefix="/airas/v1")
 app.include_router(code.router, prefix="/airas/v1")
 app.include_router(repositories.router, prefix="/airas/v1")
 app.include_router(bibfile.router, prefix="/airas/v1")

--- a/backend/api/routes/v1/experiments.py
+++ b/backend/api/routes/v1/experiments.py
@@ -1,0 +1,123 @@
+from typing import Annotated
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from api.schemas.experiments import (
+    ExecuteEvaluationRequestBody,
+    ExecuteEvaluationResponseBody,
+    ExecuteFullRequestBody,
+    ExecuteFullResponseBody,
+    ExecuteTrialRequestBody,
+    ExecuteTrialResponseBody,
+    FetchExperimentalResultsRequestBody,
+    FetchExperimentalResultsResponseBody,
+    FetchRunIdsRequestBody,
+    FetchRunIdsResponseBody,
+)
+from src.airas.core.container import Container
+from src.airas.features.executors.execute_evaluation_subgraph.execute_evaluation_subgraph import (
+    ExecuteEvaluationSubgraph,
+)
+from src.airas.features.executors.execute_full_experiment_subgraph.execute_full_experiment_subgraph import (
+    ExecuteFullExperimentSubgraph,
+)
+from src.airas.features.executors.execute_trial_experiment_subgraph.execute_trial_experiment_subgraph import (
+    ExecuteTrialExperimentSubgraph,
+)
+from src.airas.features.executors.fetch_experiment_results_subgraph.fetch_experiment_results_subgraph import (
+    FetchExperimentResultsSubgraph,
+)
+from src.airas.features.executors.fetch_run_ids_subgraph.fetch_run_ids_subgraph import (
+    FetchRunIdsSubgraph,
+)
+from src.airas.services.api_client.github_client import GithubClient
+
+router = APIRouter(prefix="/experiments", tags=["experiments"])
+
+
+@router.post("/run-ids", response_model=FetchRunIdsResponseBody)
+@inject
+async def fetch_run_ids(
+    request: FetchRunIdsRequestBody,
+    github_client: Annotated[GithubClient, Depends(Provide[Container.github_client])],
+) -> FetchRunIdsResponseBody:
+    result = (
+        await FetchRunIdsSubgraph(github_client=github_client)
+        .build_graph()
+        .ainvoke(request)
+    )
+    return FetchRunIdsResponseBody(
+        run_ids=result["run_ids"],
+        execution_time=result["execution_time"],
+    )
+
+
+@router.post("/results", response_model=FetchExperimentalResultsResponseBody)
+@inject
+async def fetch_experimental_results(
+    request: FetchExperimentalResultsRequestBody,
+    github_client: Annotated[GithubClient, Depends(Provide[Container.github_client])],
+) -> FetchExperimentalResultsResponseBody:
+    result = (
+        await FetchExperimentResultsSubgraph(github_client=github_client)
+        .build_graph()
+        .ainvoke(request)
+    )
+    return FetchExperimentalResultsResponseBody(
+        experiment_results=result["experiment_results"],
+        execution_time=result["execution_time"],
+    )
+
+
+@router.post("/test-runs", response_model=ExecuteTrialResponseBody)
+@inject
+async def execute_trial(
+    request: ExecuteTrialRequestBody,
+    github_client: Annotated[GithubClient, Depends(Provide[Container.github_client])],
+) -> ExecuteTrialResponseBody:
+    result = (
+        await ExecuteTrialExperimentSubgraph(github_client=github_client)
+        .build_graph()
+        .ainvoke(request)
+    )
+    return ExecuteTrialResponseBody(
+        dispatched=result["dispatched"],
+        run_ids=result["run_ids"],
+        execution_time=result["execution_time"],
+    )
+
+
+@router.post("/full-runs", response_model=ExecuteFullResponseBody)
+@inject
+async def execute_full(
+    request: ExecuteFullRequestBody,
+    github_client: Annotated[GithubClient, Depends(Provide[Container.github_client])],
+) -> ExecuteFullResponseBody:
+    result = (
+        await ExecuteFullExperimentSubgraph(github_client=github_client)
+        .build_graph()
+        .ainvoke(request)
+    )
+    return ExecuteFullResponseBody(
+        all_dispatched=result["all_dispatched"],
+        branch_creation_results=result["branch_creation_results"],
+        execution_time=result["execution_time"],
+    )
+
+
+@router.post("/evaluations", response_model=ExecuteEvaluationResponseBody)
+@inject
+async def execute_evaluation(
+    request: ExecuteEvaluationRequestBody,
+    github_client: Annotated[GithubClient, Depends(Provide[Container.github_client])],
+) -> ExecuteEvaluationResponseBody:
+    result = (
+        await ExecuteEvaluationSubgraph(github_client=github_client)
+        .build_graph()
+        .ainvoke(request)
+    )
+    return ExecuteEvaluationResponseBody(
+        dispatched=result["dispatched"],
+        execution_time=result["execution_time"],
+    )

--- a/backend/api/schemas/experiments.py
+++ b/backend/api/schemas/experiments.py
@@ -1,0 +1,52 @@
+from pydantic import BaseModel
+
+from airas.types.experimental_results import ExperimentalResults
+from airas.types.github import GitHubConfig
+
+
+class FetchRunIdsRequestBody(BaseModel):
+    github_config: GitHubConfig
+
+
+class FetchRunIdsResponseBody(BaseModel):
+    run_ids: list[str]
+    execution_time: dict[str, list[float]]
+
+
+class FetchExperimentalResultsRequestBody(BaseModel):
+    github_config: GitHubConfig
+
+
+class FetchExperimentalResultsResponseBody(BaseModel):
+    experiment_results: ExperimentalResults
+    execution_time: dict[str, list[float]]
+
+
+class ExecuteTrialRequestBody(BaseModel):
+    github_config: GitHubConfig
+
+
+class ExecuteTrialResponseBody(BaseModel):
+    dispatched: bool
+    run_ids: list[str]
+    execution_time: dict[str, list[float]]
+
+
+class ExecuteFullRequestBody(BaseModel):
+    github_config: GitHubConfig
+    run_ids: list[str]
+
+
+class ExecuteFullResponseBody(BaseModel):
+    all_dispatched: bool
+    branch_creation_results: list[tuple[str, str, bool]]
+    execution_time: dict[str, list[float]]
+
+
+class ExecuteEvaluationRequestBody(BaseModel):
+    github_config: GitHubConfig
+
+
+class ExecuteEvaluationResponseBody(BaseModel):
+    dispatched: bool
+    execution_time: dict[str, list[float]]

--- a/backend/src/airas/features/executors/execute_evaluation_subgraph/execute_evaluation_subgraph.py
+++ b/backend/src/airas/features/executors/execute_evaluation_subgraph/execute_evaluation_subgraph.py
@@ -26,7 +26,7 @@ class ExecuteEvaluationSubgraphInputState(TypedDict):
     github_config: GitHubConfig
 
 
-class ExecuteEvaluationSubgraphOutputState(ExecutionTimeState, total=False):
+class ExecuteEvaluationSubgraphOutputState(ExecutionTimeState):
     dispatched: bool
 
 

--- a/backend/tests/http/bibfile.http
+++ b/backend/tests/http/bibfile.http
@@ -1,6 +1,6 @@
 ### Generate BibTeX from research studies
 
-POST http://127.0.0.1:8001/airas/v1/bibfile/generations
+POST http://127.0.0.1:8000/airas/v1/bibfile/generations
 Content-Type: application/json
 
 {

--- a/backend/tests/http/experiments.http
+++ b/backend/tests/http/experiments.http
@@ -1,0 +1,75 @@
+### Fetch run IDs from repository
+POST http://127.0.0.1:8000/airas/v1/experiments/run-ids
+Content-Type: application/json
+
+# NOTE: The repo or branch name may contain confidential company information, 
+# so it was included in the request body as a POST method.
+{
+    "github_config": {
+        "github_owner": "auto-res2",
+        "repository_name": "your-repo",
+        "branch_name": "your-branch"
+    }
+}
+
+###
+
+### Fetch experimental results
+POST http://127.0.0.1:8000/airas/v1/experiments/results
+Content-Type: application/json
+
+{
+    "github_config": {
+        "github_owner": "auto-res2",
+        "repository_name": "your-repo",
+        "branch_name": "your-branch"
+    }
+}
+
+###
+
+### Execute trial experiment
+POST http://127.0.0.1:8000/airas/v1/experiments/test-runs
+Content-Type: application/json
+
+{
+    "github_config": {
+        "github_owner": "auto-res2",
+        "repository_name": "your-repo",
+        "branch_name": "your-branch"
+    }
+}
+
+###
+
+### Execute full experiment
+POST http://127.0.0.1:8000/airas/v1/experiments/full-runs
+Content-Type: application/json
+
+{
+    "github_config": {
+        "github_owner": "auto-res2",
+        "repository_name": "your-repo",
+        "branch_name": "your-branch"
+    },
+    "run_ids": [
+        "run-id-1",
+        "run-id-2"
+    ]
+}
+
+###
+
+### Execute evaluation
+POST http://127.0.0.1:8000/airas/v1/experiments/evaluations
+Content-Type: application/json
+
+{
+    "github_config": {
+        "github_owner": "auto-res2",
+        "repository_name": "your-repo",
+        "branch_name": "your-branch"
+    }
+}
+
+###

--- a/backend/tests/http/latex.http
+++ b/backend/tests/http/latex.http
@@ -1,6 +1,6 @@
 ### Generate latex
 
-POST http://127.0.0.1:8001/airas/v1/latex/generations
+POST http://127.0.0.1:8000/airas/v1/latex/generations
 Content-Type: application/json
 
 {
@@ -22,7 +22,7 @@ Content-Type: application/json
 
 ### Push latex
 
-POST http://127.0.0.1:8001/airas/v1/latex/push
+POST http://127.0.0.1:8000/airas/v1/latex/push
 Content-Type: application/json
 
 {
@@ -38,7 +38,7 @@ Content-Type: application/json
 
 ### Compile latex
 
-POST http://127.0.0.1:8001/airas/v1/latex/compile
+POST http://127.0.0.1:8000/airas/v1/latex/compile
 Content-Type: application/json
 
 {

--- a/backend/tests/http/repositories.http
+++ b/backend/tests/http/repositories.http
@@ -1,5 +1,5 @@
 
-POST http://127.0.0.1:8001/airas/v1/repositories
+POST http://127.0.0.1:8000/airas/v1/repositories
 Content-Type: application/json
 
 {


### PR DESCRIPTION
## 背景と目的

現在の実験実行機能は、サブグラフとして実装されているものの、外部から直接実行する手段がなく、以下の課題がありました：

1. **API化されていない**: 実験実行サブグラフがAPIエンドポイントとして公開されていないため、フロントエンドやCLIから実験を実行できない

このPRは、実験実行サブグラフをAPIエンドポイントとして公開し、外部から柔軟に実験を実行できるようにします。

今回の実行テスト用のリポジトリ：https://github.com/auto-res2/test-matsuzawa-20251209/actions

親Issue: https://github.com/airas-org/airas/issues/525

## 変更内容

以下の機能が追加・変更されました：

1. **実験APIエンドポイントの追加**: 5つの実験関連エンドポイントを新規作成

実装の詳細は以下の通りです：

<details>
<summary><code>1. 実験APIエンドポイントの追加</code></summary>

**実装概要**

`backend/api/routes/v1/experiments.py` と `backend/api/schemas/experiments.py` を新規作成

- **エンドポイント一覧**:
  - `POST /airas/v1/experiments/run-ids` - リポジトリからrun_idリストを取得
  - `POST /airas/v1/experiments/results` - 実験結果を取得
  - `POST /airas/v1/experiments/test-runs` - trial実験を実行
  - `POST /airas/v1/experiments/full-runs` - full実験を実行（run_ids必須）
  - `POST /airas/v1/experiments/evaluations` - 評価を実行

- **設計方針**:
  - **全エンドポイントをPOSTに統一**: GETではなくPOSTを採用
    - セキュリティ：リポジトリ名やブランチ名が機密情報の可能性があるため、URLではなくリクエストボディで送信
    - アクセスログやブラウザ履歴に機密情報が残らない
  - **依存性注入**: FastAPIの`Depends`を使用してGitHubクライアントを注入
  - **レスポンス統一**: 全エンドポイントで`execution_time`を返却

- **HTTPテストファイル**:
  - `backend/tests/http/experiments.http` を作成
  - 各エンドポイントのサンプルリクエストを含む

</details>