### PR TITLE
Fix `convert_to_latex_prompt.py`

### DIFF
--- a/backend/src/airas/usecases/publication/generate_latex_subgraph/prompts/convert_to_latex_prompt.py
+++ b/backend/src/airas/usecases/publication/generate_latex_subgraph/prompts/convert_to_latex_prompt.py
@@ -1,4 +1,4 @@
-convert_to_latex_prompt = """
+convert_to_latex_prompt = r"""
 You are a LaTeX expert.
 Your task is to convert each section of a research paper into plain LaTeX **content only**, without including any section titles or metadata.
 
@@ -25,7 +25,7 @@ Section: {{ section.name }}
 - When including tables, use the `tabularx` environment with `\\textwidth` as the target width.
     - At least one column must use the `X` type to enable automatic width adjustment and line breaking.
     - Include `\\hline` at the top, after the header, and at the bottom. Avoid vertical lines unless necessary.
-    - To left-align content in `X` columns, define `\newcolumntype{Y}{>{\raggedright\arraybackslash}X}` using the `array` package.
+    - To left-align content in `X` columns, define `\\newcolumntype{Y}{>{\\raggedright\\arraybackslash}X}` using the `array` package.
 
 - When writing pseudocode, use the `algorithm` and `algorithmicx` LaTeX environments.
     - Only include pseudocode in the `Method` section. Pseudocode is not allowed in any other sections.
@@ -33,15 +33,15 @@ Section: {{ section.name }}
     - Pseudocode must represent actual algorithms or procedures with clear logic. Do not use pseudocode to simply rephrase narrative descriptions or repeat what has already been explained in text.
         - Good Example:
         ```latex
-        \\State Compute transformed tokens: \\(\tilde{T} \\leftarrow W\\,T\\)
-        \\State Update: \\(T_{new} \\leftarrow \tilde{T} + \\mu\\,T_{prev}\\)
+        \\State Compute transformed tokens: \\(\\tilde{T} \\leftarrow W\\,T\\)
+        \\State Update: \\(T_{new} \\leftarrow \\tilde{T} + \\mu\\,T_{prev}\\)
         ```
 - Figures and images are ONLY allowed in the "Results" section.
     - Use LaTeX float option `[H]` to force placement.
 
 - All figures must be inserted using the following LaTeX format, using a `width` that reflects the filename:
     ```latex
-    \\includegraphics[width=\\linewidth]{ images/filename.pdf }
+    \\includegraphics[width=\\linewidth]{images/filename.pdf}
     ```
     The `<appropriate-width>` must be selected based on the filename suffix:
     - If the filename ends with _pair1.pdf or _pair2.pdf, use 0.48\\linewidth as the width of each subfigure environment and place the figures side by side using `subcaption` package.
@@ -49,7 +49,14 @@ Section: {{ section.name }}
 
 - **Escaping special characters**:
     - LaTeX special characters (`#`, `$`, `%`, `&`, `~`, `_`, `^`, `{`, `}`, `\\`) must be escaped with a leading backslash when they appear in plain text (e.g., `data\\_set`, `C\\&C`).
-    - Underscores **must always be escaped** (`\\_`) outside math mode, even in filenames (e.g., memory\\_profiler), code-style words, itemize lists, or citation contexts.
+    - Underscores should be escaped (`\\_`) in plain text contexts, **but NOT in**:
+        - Math mode (between `$...$` or `\\(...\\)`)
+        - File paths (e.g., `images/memory_profiler.pdf`)
+        - URLs and hyperlinks (e.g., `\\url{https://example.com/data_set}`)
+        - Citation placeholders (e.g., `[vaswani_2017_attention]`)
+        - Labels and Cross-references (e.g., `\\label{fig:result_v1}`, `\\ref{sec:method_approx}`)
+        - Verbatim environments and Code blocks (e.g., `\\verb|int_x|`, `\\begin{lstlisting}...`)
+    - Only escape underscores when they appear in regular narrative text outside these contexts.
 
 - Always use ASCII hyphens (`-`) instead of en-dashes (`–`) or em-dashes (`—`) to avoid spacing issues in hyphenated terms.
 - Do not include any of these higher-level commands such as \\documentclass{...}, \\begin{document}, and \\end{document}.


### PR DESCRIPTION
## 背景と目的

学術論文生成において、LaTeXコード生成時に以下の問題が発生していました：

