### PR TITLE
refactor(api): Add `set_github_actions_secrets_subgraph` and Create API Endpoint

### DIFF
--- a/backend/api/routes/v1/github_actions.py
+++ b/backend/api/routes/v1/github_actions.py
@@ -10,9 +10,14 @@ from airas.infra.langfuse_client import LangfuseClient
 from airas.usecases.github.poll_github_actions_subgraph.poll_github_actions_subgraph import (
     PollGithubActionsSubgraph,
 )
+from airas.usecases.github.set_github_actions_secrets_subgraph.set_github_actions_secrets_subgraph import (
+    SetGithubActionsSecretsSubgraph,
+)
 from api.schemas.github_actions import (
     PollGithubActionsRequestBody,
     PollGithubActionsResponseBody,
+    SetGithubActionsSecretsRequestBody,
+    SetGithubActionsSecretsResponseBody,
 )
 
 router = APIRouter(prefix="/github-actions", tags=["github-actions"])
@@ -41,5 +46,29 @@ async def poll_github_actions(
         workflow_run_id=result["workflow_run_id"],
         status=result["status"],
         conclusion=result["conclusion"],
+        execution_time=result["execution_time"],
+    )
+
+
+@router.post("/secrets", response_model=SetGithubActionsSecretsResponseBody)
+@inject
+@observe()
+async def set_github_actions_secrets(
+    request: SetGithubActionsSecretsRequestBody,
+    github_client: Annotated[GithubClient, Depends(Provide[Container.github_client])],
+    langfuse_client: Annotated[
+        LangfuseClient, Depends(Provide[Container.langfuse_client])
+    ],
+) -> SetGithubActionsSecretsResponseBody:
+    handler = langfuse_client.create_handler()
+    config = {"callbacks": [handler]} if handler else {}
+
+    result = (
+        await SetGithubActionsSecretsSubgraph(github_client=github_client)
+        .build_graph()
+        .ainvoke(request, config=config)
+    )
+    return SetGithubActionsSecretsResponseBody(
+        secrets_set=result["secrets_set"],
         execution_time=result["execution_time"],
     )

--- a/backend/api/schemas/github_actions.py
+++ b/backend/api/schemas/github_actions.py
@@ -12,3 +12,12 @@ class PollGithubActionsResponseBody(BaseModel):
     status: str | None
     conclusion: str | None
     execution_time: dict[str, list[float]]
+
+
+class SetGithubActionsSecretsRequestBody(BaseModel):
+    github_config: GitHubConfig
+
+
+class SetGithubActionsSecretsResponseBody(BaseModel):
+    secrets_set: bool
+    execution_time: dict[str, list[float]]

--- a/backend/src/airas/usecases/github/set_github_actions_secrets_subgraph/nodes/set_github_actions_secrets.py
+++ b/backend/src/airas/usecases/github/set_github_actions_secrets_subgraph/nodes/set_github_actions_secrets.py
@@ -1,0 +1,64 @@
+import logging
+import os
+
+from airas.core.types.github import GitHubConfig
+from airas.infra.github_client import GithubClient, GithubClientError
+
+logger = logging.getLogger(__name__)
+
+
+def set_github_actions_secrets(
+    github_config: GitHubConfig,
+    github_client: GithubClient,
+    secret_names: list[str],
+) -> bool:
+    try:
+        # Get repository public key once for all secrets
+        public_key_info = github_client.get_repository_public_key(
+            github_owner=github_config.github_owner,
+            repository_name=github_config.repository_name,
+        )
+        if not public_key_info:
+            logger.error(
+                f"Failed to get public key for repository {github_config.github_owner}/{github_config.repository_name}"
+            )
+            return False
+
+        success_count = 0
+        for secret_name in secret_names:
+            token_value = os.getenv(secret_name)
+            if not token_value:
+                logger.warning(
+                    f"Token '{secret_name}' not found in environment variables, skipping"
+                )
+                continue
+
+            logger.info(f"Token '{secret_name}' retrieved from environment variables")
+
+            success = github_client.create_or_update_repository_secret(
+                github_owner=github_config.github_owner,
+                repository_name=github_config.repository_name,
+                secret_name=secret_name,
+                secret_value=token_value,
+                public_key_info=public_key_info,
+            )
+
+            if success:
+                logger.info(
+                    f"Successfully set GitHub Actions secret '{secret_name}' for {github_config.github_owner}/{github_config.repository_name}"
+                )
+                success_count += 1
+            else:
+                logger.error(
+                    f"Failed to set GitHub Actions secret '{secret_name}' for {github_config.github_owner}/{github_config.repository_name}"
+                )
+
+        logger.info(f"Successfully set {success_count}/{len(secret_names)} secrets")
+        return success_count > 0
+
+    except GithubClientError as e:
+        logger.error(f"GitHub API error while setting secrets: {e}")
+        return False
+    except Exception as e:
+        logger.error(f"Unexpected error while setting GitHub Actions secrets: {e}")
+        return False

