### PR TITLE
fix: ECRイメージタグを:latestからブランチ名ベースに変更

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -46,6 +46,10 @@ jobs:
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Sanitize branch name for Docker tag
+        id: sanitize
+        run: echo "tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -53,7 +57,7 @@ jobs:
           push: true
           tags: |
             ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
-            ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.ref_name }}
+            ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ steps.sanitize.outputs.tag }}
 
       - name: Fetch current task definition from ECS
         run: |


### PR DESCRIPTION
## 概要

dev/prodで`:latest`タグが上書きされる問題を防ぐため、ECRイメージタグをブランチ名ベース（`github.ref_name`）に変更する。

- Issue：マルチ環境デプロイ時のECRタグ競合

## 変更内容

- 変更点1：`.github/workflows/deploy-backend.yml`のイメージタグ変更
  - `:latest` → `:${{ github.ref_name }}`（develop / main）
  - これにより`airas-backend:develop`と`airas-backend:main`が共存し、環境間でのタグ上書きが発生しなくなる

## 確認項目

- [x] developブランチへのpushで`airas-backend:develop`タグが付与されること
- [x] mainブランチへのpushで`airas-backend:main`タグが付与されること
- [x] デプロイが正常に完了すること