### PR TITLE
fix(workflows/e2e_scheduled): Fixed model name mismatch

### DIFF
--- a/.github/workflows/e2e_scheduled.yml
+++ b/.github/workflows/e2e_scheduled.yml
@@ -80,14 +80,16 @@ on:
         description: 'Primary LLM (query generation, hypothesis, design, analysis, writing, LaTeX)'
         required: false
         type: choice
+        # NOTE: Use bare model names (e.g. "gemini-2.5-flash") for LangChainClient compatibility.
+        # "provider/model" format (e.g. "google/gemini-2.5-flash") causes litellm.get_model_info() failures.
         options: &llm_options
           - 'gpt-5.2'
           - 'gpt-5.2-codex'
           - 'o3-2025-04-16'
           - 'o3-mini-2025-01-31'
           - 'gpt-5-mini-2025-08-07'
-          - 'google/gemini-2.5-pro'
-          - 'google/gemini-2.5-flash'
+          - 'gemini-2.5-pro'
+          - 'gemini-2.5-flash'
           - 'anthropic/claude-opus-4'
           - 'anthropic/claude-sonnet-4-5'
         default: 'gpt-5.2'
@@ -102,7 +104,7 @@ on:
         required: false
         type: choice
         options: *llm_options
-        default: 'google/gemini-2.5-flash'
+        default: 'gemini-2.5-flash'
       github_actions_model:
         description: 'GitHub Actions LLM (experiment dispatch, evaluation dispatch, LaTeX compilation)'
         required: false
@@ -269,7 +271,7 @@ jobs:
           # === LLM model selections ===
           PRIMARY_MODEL="${{ github.event.inputs.primary_model || 'gpt-5.2' }}"
           CODING_MODEL="${{ github.event.inputs.coding_model || 'gpt-5.2-codex' }}"
-          PAPER_RETRIEVAL_MODEL="${{ github.event.inputs.paper_retrieval_model || 'google/gemini-2.5-flash' }}"
+          PAPER_RETRIEVAL_MODEL="${{ github.event.inputs.paper_retrieval_model || 'gemini-2.5-flash' }}"
           GITHUB_ACTIONS_MODEL="${{ github.event.inputs.github_actions_model || 'anthropic/claude-sonnet-4-5' }}"
 
           # === Build LLM mapping JSON ===

--- a/backend/src/airas/infra/llm_specs.py
+++ b/backend/src/airas/infra/llm_specs.py
@@ -166,8 +166,8 @@ LLM_MODELS: TypeAlias = (
 
 # https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
 # Override for models where litellm's values appear incorrect.
-# gpt-5.2-codex: litellm reports max_input=400000 but likely shares the same
-# 400K total context window as gpt-5.2 (max_input=272000 + max_output=128000).
+# Note: As of now, litellm correctly reports gpt-5.2-codex as max_input=272000, max_output=128000.
+# This override is kept for safety but may be unnecessary.
 _MODEL_CONTEXT_OVERRIDES: dict[str, dict[str, int]] = {
     "gpt-5.2-codex": {"max_input_tokens": 272000, "max_output_tokens": 128000},
 }


### PR DESCRIPTION
## 背景と目的

E2Eテストにおいて、`retrieve_papers` ステップで処理が無限に停止し、最終的にタイムアウト (exit code 143) で失敗する問題が発生していました。この原因は、ローカルのモデル名定義と litellm が期待するモデル名形式の不一致にありました。

1. **`litellm.get_model_info()` との非互換**: `get_model_context_info()` 内で `litellm.get_model_info("google/gemini-2.5-flash")` を呼び出す際、litellm がこのフォーマットを認識できず、繰り返し `Provider List: https://docs.litellm.ai/docs/providers` というエラーメッセージを stderr に出力していました
2. **`LangChainClient` のプロバイダ解決の失敗**: `_select_provider_for_model()` で `"google/gemini-2.5-flash"` は `OPENROUTER_MODELS` にマッチしますが、`GOOGLE_MODELS` には `"gemini-2.5-flash"` (プレフィックスなし) しか定義されていないため、Google プロバイダへのフォールバックができず、プロバイダ解決に失敗していました

https://github.com/airas-org/airas/actions/runs/21565378733/job/62135916091#step:11:189

このPRは、LangChainClient で使用されるローカルモデル名定義を litellm が認識可能な形式に統一し、E2Eテストの安定性を向上させます。

親Issue: https://github.com/airas-org/airas/issues/649

## 変更内容

以下の修正が実施されました：

1. **`.github/workflows/e2e_scheduled.yml` のモデル名オプション修正**:
   - `llm_options` 内のモデル名を修正:
     - `google/gemini-2.5-pro` → `gemini-2.5-pro`
     - `google/gemini-2.5-flash` → `gemini-2.5-flash`
     - Claude モデルは `anthropic/` プレフィックスを維持 (GitHub Actions 内で LiteLLM 経由で使用されるため)
   - デフォルト値を修正:
     - `paper_retrieval_model` のデフォルト: `google/gemini-2.5-flash` → `gemini-2.5-flash`
     - `github_actions_model` のデフォルト: `anthropic/claude-sonnet-4-5` (維持)
   - モデル名形式の制約についてコメントを追加

2. **`backend/src/airas/infra/llm_specs.py` の改善**:
   - コメントを更新し、現在の litellm の挙動を記録

## 補足

- この修正により、E2Eテストの `retrieve_papers` ステップで発生していた無限ループとタイムアウトの問題が解決されます
- LiteLLM への完全移行後は、すべてのモデル名を `provider/model` 形式に統一する予定です。現在は LangChainClient との互換性を保つため、ベアモデル名を使用しています
