### PR TITLE
Update e2e_scheduled

### DIFF
--- a/.github/workflows/e2e_scheduled.yml
+++ b/.github/workflows/e2e_scheduled.yml
@@ -33,7 +33,7 @@ on:
       wandb_entity:
         description: 'W&B entity name'
         required: false
-        default: 'gengaru617-personal'
+        default: 'airas'
       is_github_repo_private:
         description: 'Make repository private'
         required: false
@@ -103,7 +103,7 @@ on:
 jobs:
   check-org-membership:
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     outputs:
       is_member: ${{ steps.check.outputs.is_member }}
     steps:
@@ -276,7 +276,7 @@ jobs:
           RESEARCH_TOPIC="${{ github.event.inputs.research_topic || 'Data-efficient image classification methods using novel regularization and augmentation techniques' }}"
           BRANCH_NAME="${{ github.event.inputs.branch_name || 'main' }}"
           REPO_NAME="${{ steps.params.outputs.repo_name }}"
-          WANDB_ENTITY="${{ github.event.inputs.wandb_entity || 'gengaru617-personal' }}"
+          WANDB_ENTITY="${{ github.event.inputs.wandb_entity || 'airas' }}"
           WANDB_PROJECT="${{ steps.params.outputs.date_only }}"
           RUNNER_LABELS='${{ github.event.inputs.runner_label }}'
           if [ -z "$RUNNER_LABELS" ]; then
@@ -284,8 +284,8 @@ jobs:
           fi
           RUNNER_DESC="${{ github.event.inputs.runner_description || 'NVIDIA A100 or H200, VRAM: 80 GB or more, RAM: 2048 GB or more' }}"
           IS_PRIVATE="${{ github.event.inputs.is_github_repo_private || 'false' }}"
-          NUM_QUERIES="${{ github.event.inputs.num_paper_search_queries || '10' }}"
-          PAPERS_PER_QUERY="${{ github.event.inputs.papers_per_query || '3' }}"
+          NUM_QUERIES="${{ github.event.inputs.num_paper_search_queries || '3' }}"
+          PAPERS_PER_QUERY="${{ github.event.inputs.papers_per_query || '5' }}"
           HYPOTHESIS_ITERS="${{ github.event.inputs.hypothesis_refinement_iterations || '2' }}"
           NUM_MODELS="${{ github.event.inputs.num_experiment_models || '1' }}"
           NUM_DATASETS="${{ github.event.inputs.num_experiment_datasets || '1' }}"


### PR DESCRIPTION
## 背景と目的

E2Eスケジュールテストワークフローのデフォルト設定が、開発・テスト用の個人設定のままになっており、本番運用に適していませんでした。また、pushイベントでもワークフローが実行される設定になっており、意図しないタイミングでテストが実行される可能性がありました。このPRは、ワークフローの設定を本番運用に適した値に更新します。

親Issue: https://github.com/airas-org/airas/issues/614

## 変更内容

以下の設定が変更されました：

1. **W&B entity のデフォルト値を更新**
   - `gengaru617-personal` → `airas` に変更
   - 本番環境用のW&Bエンティティを使用するように修正

2. **ワークフロートリガー条件の変更**
   - `github.event_name == 'push'` を削除
   - scheduleとworkflow_dispatchのみでワークフローが実行されるように制限

3. **論文検索パラメータのデフォルト値を最適化**
   - `num_paper_search_queries`: `10` → `3` に変更
   - `papers_per_query`: `3` → `5` に変更
   - 検索クエリ数を減らし、クエリあたりの論文数を増やすことで、より効率的な論文収集が可能に
