### PR TITLE
feat: UserMenuにアクセストークンコピー機能を追加

### DIFF
--- a/frontend/src/ee/auth/components/UserMenu.tsx
+++ b/frontend/src/ee/auth/components/UserMenu.tsx
@@ -37,23 +37,25 @@ export function UserMenu() {
           <div className="px-3 py-2 text-xs text-muted-foreground border-b border-border truncate">
             {session.user.email ?? ""}
           </div>
-          <button
-            type="button"
-            onClick={async () => {
-              const {
-                data: { session: s },
-              } = await supabase.auth.getSession();
-              if (s?.access_token) {
-                await navigator.clipboard.writeText(s.access_token);
-                setCopied(true);
-                setTimeout(() => setCopied(false), 2000);
-              }
-            }}
-            className="flex w-full items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-muted/60 transition-colors"
-          >
-            <Copy className="h-4 w-4" />
-            {copied ? "Copied!" : "Copy Access Token"}
-          </button>
+          {import.meta.env.DEV && (
+            <button
+              type="button"
+              onClick={async () => {
+                const {
+                  data: { session: s },
+                } = await supabase.auth.getSession();
+                if (s?.access_token) {
+                  await navigator.clipboard.writeText(s.access_token);
+                  setCopied(true);
+                  setTimeout(() => setCopied(false), 2000);
+                }
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-muted/60 transition-colors"
+            >
+              <Copy className="h-4 w-4" />
+              {copied ? "Copied!" : "Copy Access Token"}
+            </button>
+          )}
           <button
             type="button"
             onClick={() => {


### PR DESCRIPTION
## 概要

UserMenuドロップダウンにアクセストークンをクリップボードにコピーするボタンを追加。開発・デバッグ時にAPIトークンを簡単に取得できるようにする。

- Issue：なし

## 変更内容

- 変更点1：「Copy Access Token」ボタンの追加
  - UserMenuのドロップダウンメニューにアクセストークンコピーボタンを追加
  - Supabaseセッションから最新のアクセストークンを取得し、クリップボードにコピー
  - コピー成功時に2秒間「Copied!」と表示するフィードバック

## 確認項目

- [ ] UserMenuのドロップダウンに「Copy Access Token」ボタンが表示される
- [ ] ボタンクリックでアクセストークンがクリップボードにコピーされる
- [ ] コピー後「Copied!」が2秒間表示され、元に戻る