### PR TITLE
fix: Added `FAILED` to status enum

### DIFF
--- a/backend/src/airas/infra/db/models/e2e.py
+++ b/backend/src/airas/infra/db/models/e2e.py
@@ -13,6 +13,7 @@ class Status(str, Enum):
     PENDING = "pending"
     RUNNING = "running"
     COMPLETED = "completed"
+    FAILED = "failed"
 
 
 class StepType(str, Enum):

--- a/frontend/src/lib/api/models/Status.ts
+++ b/frontend/src/lib/api/models/Status.ts
@@ -6,4 +6,5 @@ export enum Status {
     PENDING = 'pending',
     RUNNING = 'running',
     COMPLETED = 'completed',
+    FAILED = 'failed',
 }

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -3063,6 +3063,7 @@ components:
       - pending
       - running
       - completed
+      - failed
       title: Status
     StepType:
       type: string


### PR DESCRIPTION
## 背景と目的

E2Eテストの実行中にエラーが発生した場合、タスクステータスが`running`のまま残り、GitHub Actionsのポーリングループが無限に継続してしまう問題がありました。これは、例外発生時にタスクステータスを`failed`に更新する処理が実装されておらず、ワークフロー側で失敗を検知できないことが原因でした。このPRでは、`Status` enumに`FAILED`ステータスを追加し、エラー発生時に適切にステータスを更新することで、ワークフローが確実に停止するようにします。

親Issue: https://github.com/airas-org/airas/issues/629

## 変更内容

以下の変更が実装されました：

1. `Status` enumに`FAILED`ステータスを追加
2. エラー発生時のステータス更新処理を実装
3. フロントエンドとOpenAPIスキーマの同期

実装の詳細は以下の通りです：

<details>
<summary><code>1. Status enumにFAILEDステータスを追加</code></summary>

**実装概要**

- **ファイル**: `backend/src/airas/infra/db/models/e2e.py`
- **変更内容**:
  - `Status` enumに`FAILED = "failed"`を追加
  - これにより、タスクが失敗状態を明示的に表現できるようになった

**変更前**:
```python
class Status(str, Enum):
    PENDING = "pending"
    RUNNING = "running"
    COMPLETED = "completed"
```

**変更後**:
```python
class Status(str, Enum):
    PENDING = "pending"
    RUNNING = "running"
    COMPLETED = "completed"
    FAILED = "failed"
```

</details>

<details>
<summary><code>2. エラー発生時のステータス更新処理を実装</code></summary>

**実装概要**

- **ファイル**: `backend/api/routes/v1/topic_open_ended_research.py`
- **変更内容**:
  - `_execute_topic_open_ended_research`関数の例外ハンドリングブロックに、ステータス更新処理を追加
  - エラー発生時に`Status.FAILED`とエラーメッセージをデータベースに記録
  - ステータス更新自体が失敗した場合でも、ログに記録することで問題を追跡可能に

**主要な追加処理**:
```python
except Exception as e:
    error_msg = f"{type(e).__name__}: {str(e)}"
    logger.error(f"[Task {task_id}] Execution failed: {error_msg}")
    logger.error(f"[Task {task_id}] Traceback:\n{traceback.format_exc()}")

    try:
        e2e_service.update(
            id=task_id, status=Status.FAILED, error_message=error_msg
        )
    except Exception as update_error:
        # If we fail to update status to FAILED, the task will remain in RUNNING state.
        # Since this runs in an async task (asyncio.create_task), exceptions won't
        # propagate to the caller, but at least we can log the error.
        logger.error(
            f"[Task {task_id}] CRITICAL: Failed to update status to FAILED. "
            f"Task may remain in RUNNING state. Error: {update_error}"
        )
```

**動作フロー**:
1. グラフ実行中にエラーが発生
2. 例外がキャッチされ、`Status.FAILED`に更新
3. GitHub Actionsのポーリングループが`failed`ステータスを検知して停止

</details>

<details>
<summary><code>3. フロントエンドとOpenAPIスキーマの同期</code></summary>

**実装概要**

- **フロントエンド**: `frontend/src/lib/api/models/Status.ts`
  - TypeScript enumに`FAILED = 'failed'`を追加
- **OpenAPIスキーマ**: `schema/openapi.yaml`
  - `Status`スキーマに`failed`を追加
  - フロントエンドとバックエンドの型定義を一致させる

</details>

## 影響範囲

- GitHub Actionsのワークフロー (`.github/workflows/e2e_scheduled.yml`) は既に`failed`ステータスをチェックする実装があるため、追加の変更は不要
- 既存のデータベースレコードは影響を受けない（新しい`FAILED`ステータスは新規エラー発生時のみ使用される）
