### PR TITLE
[Fix] Increase recursion limit in e2e endpoint

### DIFF
--- a/backend/src/airas/usecases/autonomous_research/topic_open_ended_research/topic_open_ended_research_subgraph.py
+++ b/backend/src/airas/usecases/autonomous_research/topic_open_ended_research/topic_open_ended_research_subgraph.py
@@ -508,7 +508,7 @@ class TopicOpenEndedResearchSubgraph:
             await PollGithubActionsSubgraph(github_client=self.github_client)
             .build_graph()
             .ainvoke(
-                {"github_config": state["github_config"]}, {"recursion_limit": 300}
+                {"github_config": state["github_config"]}, {"recursion_limit": 1000}
             )
         )
 
@@ -579,7 +579,7 @@ class TopicOpenEndedResearchSubgraph:
             result = (
                 await PollGithubActionsSubgraph(github_client=self.github_client)
                 .build_graph()
-                .ainvoke({"github_config": branch_config}, {"recursion_limit": 300})
+                .ainvoke({"github_config": branch_config}, {"recursion_limit": 1000})
             )
 
             status: GitHubActionsStatus | None = result.get("status")
@@ -645,7 +645,7 @@ class TopicOpenEndedResearchSubgraph:
             await PollGithubActionsSubgraph(github_client=self.github_client)
             .build_graph()
             .ainvoke(
-                {"github_config": state["github_config"]}, {"recursion_limit": 300}
+                {"github_config": state["github_config"]}, {"recursion_limit": 1000}
             )
         )
 
@@ -820,7 +820,7 @@ class TopicOpenEndedResearchSubgraph:
             await PollGithubActionsSubgraph(github_client=self.github_client)
             .build_graph()
             .ainvoke(
-                {"github_config": state["github_config"]}, {"recursion_limit": 300}
+                {"github_config": state["github_config"]}, {"recursion_limit": 1000}
             )
         )
 


### PR DESCRIPTION
# 背景
e2eの実行をしていた際にpoll_trial_workflowでrecursion limitの制限になってしまったため、300から1000に変更