### PR TITLE
feat(experiments): Add AnalyzeExperimentSubgraph API Endpoints

### DIFF
--- a/backend/api/schemas/experiments.py
+++ b/backend/api/schemas/experiments.py
@@ -1,7 +1,11 @@
 from pydantic import BaseModel
 
+from airas.types.experiment_code import ExperimentCode
+from airas.types.experimental_analysis import ExperimentalAnalysis
+from airas.types.experimental_design import ExperimentalDesign
 from airas.types.experimental_results import ExperimentalResults
 from airas.types.github import GitHubConfig
+from airas.types.research_hypothesis import ResearchHypothesis
 
 
 class FetchRunIdsRequestBody(BaseModel):
@@ -49,4 +53,16 @@ class ExecuteEvaluationRequestBody(BaseModel):
 
 class ExecuteEvaluationResponseBody(BaseModel):
     dispatched: bool
+    execution_time: dict[str, list[float]]
+
+
+class AnalyzeExperimentRequestBody(BaseModel):
+    research_hypothesis: ResearchHypothesis
+    experimental_design: ExperimentalDesign
+    experiment_code: ExperimentCode
+    experimental_results: ExperimentalResults
+
+
+class AnalyzeExperimentResponseBody(BaseModel):
+    experimental_analysis: ExperimentalAnalysis
     execution_time: dict[str, list[float]]

--- a/backend/src/airas/features/analyzers/analyze_experiment_subgraph/nodes/analyze_experiment.py
+++ b/backend/src/airas/features/analyzers/analyze_experiment_subgraph/nodes/analyze_experiment.py
@@ -6,9 +6,9 @@ from pydantic import BaseModel
 from airas.features.analyzers.analyze_experiment_subgraph.prompts.analyze_experiment_prompt import (
     analyze_experiment_prompt,
 )
+from airas.services.api_client.langchain_client import LangChainClient
 from airas.services.api_client.llm_client.llm_facade_client import (
     LLM_MODEL,
-    LLMFacadeClient,
 )
 from airas.types.experiment_code import ExperimentCode
 from airas.types.experimental_design import ExperimentalDesign
@@ -24,7 +24,7 @@ class LLMOutput(BaseModel):
 
 async def analyze_experiment(
     llm_name: LLM_MODEL,
-    llm_client: LLMFacadeClient,
+    langchain_client: LangChainClient,
     research_hypothesis: ResearchHypothesis,
     experimental_design: ExperimentalDesign,
     experiment_code: ExperimentCode,
@@ -41,10 +41,10 @@ async def analyze_experiment(
             "experimental_results": experimental_results,
         }
     )
-    output, cost = await llm_client.structured_outputs(
+    output, cost = await langchain_client.structured_outputs(
         message=messages, data_model=LLMOutput, llm_name=llm_name
     )
     if output is None:
         raise ValueError("No response from LLM in analyze_experiment.")
 
-    return output["analysis_report"]
+    return output.analysis_report

--- a/backend/tests/http/experiments.http
+++ b/backend/tests/http/experiments.http
@@ -73,3 +73,90 @@ Content-Type: application/json
 }
 
 ###
+
+### Analyze experiment
+POST http://127.0.0.1:8000/airas/v1/experiments/analyses
+Content-Type: application/json
+
+{
+    "research_hypothesis": {
+        "open_problems": "Current NLP models struggle with long-context understanding",
+        "method": "Propose a hierarchical attention mechanism to improve long-context processing",
+        "experimental_setup": "Compare the proposed method against standard Transformer on long document classification tasks",
+        "primary_metric": "Accuracy on documents longer than 2000 tokens",
+        "experimental_code": "Implement hierarchical attention in PyTorch and evaluate on IMDb and Yelp datasets",
+        "expected_result": "Improved accuracy by 3-5% on long documents compared to baseline",
+        "expected_conclusion": "Hierarchical attention effectively captures long-range dependencies"
+    },
+    "experimental_design": {
+        "experiment_summary": "Evaluate hierarchical attention mechanism on long document classification",
+        "evaluation_metrics": [
+            {
+                "name": "Accuracy",
+                "description": "Classification accuracy on test set, measuring percentage of correctly classified documents"
+            },
+            {
+                "name": "F1 Score",
+                "description": "Macro F1 score across all classes to handle potential class imbalance"
+            }
+        ],
+        "models_to_use": ["bert-base-uncased", "roberta-base"],
+        "datasets_to_use": ["imdb", "yelp_polarity"],
+        "proposed_method": {
+            "method_name": "HierarchicalAttention",
+            "description": "Hierarchical attention mechanism with chunk-level and document-level attention",
+            "training_config": {
+                "learning_rate": 2e-5,
+                "batch_size": 16,
+                "epochs": 5,
+                "optimizer": "adamw",
+                "warmup_steps": 500,
+                "weight_decay": 0.01
+            }
+        },
+        "comparative_methods": [
+            {
+                "method_name": "StandardTransformer",
+                "description": "Standard Transformer baseline without hierarchical mechanism",
+                "training_config": {
+                    "learning_rate": 2e-5,
+                    "batch_size": 16,
+                    "epochs": 5,
+                    "optimizer": "adamw"
+                }
+            }
+        ]
+    },
+    "experiment_code": {
+        "train_py": "# Training script placeholder",
+        "evaluate_py": "# Evaluation script placeholder",
+        "preprocess_py": "# Preprocessing script placeholder",
+        "model_py": "# Model definition placeholder",
+        "main_py": "# Main execution script placeholder",
+        "pyproject_toml": "# Project configuration placeholder",
+        "config_yaml": "# Config placeholder"
+    },
+    "experimental_results": {
+        "metrics_data": {
+            "HierarchicalAttention_imdb": {
+                "accuracy": 0.892,
+                "f1_score": 0.888
+            },
+            "StandardTransformer_imdb": {
+                "accuracy": 0.854,
+                "f1_score": 0.851
+            },
+            "HierarchicalAttention_yelp": {
+                "accuracy": 0.901,
+                "f1_score": 0.898
+            },
+            "StandardTransformer_yelp": {
+                "accuracy": 0.867,
+                "f1_score": 0.863
+            }
+        },
+        "figures": ["confusion_matrix.png", "attention_heatmap.png"]
+    }
+}
+
+###


