### PR TITLE
fix: CLA allowlistのbot名パターンを修正

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -32,10 +32,9 @@ jobs:
           allowlist: |
             fuyu-quant
             wkumagai
-            dependabot[bot]
-            dependabot
-            github-actions[bot]
-            github-actions
+            dependabot*
+            github-actions*
+            claude*
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION
## Summary
- `dependabot[bot]` や `claude[bot]` の `[bot]` がregexの文字クラスとして解釈され、CLAチェックが失敗していた問題を修正
- ワイルドカードパターン（`dependabot*`, `claude*`, `github-actions*`）に変更
- 重複エントリを整理

## Test plan
- [x] dependabotのPR（#751等）で `recheck` コメントしてCLAチェックがパスすること
- [x] claudeがauthorのPRでCLAチェックがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)