### PR TITLE
fix: Runner説明の初期値をNVIDIA H200スペックに変更

### DIFF
--- a/frontend/src/components/pages/autonomous-research/index.tsx
+++ b/frontend/src/components/pages/autonomous-research/index.tsx
@@ -58,7 +58,9 @@ export function AutonomousResearchPage({
   const [autoRepoName, setAutoRepoName] = useState("");
   const [autoBranch, setAutoBranch] = useState("main");
   const [autoRunnerLabels, setAutoRunnerLabels] = useState("ubuntu-latest");
-  const [autoRunnerDescription, setAutoRunnerDescription] = useState("");
+  const [autoRunnerDescription, setAutoRunnerDescription] = useState(
+    "NVIDIA H200, VRAM: 140 GB, RAM: 240 GB",
+  );
   const [autoWandbEntity, setAutoWandbEntity] = useState("");
   const [autoWandbProject, setAutoWandbProject] = useState("");
   const [autoIsPrivate, setAutoIsPrivate] = useState(false);


### PR DESCRIPTION
## Summary
- Autonomous ResearchページのGitHub Actions Runners「説明」フィールドの初期値を空文字から `NVIDIA H200, VRAM: 140 GB, RAM: 240 GB` に変更

## Test plan
- [x] Autonomous Researchページを開き、Runner説明欄に初期値が表示されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)