### PR TITLE
Switch e2e workflow runner to blacksmith to resolve timeout issue

### DIFF
--- a/.github/workflows/e2e_scheduled.yml
+++ b/.github/workflows/e2e_scheduled.yml
@@ -144,7 +144,7 @@ jobs:
   e2e-test:
     needs: check-org-membership
     if: needs.check-org-membership.outputs.is_member == 'true'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 1440  # 24 hours
 
     services:


### PR DESCRIPTION
後ほど記述します.