### PR TITLE
fix: GitHub Actions Runnersのデフォルト値をubuntu-latestに変更

### DIFF
--- a/frontend/src/components/pages/autonomous-research/index.tsx
+++ b/frontend/src/components/pages/autonomous-research/index.tsx
@@ -59,10 +59,8 @@ export function AutonomousResearchPage({
   const [autoGithubOwner, setAutoGithubOwner] = useState("auto-res2");
   const [autoRepoName, setAutoRepoName] = useState("");
   const [autoBranch, setAutoBranch] = useState("main");
-  const [autoRunnerLabels, setAutoRunnerLabels] = useState("self-hosted,gpu-runner");
-  const [autoRunnerDescription, setAutoRunnerDescription] = useState(
-    "NVIDIA H200, VRAM: 140 GB, RAM: 240 GB",
-  );
+  const [autoRunnerLabels, setAutoRunnerLabels] = useState("ubuntu-latest");
+  const [autoRunnerDescription, setAutoRunnerDescription] = useState("CPU: 4 vCPU, RAM: 16 GB");
   const [autoWandbEntity, setAutoWandbEntity] = useState("airas");
   const [autoWandbProject, setAutoWandbProject] = useState("");
   const [autoIsPrivate, setAutoIsPrivate] = useState(false);


### PR DESCRIPTION
## 概要

自律研究フォームのGitHub Actions Runnersのデフォルト値を汎用的な設定に変更。

- Issue：なし

## 変更内容

- 変更点1：ラベルのデフォルト値を変更
  - `self-hosted,gpu-runner` → `ubuntu-latest`
- 変更点2：説明のデフォルト値を変更
  - `NVIDIA H200, VRAM: 140 GB, RAM: 240 GB` → `CPU: 4 vCPU, RAM: 16 GB`

## 確認項目

- [x] 自律研究フォームのGitHub Actions Runnersのラベルが「ubuntu-latest」になっていること
- [x] 説明が「CPU: 4 vCPU, RAM: 16 GB」になっていること