--- a/backend/src/airas/usecases/github/set_github_actions_secrets_subgraph/set_github_actions_secrets_subgraph.py
+++ b/backend/src/airas/usecases/github/set_github_actions_secrets_subgraph/set_github_actions_secrets_subgraph.py
@@ -1,0 +1,86 @@
+import logging
+
+from langgraph.graph import END, START, StateGraph
+from typing_extensions import TypedDict
+
+from airas.core.execution_timers import ExecutionTimeState, time_node
+from airas.core.logging_utils import setup_logging
+from airas.core.types.github import GitHubConfig
+from airas.infra.github_client import GithubClient
+from airas.usecases.github.set_github_actions_secrets_subgraph.nodes.set_github_actions_secrets import (
+    set_github_actions_secrets,
+)
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+record_execution_time = lambda f: time_node("set_github_actions_secrets")(f)  # noqa: E731
+
+
+class SetGithubActionsSecretsInputState(TypedDict):
+    github_config: GitHubConfig
+
+
+class SetGithubActionsSecretsOutputState(ExecutionTimeState):
+    secrets_set: bool
+
+
+class SetGithubActionsSecretsState(
+    SetGithubActionsSecretsInputState,
+    SetGithubActionsSecretsOutputState,
+):
+    pass
+
+
+class SetGithubActionsSecretsSubgraph:
+    def __init__(
+        self,
+        github_client: GithubClient,
+        secret_names: list[str]
+        | None = None,  # TODO: no caller passes a custom list; consider removing
+    ):
+        self.secret_names = secret_names or [
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "OPENROUTER_API_KEY",
+            "AWS_BEARER_TOKEN_BEDROCK",
+            "WANDB_API_KEY",
+            "HF_TOKEN",
+            "LANGFUSE_SECRET_KEY",
+            "LANGFUSE_PUBLIC_KEY",
+            "LANGFUSE_BASE_URL",
+        ]
+        self.github_client = github_client
+
+    @record_execution_time
+    def _set_github_actions_secrets(
+        self, state: SetGithubActionsSecretsState
+    ) -> dict[str, bool]:
+        if not self.secret_names:
+            logger.info(
+                "No secret names provided, skipping GitHub Actions secrets setup"
+            )
+            return {"secrets_set": False}
+
+        success = set_github_actions_secrets(
+            github_config=state["github_config"],
+            github_client=self.github_client,
+            secret_names=self.secret_names,
+        )
+        return {"secrets_set": success}
+
+    def build_graph(self):
+        graph_builder = StateGraph(
+            SetGithubActionsSecretsState,
+            input_schema=SetGithubActionsSecretsInputState,
+            output_schema=SetGithubActionsSecretsOutputState,
+        )
+        graph_builder.add_node(
+            "set_github_actions_secrets", self._set_github_actions_secrets
+        )
+
+        graph_builder.add_edge(START, "set_github_actions_secrets")
+        graph_builder.add_edge("set_github_actions_secrets", END)
+
+        return graph_builder.compile()

