### PR TITLE
[bug fix] Log full traceback for exceptions in status polling endpoint

### DIFF
--- a/.github/workflows/e2e_scheduled.yml
+++ b/.github/workflows/e2e_scheduled.yml
@@ -399,6 +399,11 @@ jobs:
             if [ "$STATUS_HTTP" -ne 200 ]; then
               CONSECUTIVE_ERRORS=$((CONSECUTIVE_ERRORS + 1))
               echo "[Poll #${POLL_COUNT}] HTTP ${STATUS_HTTP} (error ${CONSECUTIVE_ERRORS}/${MAX_CONSECUTIVE_ERRORS})"
+              echo "--- Error response body ---"
+              echo "$STATUS_BODY" | jq . 2>/dev/null || echo "$STATUS_BODY"
+              echo "--- Server log (last 20 lines) ---"
+              tail -n 20 /tmp/e2e-logs/server.log 2>/dev/null || echo "(no log)"
+              echo "---"
               if [ "$CONSECUTIVE_ERRORS" -ge "$MAX_CONSECUTIVE_ERRORS" ]; then
                 echo "ABORT: Too many consecutive HTTP errors"
                 tail -n 100 /tmp/e2e-logs/server.log 2>/dev/null || true

--- a/backend/api/routes/v1/topic_open_ended_research.py
+++ b/backend/api/routes/v1/topic_open_ended_research.py
@@ -178,13 +178,15 @@ async def get_topic_open_ended_research_status(
         ) from exc
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception(f"[Status {task_id}] Failed to get status")
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(status_code=500, detail="Internal Server Error") from exc
 
     try:
         return TopicOpenEndedResearchStatusResponseBody.model_validate(result)
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception(f"[Status {task_id}] Failed to validate response")
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=500, detail="Failed to validate response"
+        ) from exc
 
 
 @router.get("", response_model=TopicOpenEndedResearchListResponseBody)
@@ -234,10 +236,12 @@ async def update_topic_open_ended_research(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception(f"[Update {task_id}] Failed to update")
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(status_code=500, detail="Internal Server Error") from exc
 
     try:
         return TopicOpenEndedResearchStatusResponseBody.model_validate(updated)
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception(f"[Update {task_id}] Failed to validate response")
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=500, detail="Failed to validate response"
+        ) from exc


### PR DESCRIPTION
## 背景と目的

E2E scheduled test実行中、長時間（約11時間）のGitHub Actionsポーリング中に、ステータスエンドポイント (`GET /airas/v1/topic_open_ended_research/status/{task_id}`) が連続してHTTP 500エラーを返す問題が発生しました（[該当ワークフロー実行](https://github.com/airas-org/airas/actions/runs/21476787371/job/61862720749#step:12:8531)）。

サーバー側では `poll_github_actions_subgraph` が正常にポーリングを継続していたにもかかわらず、ステータスエンドポイントからHTTP 500が返され続けたため、E2E scheduled testワークフローが中断されました。

FastAPIのデフォルトログでは以下のようにHTTPステータスコードのみが記録され、例外の種類やトレースバックが一切記録されないため、根本原因を特定できませんでした：

```
INFO:     127.0.0.1:59636 - "GET /status/xxx HTTP/1.1" 500 Internal Server Error
```

このPRは、全エラーハンドリング箇所に `logger.exception()` を追加し、次回同様の問題が発生した際に例外の詳細（種類、メッセージ、トレースバック）を記録できるようにします。また、GitHub Actions側でもエラー発生時の診断情報を追加し、問題の早期発見と原因特定を可能にします。

親Issue: https://github.com/airas-org/airas/issues/640

## 変更内容

以下の機能が変更されました：
1. FastAPIエンドポイントのエラーロギング改善
2. GitHub Actionsワークフローのエラー診断情報追加

実装の詳細は以下の通りです：

<details>
<summary><code>1. FastAPIエンドポイントのエラーロギング改善</code></summary>

**実装概要**

`backend/api/routes/v1/topic_open_ended_research.py` を更新

- **`_execute_topic_open_ended_research()` 関数**:
  - `logger.error()` + `traceback.format_exc()` → `logger.exception()` に統一
    - 例外のトレースバックを自動的に記録するように改善
  - ステータス更新失敗時のエラーハンドリングを改善
    - 未使用の例外変数 `update_error` を削除し、`logger.exception()` で詳細を記録

- **`get_topic_open_ended_research_status()` 関数**:
  - 一般例外のエラーメッセージを `str(exc)` から `"Internal Server Error"` に変更
    - 内部エラーの詳細をクライアントに公開しないセキュリティ改善
  - `logger.exception()` を追加してサーバーログに例外詳細を記録
  - レスポンスバリデーション失敗時のエラーハンドリングを追加
    - `model_validate()` の例外を捕捉し、適切なエラーメッセージとログを記録

- **`update_topic_open_ended_research()` 関数**:
  - 一般例外のエラーメッセージを `str(exc)` から `"Internal Server Error"` に変更
  - `logger.exception()` を追加してサーバーログに例外詳細を記録
  - レスポンスバリデーション失敗時のエラーハンドリングを追加

**ロギング改善の効果**:

従来:
```
INFO:     127.0.0.1:59636 - "GET /status/xxx HTTP/1.1" 500 Internal Server Error
```

改善後:
```
ERROR:    [Status xxx] Failed to get status
Traceback (most recent call last):
  File "backend/api/routes/v1/topic_open_ended_research.py", line 180, in get_topic_open_ended_research_status
    result = e2e_service.get(task_id)
  File "backend/src/airas/services/e2e_service.py", line 45, in get
    raise ValueError("Task not found")
ValueError: Task not found
INFO:     127.0.0.1:59636 - "GET /status/xxx HTTP/1.1" 500 Internal Server Error
```

</details>

<details>
<summary><code>2. GitHub Actionsワークフローのエラー診断情報追加</code></summary>

**実装概要**

`.github/workflows/e2e_scheduled.yml` を更新

- **ステータスポーリングループのエラーハンドリング**:
  - HTTP 500エラー発生時に以下の診断情報を出力するように改善:
    1. エラーレスポンスボディ（JSON整形、または生テキスト）
    2. サーバーログの最後20行
  - これにより、エラー発生時の状況を即座に確認可能に

**診断情報出力例**:
```bash
[Poll #229] HTTP 500 (error 1/10)
--- Error response body ---
{
  "detail": "Internal Server Error"
}
--- Server log (last 20 lines) ---
ERROR:    [Status xxx] Failed to get status
Traceback (most recent call last):
  ...
ValueError: Task not found
---
```

</details>
