### PR TITLE
fix: Cloudflareトンネル経由のCORSエラーを修正

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -82,7 +82,7 @@ app.add_middleware(
         "http://localhost:5173",
         "http://127.0.0.1:5173",
     ],
-    allow_origin_regex=r"https://airas.*\.vercel\.app",
+    allow_origin_regex=r"https://(airas.*\.vercel\.app|.*\.trycloudflare\.com)",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,9 @@ import { defineConfig } from "vite";
 export default defineConfig({
   envDir: path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."),
   plugins: [react()],
+  server: {
+    allowedHosts: [".trycloudflare.com"],
+  },
   resolve: {
     alias: {
       "@": path.resolve(path.dirname(fileURLToPath(import.meta.url)), "./src"),


### PR DESCRIPTION
## Summary
- Cloudflareトンネル（`*.trycloudflare.com`）経由でフロントエンドからバックエンドAPIにアクセスした際、CORSプリフライト（OPTIONS）リクエストが400 Bad Requestで拒否される問題を修正
- バックエンドの`allow_origin_regex`に`*.trycloudflare.com`を追加
- フロントエンドのVite設定に`allowedHosts`として`.trycloudflare.com`を追加

## Test plan
- [ ] Cloudflareトンネル経由でフロントエンドにアクセスし、APIリクエストが正常に通ることを確認
- [ ] `curl -X OPTIONS` でプリフライトリクエストが200を返すことを確認
- [ ] localhost経由のアクセスが引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)