### PR TITLE
feat: Changed to ubicloud runner

### DIFF
--- a/.github/workflows/e2e_scheduled.yml
+++ b/.github/workflows/e2e_scheduled.yml
@@ -144,7 +144,7 @@ jobs:
   e2e-test:
     needs: check-org-membership
     if: needs.check-org-membership.outputs.is_member == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     timeout-minutes: 1440  # 24 hours
 
     services:


### PR DESCRIPTION
## 背景と目的

E2Eテストの定期実行ワークフローにおいて、GitHub Actionsのubuntu-latestランナーでは6時間を超える長時間実行をサポートしておらず、テストがタイムアウトする問題が発生していました。このPRでは、より長時間の実行に対応し、かつコスト効率の良いランナーに切り替えることで、この問題を解決します。

親Issue: https://github.com/airas-org/airas/issues/625

参考：https://www.ubicloud.com/docs/github-actions-integration/runner-types#available-labels

## 変更内容

以下の変更が実装されました：

1. E2E定期実行ワークフローのランナーを変更
   - `ubuntu-latest` → `ubicloud-standard-2` に変更
   - 6時間以上の長時間実行をサポート
   - コスト効率の良いランナーを使用
   - タイムアウト設定は24時間（1440分）を維持
