### PR TITLE
feat(search): Add a new paper search function for international conferences

### DIFF
--- a/backend/src/airas/usecases/retrieve/search_paper_titles_subgraph/nodes/search_paper_titles_from_airas_db.py
+++ b/backend/src/airas/usecases/retrieve/search_paper_titles_subgraph/nodes/search_paper_titles_from_airas_db.py
@@ -10,11 +10,27 @@ logger = getLogger(__name__)
 
 DB_BASE_URL = "https://raw.githubusercontent.com/airas-org/airas-papers-db/main/data"
 
+# TODO: It would be better to allow external configuration of CONFERENCES_AND_YEARS
+# instead of hardcoding them here, enabling dynamic updates without code changes.
 CONFERENCES_AND_YEARS = {
-    "cvpr": ["2023", "2024"],
-    "iclr": ["2020", "2021", "2022", "2023", "2024"],
-    "icml": ["2020", "2021", "2022", "2023", "2024"],
-    "neurips": ["2020", "2021", "2022", "2023", "2024"],
+    # ==================== Core Machine Learning (ML) ====================
+    "iclr": ["2020", "2021", "2022", "2023", "2024", "2025"],
+    "icml": ["2020", "2021", "2022", "2023", "2024", "2025"],
+    "neurips": ["2020", "2021", "2022", "2023", "2024", "2025"],
+    # ==================== Natural Language Processing (NLP) ====================
+    "acl": ["2020", "2021", "2022", "2023", "2024"],
+    "emnlp": ["2020", "2021", "2022", "2023", "2024"],
+    "naacl": ["2021", "2022", "2024"],
+    # ==================== Computer Vision (CV) ====================
+    # "cvpr": ["2023", "2024", "2025"],
+    # "eccv": ["2024"],
+    # ==================== ML Theory ====================
+    # "colt": ["2019", "2020", "2021", "2022", "2023", "2024", "2025"],
+    # "aabi": ["2018", "2019", "2024", "2025"],
+    # ==================== Statistical / Probabilistic ML ====================
+    # "aistats": ["2019", "2020", "2021", "2022", "2023", "2024", "2025"],
+    # "uai":     ["2019", "2020", "2021", "2022", "2023", "2024", "2025"],
+    # "pgm":     ["2016", "2020", "2022", "2024"],
 }
 
 
@@ -112,3 +128,49 @@ async def search_paper_titles_from_airas_db(
                     results.append(title)
 
     return results
+
+
+async def main() -> None:
+    import logging
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+
+    logger.info("=" * 80)
+    logger.info("Starting AIRAS DB paper search test...")
+    logger.info("=" * 80)
+
+    search_index = AirasDbPaperSearchIndex()
+
+    test_queries = [
+        "transformer",
+        "attention mechanism",
+        "neural network",
+    ]
+
+    logger.info(f"\nTest queries: {test_queries}")
+    logger.info("-" * 80)
+
+    results = await search_paper_titles_from_airas_db(
+        queries=test_queries,
+        max_results_per_query=5,
+        search_index=search_index,
+    )
+
+    logger.info(f"\n{'=' * 80}")
+    logger.info(f"Found {len(results)} unique papers:")
+    logger.info(f"{'=' * 80}")
+    for i, title in enumerate(results, 1):
+        logger.info(f"{i:3d}. {title}")
+
+    logger.info(f"\n{'=' * 80}")
+    logger.info("Test completed successfully!")
+    logger.info(f"{'=' * 80}")
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())


### PR DESCRIPTION
## 背景と目的

このPRは、[airas-papers-db](https://github.com/airas-org/airas-papers-db)リポジトリの設定に基づいて、対応会議を大幅に拡充し、より多様な学術分野の論文検索に対応します。

親Issue: https://github.com/airas-org/airas/issues/659

## 変更内容

以下の機能が変更されました：

1. **対応会議の拡充**：新しい国際会議を追加し、研究分野別にカテゴライズ
   - **コア機械学習**：ICLR、ICML、NeurIPS（2025年まで対応）
   - **自然言語処理（NLP）**：ACL、EMNLP、NAACL を新規追加
   - **コンピュータビジョン（CV）**：CVPR、ECCV（コメントアウト）
   - **機械学習理論**：COLT、AABI（コメントアウト）
   - **統計・確率的機械学習**：AISTATS、UAI、PGM（コメントアウト）

2. **動作確認用のテスト関数を追加**：`main()` 関数を実装
   - ロギング設定を含む
   - テストクエリ（"transformer"、"attention mechanism"、"neural network"）での検索を実行
   - 検索結果を見やすくフォーマットして表示

3. **コード品質の改善**：
   - `CONFERENCES_AND_YEARS` の構造を研究分野別に整理
   - 外部からの設定を可能にするTODOコメントを追加
   - 会議設定を、airas-papers-dbリポジトリの[conferences.jsonc](https://github.com/airas-org/airas-papers-db/blob/main/scripts/configs/conferences.jsonc)に同期

実装の詳細：

<details>
<summary>対応会議の詳細設定</summary>

**有効な会議（実装済み）**：
- ICLR：2020-2025
- ICML：2020-2025
- NeurIPS：2020-2025
- ACL：2020-2024
- EMNLP：2020-2024
- NAACL：2021-2022、2024

**将来対応予定（コメントアウト）**：
- CVPR：2023-2025
- ECCV：2024
- COLT：2019-2025
- AABI：2018-2019、2024-2025
- AISTATS：2019-2025
- UAI：2019-2025
- PGM：2016、2020、2022、2024

</details>

## 補足

- 将来的には、`CONFERENCES_AND_YEARS` を外部設定ファイルから読み込むように改善することが推奨されています（TODOコメント参照）
- 現在、CV・理論系の会議はコメントアウト状態です。