### PR TITLE
Fix db session management to prevent connection pool exhaustion in background tasks

### DIFF
--- a/backend/api/routes/v1/topic_open_ended_research.py
+++ b/backend/api/routes/v1/topic_open_ended_research.py
@@ -116,8 +116,6 @@ async def _execute_topic_open_ended_research(
                 f"[Task {task_id}] CRITICAL: Failed to update status to FAILED. "
                 f"Task may remain in RUNNING state."
             )
-    finally:
-        e2e_service.close()
 
 
 @router.post("/run", response_model=TopicOpenEndedResearchResponseBody)
@@ -136,7 +134,7 @@ async def execute_topic_open_ended_research(
     ],
     e2e_service: Annotated[
         TopicOpenEndedResearchService,
-        Depends(Closing[Provide[Container.topic_open_ended_research_service]]),
+        Depends(Provide[Container.topic_open_ended_research_service]),
     ],
 ) -> TopicOpenEndedResearchResponseBody:
     container: Container = fastapi_request.app.state.container

--- a/backend/src/airas/container.py
+++ b/backend/src/airas/container.py
@@ -25,9 +25,6 @@ from airas.repository.assisted_research_session_repository import (
 from airas.repository.assisted_research_step_repository import (
     AssistedResearchStepRepository,
 )
-from airas.repository.topic_open_ended_research_service_repository import (
-    TopicOpenEndedResearchRepository,
-)
 from airas.usecases.assisted_research.assisted_research_link_service import (
     AssistedResearchLinkService,
 )
@@ -206,11 +203,8 @@ class Container(containers.DeclarativeContainer):
     )
 
     ## ---  Autonomous Research Service ---
-    topic_open_ended_research_repository = providers.Factory(
-        TopicOpenEndedResearchRepository, db=db_session
-    )
     topic_open_ended_research_service = providers.Factory(
-        TopicOpenEndedResearchService, repo=topic_open_ended_research_repository
+        TopicOpenEndedResearchService, session_factory=session_factory
     )
 
 


### PR DESCRIPTION
## 背景と目的

E2E研究タスクの実行中に、SQLAlchemyのコネクションプール枯渇により `QueuePool limit of size 5 overflow 10 reached, connection timed out` エラーが発生していました。

https://github.com/airas-org/airas/actions/runs/21518978010/job/62004653316#step:11:5997

**根本原因:**
- 長時間実行されるバックグラウンドタスク（数時間〜最大100時間）が、1つのDBセッション（=1つのコネクション）をタスク全体で保持し続けていた
- デフォルトのコネクションプール上限（15接続）に対し、複数の長時間タスクが並行実行されると全コネクションが占有され、ステータス確認などの短いクエリすら実行できなくなっていた

このPRは、`TopicOpenEndedResearchService` のセッション管理を **操作単位のセッション取得・即座返却** パターンにリファクタリングし、長時間タスクがコネクションを占有し続ける問題を解決します。

親Issue: https://github.com/airas-org/airas/issues/648

## 変更内容

以下の変更が実装されました：

1. **`TopicOpenEndedResearchService` のセッション管理パターンを変更**
   - 従来: コンストラクタで `Repository`（内部に `Session` を保持）を受け取り、サービスのライフサイクル全体でセッションを保持
   - 変更後: コンストラクタで `session_factory: Callable[[], Session]` を受け取り、各メソッド（`create`, `update`, `get`, `list`, `delete`）で `with session_factory() as session:` によりセッションを取得・即座返却
   - 効果: DB操作完了後、即座にコネクションがプールに返却されるため、長時間タスク実行中もコネクションを占有しない

2. **DIコンテナの設定を変更**
   - 不要になった中間プロバイダ `topic_open_ended_research_repository` を削除
   - サービスに `session_factory`（Singleton sessionmaker）を直接注入

3. **API層のクリーンアップ**
   - `/run` エンドポイントから `Closing[]` ラッパーを削除（セッションは各操作で自己管理されるため不要）
   - バックグラウンドタスクの `finally` ブロックから `e2e_service.close()` を削除
   - サービスの `close()` メソッドを no-op に変更（セッションは `with` 文で自動クローズされる）

実装の詳細は以下の通りです：

<details>
<summary><code>backend/src/airas/usecases/autonomous_research/topic_open_ended_research/topic_open_ended_research_service.py</code></summary>

**変更前の問題:**
```python
class TopicOpenEndedResearchService:
    def __init__(self, repo: TopicOpenEndedResearchRepository):
        self.repo = repo  # Sessionを内包するRepositoryを保持

    def update(self, id: UUID, ...) -> E2EModel:
        updated = self.repo.update(id, ...)  # 共有セッションを使用
        return updated

    def close(self) -> None:
        self.repo.db.close()  # タスク終了時に明示的にクローズ
```

**問題点:**
- バックグラウンドタスクが数時間実行される間、1つのセッション（=1つのDBコネクション）を占有し続ける
- ポーリング待機中もコネクションを保持したままとなる

**変更後:**
```python
class TopicOpenEndedResearchService:
    def __init__(self, session_factory: Callable[[], Session]):
        self._session_factory = session_factory  # セッション生成関数を保持

    def update(self, id: UUID, ...) -> E2EModel:
        with self._session_factory() as session:  # 操作ごとに新しいセッションを取得
            repo = TopicOpenEndedResearchRepository(db=session)
            updated = repo.update(id, ...)
            return updated
        # withを抜けた時点でセッション自動クローズ、コネクション返却

    def close(self) -> None:
        pass  # 各操作で自己完結するため何もしない
```

**改善効果:**
- DB操作のたびにコネクションを取得し、操作完了後すぐプールに返却
- ポーリング待機中（数時間）はコネクション不使用
- 同様の変更を `create()`, `get()`, `list()`, `delete()` にも適用

</details>

<details>
<summary><code>backend/src/airas/container.py</code></summary>

**変更内容:**

DIコンテナの設定を簡素化：

```python
# 変更前: db_session(Factory) → Repository → Service
topic_open_ended_research_repository = providers.Factory(
    TopicOpenEndedResearchRepository, db=db_session
)
topic_open_ended_research_service = providers.Factory(
    TopicOpenEndedResearchService, repo=topic_open_ended_research_repository
)

# 変更後: session_factory(Singleton) → Service
topic_open_ended_research_service = providers.Factory(
    TopicOpenEndedResearchService, session_factory=session_factory
)
```

- 不要になった `TopicOpenEndedResearchRepository` の import を削除
- Repository はサービスの各メソッド内で都度生成されるため、DIコンテナから除外

</details>

<details>
<summary><code>backend/api/routes/v1/topic_open_ended_research.py</code></summary>

**変更内容:**

1. `/run` エンドポイントから `Closing[]` を削除：
   ```python
   # 変更前
   e2e_service: Annotated[
       TopicOpenEndedResearchService,
       Depends(Closing[Provide[Container.topic_open_ended_research_service]]),
   ],

   # 変更後
   e2e_service: Annotated[
       TopicOpenEndedResearchService,
       Depends(Provide[Container.topic_open_ended_research_service]),
   ],
   ```
   - 理由: セッションは各操作で自己管理されるため、エンドポイント終了時のクローズ処理は不要

2. バックグラウンドタスク `_execute_topic_open_ended_research` から `finally` ブロックを削除：
   ```python
   # 変更前
   except Exception:
       logger.exception(...)
   finally:
       e2e_service.close()  # 削除

   # 変更後
   except Exception:
       logger.exception(...)
   # finally ブロック自体を削除
   ```
   - 理由: `close()` は no-op となったため呼び出し不要

</details>