--- a/backend/tests/http/github_actions.http
+++ b/backend/tests/http/github_actions.http
@@ -10,4 +10,16 @@ Content-Type: application/json
     }
 }
 
+### Set github actions secrets
+POST http://127.0.0.1:8000/airas/v1/github-actions/secrets
+Content-Type: application/json
+
+{
+    "github_config": {
+        "github_owner": "auto-res2",
+        "repository_name": "e2e-test-matsuzawa-20260128",
+        "branch_name": "main"
+    }
+}
+
 ###

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -98,6 +98,8 @@ export { SearchMethod } from './models/SearchMethod';
 export type { SearchPaperTitlesRequestBody } from './models/SearchPaperTitlesRequestBody';
 export type { SearchPaperTitlesResponseBody } from './models/SearchPaperTitlesResponseBody';
 export type { SearchSpace } from './models/SearchSpace';
+export type { SetGithubActionsSecretsRequestBody } from './models/SetGithubActionsSecretsRequestBody';
+export type { SetGithubActionsSecretsResponseBody } from './models/SetGithubActionsSecretsResponseBody';
 export { Status } from './models/Status';
 export { StepType } from './models/StepType';
 export type { TopicOpenEndedResearchListItemResponse } from './models/TopicOpenEndedResearchListItemResponse';

--- a/frontend/src/lib/api/models/SetGithubActionsSecretsRequestBody.ts
+++ b/frontend/src/lib/api/models/SetGithubActionsSecretsRequestBody.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { GitHubConfig } from './GitHubConfig';
+export type SetGithubActionsSecretsRequestBody = {
+    github_config: GitHubConfig;
+};
+

--- a/frontend/src/lib/api/models/SetGithubActionsSecretsResponseBody.ts
+++ b/frontend/src/lib/api/models/SetGithubActionsSecretsResponseBody.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type SetGithubActionsSecretsResponseBody = {
+    secrets_set: boolean;
+    execution_time: Record<string, Array<number>>;
+};
+

--- a/frontend/src/lib/api/services/GithubActionsService.ts
+++ b/frontend/src/lib/api/services/GithubActionsService.ts
@@ -4,6 +4,8 @@
 /* eslint-disable */
 import type { PollGithubActionsRequestBody } from '../models/PollGithubActionsRequestBody';
 import type { PollGithubActionsResponseBody } from '../models/PollGithubActionsResponseBody';
