### PR TITLE
fix: App.tsxの未使用importを削除しビルドエラーを修正

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,8 +2,7 @@
 
 import { SiDiscord, SiGithub, SiX } from "@icons-pack/react-simple-icons";
 import axios from "axios";
-import { ChevronDown, ChevronRight, UserCircle } from "lucide-react";
-import { FileText, Github, X as XIcon } from "lucide-react";
+import { ChevronDown, ChevronRight, FileText, UserCircle } from "lucide-react";
 
 import { useCallback, useEffect, useState } from "react";
 import {

--- a/frontend/src/ee/auth/components/AuthGuard.tsx
+++ b/frontend/src/ee/auth/components/AuthGuard.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
+import { LoadingSpinner } from "@/ee/auth/components/LoadingSpinner";
 import { LoginPage } from "@/ee/auth/components/LoginPage";
 import { useSession } from "@/ee/auth/hooks/useSession";
-import { LoadingSpinner } from "@/ee/auth/components/LoadingSpinner";
 
 export function AuthGuard({ children }: { children: ReactNode }) {
   const { session, loading } = useSession();

--- a/frontend/src/ee/auth/components/LoadingSpinner.tsx
+++ b/frontend/src/ee/auth/components/LoadingSpinner.tsx
@@ -12,14 +12,7 @@ export function LoadingSpinner({ className = "h-5 w-5" }: LoadingSpinnerProps) {
       role="img"
       aria-label="Loading"
     >
-      <circle
-        className="opacity-25"
-        cx="12"
-        cy="12"
-        r="10"
-        stroke="currentColor"
-        strokeWidth="4"
-      />
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
       <path
         className="opacity-75"
         fill="currentColor"

--- a/frontend/src/ee/auth/components/LoginPage.tsx
+++ b/frontend/src/ee/auth/components/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { useAuth } from "@/ee/auth/hooks/useAuth";
 import { LoadingSpinner } from "@/ee/auth/components/LoadingSpinner";
+import { useAuth } from "@/ee/auth/hooks/useAuth";
 
 type SignInProvider = "google" | "github" | null;
 


### PR DESCRIPTION
## Summary
- `App.tsx` の未使用import（`Github`, `XIcon`）を削除し、TypeScriptビルドエラー（TS6133）を修正
- biomeによるフォーマット修正（EE auth コンポーネント）

## Test plan
- [ ] `npm run build` がエラーなく完了すること
- [ ] Vercelデプロイが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)