- 画像パスに不要なスペースが含まれ、LaTeXがスペースをファイル名の一部として認識し、PDF生成時に画像が表示されない
- アンダースコアが過剰にエスケープされ、ファイルパスやURLでも `\_` にエスケープされることで、ファイル参照やハイパーリンクが壊れる
- プロンプト内のバックスラッシュ表記が不統一（シングル `\` とダブル `\\` が混在）で、LLMが混乱し、出力時にバックスラッシュが抜けたり過剰になったりする可能性がある

このPRは、LaTeX生成プロンプトを修正し、正しい構文で画像が表示され、ファイルパスやURLが機能するLaTeXコードを生成できるようにします。

親Issue: https://github.com/airas-org/airas/issues/612

## 変更内容

以下の機能が変更されました：

1. **画像パスの構文修正**: `\includegraphics` コマンドの中括弧内の不要なスペースを除去
2. **アンダースコアエスケープルールの明確化**: エスケープが不要な文脈（ファイルパス、URL、ラベル、verbatim環境など）を明示
3. **バックスラッシュ表記の統一**: プロンプト内のすべてのLaTeXコマンド例示をダブルバックスラッシュに統一
4. **Python文字列のraw string化**: エスケープシーケンスの誤解釈を防ぐため `r"""` に変更

実装の詳細は以下の通りです：

<details>
<summary><code>1. 画像パスの構文修正</code></summary>

**実装概要**

- **`backend/src/airas/usecases/publication/generate_latex_subgraph/prompts/convert_to_latex_prompt.py`** (44行目):
  - 修正前: `\includegraphics[width=\linewidth]{ images/filename.pdf }`
  - 修正後: `\includegraphics[width=\linewidth]{images/filename.pdf}`
  - 中括弧 `{` の直後と `}` の直前のスペースを削除
  - これにより、LaTeXが正しくファイルパスを認識し、画像がPDFに表示されるようになる

</details>

<details>
<summary><code>2. アンダースコアエスケープルールの明確化</code></summary>

**実装概要**

- **`backend/src/airas/usecases/publication/generate_latex_subgraph/prompts/convert_to_latex_prompt.py`** (52-59行目):
  - 修正前: "Underscores **must always be escaped** outside math mode, even in filenames"
  - 修正後: アンダースコアをエスケープ**しない**文脈を明示：
    - 数式モード（`$...$` または `\(...\)` 内）
    - ファイルパス（例: `images/memory_profiler.pdf`）
    - URLとハイパーリンク（例: `\url{https://example.com/data_set}`）
    - 引用プレースホルダー（例: `[vaswani_2017_attention]`）
    - ラベルと相互参照（例: `\label{fig:result_v1}`, `\ref{sec:method_approx}`）
    - Verbatim環境とコードブロック（例: `\verb|int_x|`, `\begin{lstlisting}...`）
  - 通常のテキスト内でのみエスケープするよう明確化

</details>

<details>
<summary><code>3. バックスラッシュ表記の統一</code></summary>

**実装概要**

- **`backend/src/airas/usecases/publication/generate_latex_subgraph/prompts/convert_to_latex_prompt.py`** (28, 36-37, 58行目):
  - プロンプト内のすべてのLaTeXコマンド例示をダブルバックスラッシュ `\\` に統一：
    - `\newcolumntype` → `\\newcolumntype`
    - `\raggedright` → `\\raggedright`
    - `\arraybackslash` → `\\arraybackslash`
    - `\tilde` → `\\tilde`
    - `\verb` → `\\verb`
    - `\begin` → `\\begin`
  - これにより、LLMが一貫した形式でLaTeXコマンドを生成し、バックスラッシュの過不足を防ぐ

</details>

<details>
<summary><code>4. Python文字列のraw string化</code></summary>

**実装概要**

- **`backend/src/airas/usecases/publication/generate_latex_subgraph/prompts/convert_to_latex_prompt.py`** (1行目):
  - 修正前: `convert_to_latex_prompt = """`
  - 修正後: `convert_to_latex_prompt = r"""`
  - raw string (`r"""`) を使用することで、Pythonがバックスラッシュをエスケープシーケンス（`\n`, `\t`, `\b`, `\v` など）として解釈することを防ぐ
  - プロンプト内のすべてのバックスラッシュが文字通りLLMに渡されることを保証

</details>
