### PR TITLE
fix: #706マージによるフロントエンドLLMMapping型・構造のずれを修正

### DIFF
--- a/frontend/src/components/features/llm-config/constants.ts
+++ b/frontend/src/components/features/llm-config/constants.ts
@@ -107,6 +107,17 @@ export const SUBGRAPH_NODE_CONFIGS = {
   compile_latex: [{ key: "compile_latex", label: "LaTeXコンパイル" }],
 } as const;
 
+/**
+ * Mapping from display subgraph key to actual nested path in TopicOpenEndedResearchLLMMapping.
+ * After #706, `dispatch_code_generation` is nested under `code_generation`,
+ * and `generate_latex`/`compile_latex` are nested under `latex`.
+ */
+export const NESTED_SUBGRAPH_PATHS: Record<string, { topKey: string; nestedKey: string }> = {
+  dispatch_code_generation: { topKey: "code_generation", nestedKey: "dispatch_code_generation" },
+  generate_latex: { topKey: "latex", nestedKey: "generate_latex" },
+  compile_latex: { topKey: "latex", nestedKey: "compile_latex" },
+};
+
 export const SUBGRAPH_DISPLAY_CONFIG = [
   { key: "generate_queries", title: "1. クエリ生成" },
   { key: "search_paper_titles_from_qdrant", title: "2. Qdrant論文検索" },

--- a/frontend/src/components/pages/autonomous-research/index.tsx
+++ b/frontend/src/components/pages/autonomous-research/index.tsx
@@ -18,10 +18,10 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import {
   Status,
+  type TopicOpenEndedResearchLLMMapping,
   type TopicOpenEndedResearchRequestBody,
   TopicOpenEndedResearchService,
   type TopicOpenEndedResearchStatusResponseBody,
-  type TopicOpenEndedResearchSubgraphLLMMapping,
 } from "@/lib/api";
 import type { ResearchSection } from "@/types/research";
 import {
@@ -77,9 +77,7 @@ export function AutonomousResearchPage({
     useState("2");
   const [autoLatexTemplateName, setAutoLatexTemplateName] = useState("mdpi");
   // LLM設定
-  const [llmMapping, setLlmMapping] = useState<TopicOpenEndedResearchSubgraphLLMMapping | null>(
-    null,
-  );
+  const [llmMapping, setLlmMapping] = useState<TopicOpenEndedResearchLLMMapping | null>(null);
   const [autoStatus, setAutoStatus] = useState<TopicOpenEndedResearchStatusResponseBody | null>(
     null,
   );


### PR DESCRIPTION
## Summary
- PR #706 のマージにより、バックエンドの `TopicOpenEndedResearchLLMMapping` 型がリファクタリングされたが、フロントエンドのLLM設定UIが旧型名・旧構造のまま残っていた問題を修正
- 旧型名 `TopicOpenEndedResearchSubgraphLLMMapping` → 新型名 `TopicOpenEndedResearchLLMMapping` に更新
- ネスト構造の変更に対応: `dispatch_code_generation` → `code_generation.dispatch_code_generation`、`generate_latex`/`compile_latex` → `latex.generate_latex`/`latex.compile_latex`

## 変更ファイル
- `frontend/src/components/pages/autonomous-research/index.tsx` — 型名の修正
- `frontend/src/components/features/llm-config/all-llm-config.tsx` — 型名修正 + ネスト構造対応の読み書きロジック追加
- `frontend/src/components/features/llm-config/constants.ts` — `NESTED_SUBGRAPH_PATHS` マッピング追加

## Test plan
- [x] TypeScriptコンパイル (`tsc --noEmit`) パス確認済み
- [x] Biome lint/format パス確認済み
- [x] Autonomous Researchページの LLM設定UIでモデルの選択・変更が正しく動作すること
- [x] LLM設定がAPIリクエストに正しいネスト構造で含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)