### PR TITLE
feat: 全APIエンドポイントに認証を必須化

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -2,7 +2,7 @@ import os
 from contextlib import asynccontextmanager
 
 from dependency_injector import providers
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import SQLModel
 
@@ -11,6 +11,7 @@ from airas.container import Container
 from airas.usecases.autonomous_research.in_memory_e2e_research_service import (
     InMemoryE2EResearchService,
 )
+from api.ee.auth.dependencies import get_current_user_id
 from api.ee.settings import get_ee_settings
 from api.routes.v1 import (
     assisted_research,
@@ -82,22 +83,29 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.include_router(papers.router, prefix="/airas/v1")
-app.include_router(models.router, prefix="/airas/v1")
-app.include_router(datasets.router, prefix="/airas/v1")
-app.include_router(hypotheses.router, prefix="/airas/v1")
-app.include_router(experimental_settings.router, prefix="/airas/v1")
-app.include_router(experiments.router, prefix="/airas/v1")
-app.include_router(code.router, prefix="/airas/v1")
-app.include_router(repositories.router, prefix="/airas/v1")
-app.include_router(bibfile.router, prefix="/airas/v1")
-app.include_router(latex.router, prefix="/airas/v1")
-app.include_router(research_history.router, prefix="/airas/v1")
-app.include_router(github_actions.router, prefix="/airas/v1")
-app.include_router(github.router, prefix="/airas/v1")
-app.include_router(assisted_research.router, prefix="/airas/v1")
-app.include_router(topic_open_ended_research.router, prefix="/airas/v1")
-app.include_router(hypothesis_driven_research.router, prefix="/airas/v1")
+auth_deps = [Depends(get_current_user_id)]
+app.include_router(papers.router, prefix="/airas/v1", dependencies=auth_deps)
+app.include_router(models.router, prefix="/airas/v1", dependencies=auth_deps)
+app.include_router(datasets.router, prefix="/airas/v1", dependencies=auth_deps)
+app.include_router(hypotheses.router, prefix="/airas/v1", dependencies=auth_deps)
+app.include_router(
+    experimental_settings.router, prefix="/airas/v1", dependencies=auth_deps
+)
+app.include_router(experiments.router, prefix="/airas/v1", dependencies=auth_deps)
+app.include_router(code.router, prefix="/airas/v1", dependencies=auth_deps)
+app.include_router(repositories.router, prefix="/airas/v1", dependencies=auth_deps)
+app.include_router(bibfile.router, prefix="/airas/v1", dependencies=auth_deps)
+app.include_router(latex.router, prefix="/airas/v1", dependencies=auth_deps)
+app.include_router(research_history.router, prefix="/airas/v1", dependencies=auth_deps)
+app.include_router(github_actions.router, prefix="/airas/v1", dependencies=auth_deps)
+app.include_router(github.router, prefix="/airas/v1", dependencies=auth_deps)
+app.include_router(assisted_research.router, prefix="/airas/v1", dependencies=auth_deps)
+app.include_router(
+    topic_open_ended_research.router, prefix="/airas/v1", dependencies=auth_deps
+)
+app.include_router(
+    hypothesis_driven_research.router, prefix="/airas/v1", dependencies=auth_deps
+)
 
 # Register EE routes if enterprise is enabled
 _ee_settings = get_ee_settings()


### PR DESCRIPTION
## Summary
- 全 `/airas/v1/*` エンドポイントにJWT認証を必須化
- `ENTERPRISE_ENABLED=true` (本番) → 未認証リクエストは `401 Unauthorized`
- `ENTERPRISE_ENABLED=false` (ローカル開発) → 従来通り認証なしで動作
- `/health` は認証不要のまま

## 変更内容
- `backend/api/main.py`: 各ルーターの `include_router` に `dependencies=[Depends(get_current_user_id)]` を追加

## Test plan
- [x] `ENTERPRISE_ENABLED=true` で未認証リクエストが `401` を返すこと
- [x] `ENTERPRISE_ENABLED=true` で有効なJWTトークン付きリクエストが正常に動作すること
- [x] `ENTERPRISE_ENABLED=false` で認証なしリクエストが従来通り動作すること
- [x] `/health` が認証なしでアクセス可能なこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)