### PR TITLE
remove claudes permissions from the project rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,19 +2,6 @@
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
-  "permissions": {
-    "allow": [
-      "Write",
-      "Edit",
-      "Bash",
-      "mcp__serena__*"
-    ],
-    "deny": [
-      "Bash(rm -rf:*)",
-      "Bash(sudo:*)",
-      "Bash(git push --force:*)"
-    ]
-  },
   "enabledPlugins": {
     "claude-mem@thedotmack": true,
     "superpowers@claude-plugins-official": true


### PR DESCRIPTION

## 概要

`.claude/settings.json` ファイルからClaudeのパーミッション設定を削除しました。

## 変更内容

### 削除された設定

`permissions` セクションを完全に削除しました。以下の設定が対象です：

- **許可（Allow）**
  - Write
  - Edit
  - Bash
  - mcp__serena__*

- **拒否（Deny）**
  - Bash(rm -rf:*)
  - Bash(sudo:*)
  - Bash(git push --force:*)

## 変更ファイル

- `.claude/settings.json`: パーミッション設定セクションの削除（13行削除）

## 理由

プロジェクトルールからClaudeのパーミッション制限を削除し、より柔軟な設定構成を実現しました。