### PR DESCRIPTION
## 背景と目的

`AnalyzeExperimentSubgraph`が`LLMFacadeClient`を使用しているため、LangChainの統合メリットを活用できず、コードの一貫性も損なわれています。このPRは、`AnalyzeExperimentSubgraph`を`LangChainClient`に置き換え、さらに実験分析機能のAPIエンドポイントを追加して、ユーザーが実験結果を分析できるようにします。

親Issue: https://github.com/airas-org/airas/issues/528

## 変更内容

以下の機能が変更されました：
1. `AnalyzeExperimentSubgraph`のクライアント置き換え: `LLMFacadeClient`から`LangChainClient`への移行
2. 実験分析APIエンドポイントの追加: `POST /experiments/analyses`を実装
3. HTTPテストケースの追加: 実験分析エンドポイントのテストを追加

実装の詳細は以下の通りです：

<details>
<summary><code>1. AnalyzeExperimentSubgraphのクライアント置き換え</code></summary>

**実装概要**

- **`AnalyzeExperimentSubgraph`クラスの変更**:
  - `__init__()`:
    - `llm_client: LLMFacadeClient` → `langchain_client: LangChainClient`に変更
    - インスタンス変数も`self.llm_client` → `self.langchain_client`に変更
  - `_analyze_experiment()`:
    - `analyze_experiment()`関数の呼び出し時に`langchain_client`を渡すように変更
    - デコレータ名を`@analytic_timed` → `@record_execution_time`に統一

- **`analyze_experiment()`関数の変更** (`backend/src/airas/features/analyzers/analyze_experiment_subgraph/nodes/analyze_experiment.py`):
  - 関数シグネチャを`llm_client: LLMFacadeClient` → `langchain_client: LangChainClient`に変更
  - `langchain_client.structured_outputs()`を使用してLLMの出力を取得
  - 返り値を`output`（LLMOutputオブジェクト）から`output.analysis_report`（文字列）に修正

- **型定義とインポートの整理**:
  - `LLMFacadeClient`のインポートを削除し、`LangChainClient`のインポートを追加
  - 型定義の`total=False`の位置を適切に調整

- **`main()`関数の削除**:
  - ローカル実行用の`main()`関数とエントリポイントを削除（APIエンドポイント経由での実行に統一）

</details>

<details>
<summary><code>2. 実験分析APIエンドポイントの追加</code></summary>

**実装概要**

- **APIルートの追加** (`backend/api/routes/v1/experiments.py`):
  - `POST /experiments/analyses`エンドポイントを追加
  - `analyze_experiment()`関数を実装:
    - `AnalyzeExperimentRequestBody`をリクエストとして受け取る
    - `LangChainClient`を依存性注入で取得
    - `AnalyzeExperimentSubgraph`を初期化してグラフを実行
    - `AnalyzeExperimentResponseBody`を返す

- **スキーマの追加** (`backend/api/schemas/experiments.py`):
  - `AnalyzeExperimentRequestBody`:
    - `research_hypothesis: ResearchHypothesis` - 研究仮説
    - `experimental_design: ExperimentalDesign` - 実験設計
    - `experiment_code: ExperimentCode` - 実験コード
    - `experimental_results: ExperimentalResults` - 実験結果
  - `AnalyzeExperimentResponseBody`:
    - `experimental_analysis: ExperimentalAnalysis` - 実験分析レポート
    - `execution_time: dict[str, list[float]]` - 実行時間

</details>

<details>
<summary><code>3. HTTPテストケースの追加</code></summary>

**実装概要**

- **テストファイルの更新** (`backend/tests/http/experiments.http`):
  - `POST /experiments/analyses`のテストケースを追加
  - テストデータには以下を含む:
    - 研究仮説: 長文理解における階層的注意機構の提案
    - 実験設計: 評価指標（Accuracy、F1 Score）、使用モデル（BERT、RoBERTa）、データセット（IMDb、Yelp）
    - 実験コード: 各スクリプトのプレースホルダー
    - 実験結果: IMDbとYelpデータセットでの精度とF1スコアのメトリクス

</details>
