### PR TITLE
Fix deploy workflows: move env block to job level for environment vars

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -16,14 +16,15 @@ permissions:
   id-token: write
   contents: read
 
-env:
-  AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-1' }}
-
 jobs:
   deploy:
     name: Build & Deploy Backend
     runs-on: ubuntu-latest
     environment: dev
+
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-1' }}
+      ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY || 'airas-backend' }}
 
     steps:
       - name: Checkout
@@ -46,8 +47,8 @@ jobs:
           context: ./backend
           push: true
           tags: |
-            ${{ steps.ecr-login.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ github.sha }}
-            ${{ steps.ecr-login.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:latest
+            ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+            ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
 
       - name: Render Amazon ECS task definition
         id: render-task-def
@@ -55,7 +56,7 @@ jobs:
         with:
           task-definition: .aws/task-definition.json
           container-name: ${{ vars.ECS_CONTAINER_NAME }}
-          image: ${{ steps.ecr-login.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ github.sha }}
+          image: ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
 
       - name: Deploy to Amazon ECS
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -16,14 +16,14 @@ permissions:
   id-token: write
   contents: read
 
-env:
-  AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-1' }}
-
 jobs:
   deploy:
     name: Build & Deploy Frontend
     runs-on: ubuntu-latest
     environment: dev
+
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-1' }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- デプロイワークフロー（backend/frontend）の `env` ブロックをワークフローレベルからジョブレベルに移動
- `environment: dev` の変数（`vars.ECR_REPOSITORY` 等）が正しく解決されるよう修正
- Dockerタグの `invalid reference format` エラーを解消

## Root Cause
`env` ブロックがワークフローレベルに定義されていたため、`vars` コンテキストが `environment: dev` の変数を参照できず、`ECR_REPOSITORY` が空になっていた。結果としてDockerタグが `...amazonaws.com/:sha` という不正な形式になりビルドが失敗していた。

## Changes
- `deploy-backend.yml`: `env` ブロックをジョブレベルに移動、`ECR_REPOSITORY` の参照を `vars` から `env` に統一
- `deploy-frontend.yml`: 同様に `env` ブロックをジョブレベルに移動（予防的修正）

## Test plan
- [ ] `deploy-backend.yml` ワークフローを `workflow_dispatch` で手動実行し、Dockerイメージが正しいタグでビルド・プッシュされることを確認
- [ ] `deploy-frontend.yml` ワークフローを手動実行し、正常にデプロイされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)