### PR TITLE
Fix S3 bucket name empty error in frontend deploy workflow

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -24,6 +24,7 @@ jobs:
 
     env:
       AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-1' }}
+      S3_BUCKET: ${{ vars.S3_BUCKET || 'airas-dev-frontend' }}
 
     steps:
       - name: Checkout
@@ -53,8 +54,15 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Validate required variables
+        run: |
+          if [ -z "${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}" ]; then
+            echo "::error::CLOUDFRONT_DISTRIBUTION_ID is not set in environment variables"
+            exit 1
+          fi
+
       - name: Deploy to S3
-        run: aws s3 sync frontend/dist/ s3://${{ vars.S3_BUCKET }} --delete
+        run: aws s3 sync frontend/dist/ s3://${{ env.S3_BUCKET }} --delete
 
       - name: Invalidate CloudFront cache
         run: |


### PR DESCRIPTION
## Summary
- `vars.S3_BUCKET` が未設定時に `s3://` だけが渡されデプロイが失敗する問題を修正
- Terraform の命名規則 (`airas-dev-frontend`) に基づくデフォルト値を追加
- `CLOUDFRONT_DISTRIBUTION_ID` 未設定時に明確なエラーメッセージで早期失敗するバリデーションを追加

## Test plan
- [x] `vars.S3_BUCKET` 未設定時にデフォルト値 `airas-dev-frontend` が使用されることを確認
- [x] `vars.CLOUDFRONT_DISTRIBUTION_ID` 未設定時にバリデーションステップで失敗することを確認
- [x] `vars.S3_BUCKET` 設定時にその値が優先されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)