### PR TITLE
fix: CLA allowlistをカンマ区切り形式に修正

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,12 +29,7 @@ jobs:
           path-to-document: 'https://github.com/cla-assistant/github-action/blob/master/SAPCLA.md' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'cla-signatures'
-          allowlist: |
-            fuyu-quant
-            wkumagai
-            dependabot*
-            github-actions*
-            claude*
+          allowlist: 'fuyu-quant,wkumagai,dependabot[bot],dependabot,github-actions[bot],github-actions,claude,claude[bot]'
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION
## Summary
- CLA allowlistをYAML multiline形式からカンマ区切り文字列に修正
- 公式ドキュメントの推奨形式（`dependabot[bot],claude[bot],...`）に合わせる

## Test plan
- [ ] マージ後、dependabotのPRで `recheck` コメントしてCLAチェックがパスすること
- [ ] claudeがauthorのPRでCLAチェックがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)