### PR TITLE
feat: Swagger UIにAuthorizeボタンを追加

### DIFF
--- a/backend/api/ee/auth/dependencies.py
+++ b/backend/api/ee/auth/dependencies.py
@@ -1,14 +1,22 @@
 from uuid import UUID
 
-from fastapi import Request
+from fastapi import Depends, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from api.ee.auth.middleware import extract_user_id_from_request
 from api.ee.settings import get_ee_settings
 
 SYSTEM_USER_ID = UUID("00000000-0000-0000-0000-000000000001")
 
+# Show "Authorize" button in Swagger UI when EE is enabled
+_bearer_scheme = HTTPBearer(auto_error=False)
+_bearer_dependency = Depends(_bearer_scheme)
 
-def get_current_user_id(request: Request) -> UUID:
+
+def get_current_user_id(
+    request: Request,
+    _credentials: HTTPAuthorizationCredentials | None = _bearer_dependency,
+) -> UUID:
     """Return user ID from JWT if EE is enabled, otherwise return SYSTEM_USER_ID."""
     settings = get_ee_settings()
     if not settings.enabled:

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -38,6 +38,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/papers/retrieval:
     post:
       tags:
@@ -63,6 +65,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/papers/generations:
     post:
       tags:
@@ -88,6 +92,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/models:
     post:
       tags:
@@ -113,6 +119,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/datasets:
     post:
       tags:
@@ -138,6 +146,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/hypotheses/generations:
     post:
       tags:
@@ -163,6 +173,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/experimental_settings/generations:
     post:
       tags:
@@ -188,6 +200,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/experiments/run-ids:
     post:
       tags:
@@ -213,6 +227,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/experiments/results:
     post:
       tags:
@@ -238,6 +254,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/experiments/sanity-checks/dispatch:
     post:
       tags:
@@ -263,6 +281,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/experiments/validations/dispatch:
     post:
       tags:
@@ -288,6 +308,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/experiments/main-runs/dispatch:
     post:
       tags:
@@ -313,6 +335,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/experiments/visualizations/dispatch:
     post:
       tags:
@@ -338,6 +362,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/experiments/analyses:
     post:
       tags:
@@ -363,6 +389,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/code/generations/dispatch:
     post:
       tags:
@@ -388,6 +416,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/code/fetch:
     post:
       tags:
@@ -413,6 +443,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/repositories:
     post:
       tags:
@@ -438,6 +470,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/bibfile/generations:
     post:
       tags:
@@ -463,6 +497,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/latex/generations:
     post:
       tags:
@@ -488,6 +524,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/latex/push:
     post:
       tags:
@@ -513,6 +551,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/latex/compile:
     post:
       tags:
@@ -538,6 +578,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/research-history/download:
     post:
       tags:
@@ -563,6 +605,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/research-history/upload:
     post:
       tags:
@@ -588,6 +632,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/github-actions/polling:
     post:
       tags:
@@ -613,6 +659,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/github-actions/secrets:
     post:
       tags:
@@ -638,6 +686,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/github-actions/artifacts/download:
     post:
       tags:
@@ -663,6 +713,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/github/push:
     post:
       tags:
@@ -688,6 +740,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/assisted_research/session:
     post:
       tags:
@@ -713,12 +767,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/assisted_research/session/{session_id}:
     get:
       tags:
       - assisted_research
       summary: Get Session
       operationId: get_session_airas_v1_assisted_research_session__session_id__get
+      security:
+      - HTTPBearer: []
       parameters:
       - name: session_id
         in: path
@@ -765,12 +823,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/assisted_research/step/{step_id}:
     get:
       tags:
       - assisted_research
       summary: Get Step
       operationId: get_step_airas_v1_assisted_research_step__step_id__get
+      security:
+      - HTTPBearer: []
       parameters:
       - name: step_id
         in: path
@@ -817,12 +879,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/assisted_research/link/{from_step_id}:
     get:
       tags:
       - assisted_research
       summary: Get Link
       operationId: get_link_airas_v1_assisted_research_link__from_step_id__get
+      security:
+      - HTTPBearer: []
       parameters:
       - name: from_step_id
         in: path
@@ -869,12 +935,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/topic_open_ended_research/status/{task_id}:
     get:
       tags:
       - topic_open_ended_research
       summary: Get Topic Open Ended Research Status
       operationId: get_topic_open_ended_research_status_airas_v1_topic_open_ended_research_status__task_id__get
+      security:
+      - HTTPBearer: []
       parameters:
       - name: task_id
         in: path
@@ -902,6 +972,8 @@ paths:
       - topic_open_ended_research
       summary: List Topic Open Ended Research
       operationId: list_topic_open_ended_research_airas_v1_topic_open_ended_research_get
+      security:
+      - HTTPBearer: []
       parameters:
       - name: offset
         in: query
@@ -937,6 +1009,8 @@ paths:
       - topic_open_ended_research
       summary: Update Topic Open Ended Research
       operationId: update_topic_open_ended_research_airas_v1_topic_open_ended_research__task_id__patch
+      security:
+      - HTTPBearer: []
       parameters:
       - name: task_id
         in: path
@@ -989,12 +1063,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /airas/v1/hypothesis_driven_research/status/{task_id}:
     get:
       tags:
       - hypothesis_driven_research
       summary: Get Hypothesis Driven Research Status
       operationId: get_hypothesis_driven_research_status_airas_v1_hypothesis_driven_research_status__task_id__get
+      security:
+      - HTTPBearer: []
       parameters:
       - name: task_id
         in: path
@@ -1022,6 +1100,8 @@ paths:
       - hypothesis_driven_research
       summary: List Hypothesis Driven Research
       operationId: list_hypothesis_driven_research_airas_v1_hypothesis_driven_research_get
+      security:
+      - HTTPBearer: []
       parameters:
       - name: offset
         in: query
@@ -1057,6 +1137,8 @@ paths:
       - hypothesis_driven_research
       summary: Update Hypothesis Driven Research
       operationId: update_hypothesis_driven_research_airas_v1_hypothesis_driven_research__task_id__patch
+      security:
+      - HTTPBearer: []
       parameters:
       - name: task_id
         in: path
@@ -4166,3 +4248,7 @@ components:
       - paper_content
       - execution_time
       title: WriteSubgraphResponseBody
+  securitySchemes:
+    HTTPBearer:
+      type: http
+      scheme: bearer


### PR DESCRIPTION
## Summary
- Swagger UI（`/docs`）に「Authorize」ボタンを追加
- Bearer トークンを入力して、認証付きAPIを直接テスト可能に

## Changes

| File | Change |
|------|--------|
| `backend/api/ee/auth/dependencies.py` | `HTTPBearer`スキームを追加し、Swagger UIで認証ボタンを表示 |

## 使い方
1. `/docs` にアクセス
2. 右上の「Authorize」ボタンをクリック
3. Supabaseのアクセストークンを入力
4. APIを直接実行してテスト

## Test plan
- [ ] `/docs` にAuthorizeボタンが表示されること
- [ ] トークン入力後、認証付きAPIが実行できること
- [ ] EE無効時は認証なしでAPIが実行できること（既存動作に影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)