+import type { SetGithubActionsSecretsRequestBody } from '../models/SetGithubActionsSecretsRequestBody';
+import type { SetGithubActionsSecretsResponseBody } from '../models/SetGithubActionsSecretsResponseBody';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -20,6 +22,25 @@ export class GithubActionsService {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/airas/v1/github-actions/polling',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Set Github Actions Secrets
+     * @param requestBody
+     * @returns SetGithubActionsSecretsResponseBody Successful Response
+     * @throws ApiError
+     */
+    public static setGithubActionsSecretsAirasV1GithubActionsSecretsPost(
+        requestBody: SetGithubActionsSecretsRequestBody,
+    ): CancelablePromise<SetGithubActionsSecretsResponseBody> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/airas/v1/github-actions/secrets',
             body: requestBody,
             mediaType: 'application/json',
             errors: {

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -578,6 +578,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /airas/v1/github-actions/secrets:
+    post:
+      tags:
+      - github-actions
+      summary: Set Github Actions Secrets
+      operationId: set_github_actions_secrets_airas_v1_github_actions_secrets_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetGithubActionsSecretsRequestBody'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetGithubActionsSecretsResponseBody'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /airas/v1/assisted_research/session:
     post:
       tags:
@@ -3057,6 +3082,31 @@ components:
       - param_name
       - distribution_type
       title: SearchSpace
+    SetGithubActionsSecretsRequestBody:
+      properties:
+        github_config:
+          $ref: '#/components/schemas/GitHubConfig'
+      type: object
+      required:
+      - github_config
+      title: SetGithubActionsSecretsRequestBody
+    SetGithubActionsSecretsResponseBody:
+      properties:
+        secrets_set:
+          type: boolean
+          title: Secrets Set
+        execution_time:
+          additionalProperties:
+            items:
+              type: number
+            type: array
+          type: object
+          title: Execution Time
+      type: object
+      required:
+      - secrets_set
+      - execution_time
+      title: SetGithubActionsSecretsResponseBody
     Status:
       type: string
       enum:


### PR DESCRIPTION
## 背景と目的

`push_code_subgraph` に含まれていた GitHub Actions シークレット設定機能を独立したサブグラフとして新規作成し、API エンドポイントとして公開します。これにより、シークレット設定の機能を柔軟に再利用できるようになります。

尚、既存の`push_code_subgraph/`には変更を加えていません。

## 変更内容

### 1. サブグラフの新規作成

**`set_github_actions_secrets_subgraph`** を新規作成し、以下の構成で実装：

- **ディレクトリ構造**:
  - `backend/src/airas/usecases/github/set_github_actions_secrets_subgraph/`
    - `set_github_actions_secrets_subgraph.py` - サブグラフ本体
    - `nodes/set_github_actions_secrets.py` - ノード実装

- **サブグラフの仕様**:
  - **入力**: `github_config: GitHubConfig`
  - **出力**: `secrets_set: bool`, `execution_time: dict[str, list[float]]`
  - **処理フロー**: `START → set_github_actions_secrets → END`
  - **設定対象のシークレット** (デフォルト):
    - `OPENAI_API_KEY`, `GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`
    - `AWS_BEARER_TOKEN_BEDROCK`, `WANDB_API_KEY`, `HF_TOKEN`
    - `LANGFUSE_SECRET_KEY`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_BASE_URL`

### 2. API エンドポイント追加

**`POST /airas/v1/github-actions/secrets`** を新規追加：

- **ファイル**:
  - `api/routes/v1/github_actions.py` - エンドポイント実装
  - `api/schemas/github_actions.py` - リクエスト/レスポンススキーマ

- **リクエストボディ**:
  ```python
  class SetGithubActionsSecretsRequestBody(BaseModel):
      github_config: GitHubConfig
  ```

- **レスポンスボディ**:
  ```python
  class SetGithubActionsSecretsResponseBody(BaseModel):
      secrets_set: bool
      execution_time: dict[str, list[float]]
  ```

- **エンドポイント実装の特徴**:
  - `@inject` + `@observe()` デコレータで DI と Langfuse 計測を実装
  - `GithubClient` と `LangfuseClient` を依存性注入で取得
  - サブグラフ実行時に Langfuse ハンドラを config に追加

### 3. HTTP テスト追加

`tests/http/github_actions.http` に新規テストケースを追加：

```http
### Set github actions secrets
POST http://127.0.0.1:8000/airas/v1/github-actions/secrets
Content-Type: application/json

{
    "github_config": {
        "github_owner": "auto-res2",
        "repository_name": "your-repo",
        "branch_name": "your-branch"
    }
}
```

### 4. 実装上の注意

- **`secret_names` パラメータ**:
  - コンストラクタ引数として残されていますが、現在のエンドポイントでは常にデフォルト値で呼ばれるため、将来的には削除を検討するよう TODO コメントを付与

## 関連ファイル

- `backend/src/airas/usecases/github/set_github_actions_secrets_subgraph/`
- `backend/api/routes/v1/github_actions.py`
- `backend/api/schemas/github_actions.py`
- `backend/tests/http/github_actions.http`
- `frontend/src/lib/api/models/SetGithubActionsSecretsRequestBody.ts`
- `frontend/src/lib/api/models/SetGithubActionsSecretsResponseBody.ts`
- `frontend/src/lib/api/services/GithubActionsService.ts`
- `schema/openapi.yaml`
