### PR TITLE
debug: JWT検証にalgヘッダーのログを追加

### DIFF
--- a/backend/api/ee/auth/middleware.py
+++ b/backend/api/ee/auth/middleware.py
@@ -36,6 +36,7 @@ def verify_jwt(token: str) -> dict:
     try:
         header = jwt.get_unverified_header(token)
         alg = header.get("alg", "")
+        logger.info("JWT header alg=%s kid=%s", alg, header.get("kid", "N/A"))
 
         if alg == "HS256":
             if not settings.supabase_jwt_secret:


### PR DESCRIPTION
## Summary
- JWT検証時にトークンヘッダーの `alg` と `kid` をログ出力するように追加
- デプロイ反映の確認と、実際のトークンのアルゴリズム特定が目的
- 問題解決後に削除予定の一時的なログ

## Background
`fix/jwt-dual-algorithm-support` をマージ後も `InvalidAlgorithmError` が継続しているため、以下を切り分ける:
1. デプロイが反映されていない
2. トークンの `alg` が HS256/ES256 以外

🤖 Generated with [Claude Code](https://claude.com/claude-code)