### PR TITLE
LLM設定と自動研究ページのTypeScriptエラーを修正

### DIFF
--- a/frontend/src/components/features/llm-config/constants.ts
+++ b/frontend/src/components/features/llm-config/constants.ts
@@ -55,37 +55,35 @@ export const BEDROCK_MODELS = [
 
 export const DEFAULT_NODE_LLM_CONFIG = {
   generate_queries: DEFAULT_MODEL,
+  search_paper_titles_from_qdrant: DEFAULT_MODEL,
   search_arxiv_id_from_title: DEFAULT_MODEL,
   summarize_paper: DEFAULT_MODEL,
   extract_github_url_from_text: DEFAULT_MODEL,
-  extract_experimental_info: DEFAULT_MODEL,
+  select_experimental_files: DEFAULT_MODEL,
   extract_reference_titles: DEFAULT_MODEL,
   generate_hypothesis: DEFAULT_MODEL,
   evaluate_novelty_and_significance: DEFAULT_MODEL,
   refine_hypothesis: DEFAULT_MODEL,
   generate_experimental_design: DEFAULT_MODEL,
+  dispatch_code_generation: REASONING_MODEL,
+  dispatch_experiment_validation: GITHUB_ACTIONS_MODEL,
   analyze_experiment: DEFAULT_MODEL,
   write_paper: DEFAULT_MODEL,
   refine_paper: DEFAULT_MODEL,
   convert_to_latex: DEFAULT_MODEL,
-
-  generate_run_config: REASONING_MODEL,
-  generate_experiment_code: REASONING_MODEL,
-  validate_experiment_code: REASONING_MODEL,
-
   compile_latex: GITHUB_ACTIONS_MODEL,
-  dispatch_trial_experiment: GITHUB_ACTIONS_MODEL,
-  dispatch_full_experiments: GITHUB_ACTIONS_MODEL,
-  dispatch_evaluation: GITHUB_ACTIONS_MODEL,
 } as const;
 
 export const SUBGRAPH_NODE_CONFIGS = {
   generate_queries: [{ key: "generate_queries", label: "クエリ生成" }],
+  search_paper_titles_from_qdrant: [
+    { key: "search_paper_titles_from_qdrant", label: "Qdrant論文検索" },
+  ],
   retrieve_paper: [
     { key: "search_arxiv_id_from_title", label: "ArXiv ID検索" },
     { key: "summarize_paper", label: "論文要約" },
     { key: "extract_github_url_from_text", label: "GitHub URL抽出" },
-    { key: "extract_experimental_info", label: "実験情報抽出" },
+    { key: "select_experimental_files", label: "実験ファイル選択" },
     { key: "extract_reference_titles", label: "参考文献抽出" },
   ],
   generate_hypothesis: [
@@ -96,10 +94,9 @@ export const SUBGRAPH_NODE_CONFIGS = {
   generate_experimental_design: [
     { key: "generate_experimental_design", label: "実験デザイン生成" },
   ],
-  generate_code: [
-    { key: "generate_run_config", label: "実行設定生成" },
-    { key: "generate_experiment_code", label: "実験コード生成" },
-    { key: "validate_experiment_code", label: "コード検証" },
+  dispatch_code_generation: [{ key: "dispatch_code_generation", label: "コード生成ディスパッチ" }],
+  dispatch_experiment_validation: [
+    { key: "dispatch_experiment_validation", label: "実験バリデーション" },
   ],
   analyze_experiment: [{ key: "analyze_experiment", label: "実験分析" }],
   write: [
@@ -108,22 +105,18 @@ export const SUBGRAPH_NODE_CONFIGS = {
   ],
   generate_latex: [{ key: "convert_to_latex", label: "LaTeX変換" }],
   compile_latex: [{ key: "compile_latex", label: "LaTeXコンパイル" }],
-  execute_trial_experiment: [{ key: "dispatch_trial_experiment", label: "試行実験実行" }],
-  execute_full_experiment: [{ key: "dispatch_full_experiments", label: "本実験実行" }],
-  execute_evaluation: [{ key: "dispatch_evaluation", label: "評価実行" }],
 } as const;
 
 export const SUBGRAPH_DISPLAY_CONFIG = [
   { key: "generate_queries", title: "1. クエリ生成" },
-  { key: "retrieve_paper", title: "2. 論文取得" },
-  { key: "generate_hypothesis", title: "3. 仮説生成" },
-  { key: "generate_experimental_design", title: "4. 実験デザイン生成" },
-  { key: "generate_code", title: "5. コード生成" },
-  { key: "execute_trial_experiment", title: "6. 試行実験実行" },
-  { key: "execute_full_experiment", title: "7. 本実験実行" },
-  { key: "execute_evaluation", title: "8. 評価実行" },
-  { key: "analyze_experiment", title: "9. 実験分析" },
-  { key: "write", title: "10. 論文執筆" },
-  { key: "generate_latex", title: "11. LaTeX生成" },
-  { key: "compile_latex", title: "12. LaTeXコンパイル" },
+  { key: "search_paper_titles_from_qdrant", title: "2. Qdrant論文検索" },
+  { key: "retrieve_paper", title: "3. 論文取得" },
+  { key: "generate_hypothesis", title: "4. 仮説生成" },
+  { key: "generate_experimental_design", title: "5. 実験デザイン生成" },
+  { key: "dispatch_code_generation", title: "6. コード生成" },
+  { key: "dispatch_experiment_validation", title: "7. 実験バリデーション" },
+  { key: "analyze_experiment", title: "8. 実験分析" },
+  { key: "write", title: "9. 論文執筆" },
+  { key: "generate_latex", title: "10. LaTeX生成" },
+  { key: "compile_latex", title: "11. LaTeXコンパイル" },
 ] as const;

--- a/frontend/src/components/pages/autonomous-research/index.tsx
+++ b/frontend/src/components/pages/autonomous-research/index.tsx
@@ -152,7 +152,6 @@ export function AutonomousResearchPage({
       num_experiment_models: toNumber(autoNumExperimentModels),
       num_experiment_datasets: toNumber(autoNumExperimentDatasets),
       num_comparison_methods: toNumber(autoNumComparativeMethods),
-      experiment_code_validation_iterations: toNumber(autoExperimentCodeValidationIterations),
       paper_content_refinement_iterations: toNumber(autoPaperContentRefinementIterations),
       latex_template_name: autoLatexTemplateName.trim() || undefined,
       llm_mapping: llmMapping,


### PR DESCRIPTION
## 概要
- `SUBGRAPH_NODE_CONFIGS` と `SUBGRAPH_DISPLAY_CONFIG` のキーを API 型 `TopicOpenEndedResearchSubgraphLLMMapping` に合わせて修正（`generate_code` → `dispatch_code_generation`、`execute_*` → `dispatch_experiment_validation` 等）
- `retrieve_paper` のノードキーを変更: `extract_experimental_info` → `select_experimental_files`
- `search_paper_titles_from_qdrant` サブグラフ設定を追加
- API 型 `TopicOpenEndedResearchRequestBody` から削除された `experiment_code_validation_iterations` をリクエストペイロードから除去

## テスト計画
- [x] `tsc --noEmit` エラーなし
- [x] `npm run build` 成功
- [x] ブラウザでLLM設定UIが正しく表示されることを確認

🤖 [Claude Code](https://claude.com/claude-code) で生成