### PR TITLE
chore: CLAUDE.mdをリファクタリングしrulesディレクトリを追加

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,15 +1,10 @@
 # CLAUDE.md
 @.claude/CLAUDE.local.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+A web application for research automation. The frontend is built with React, the backend with FastAPI, and PostgreSQL is used as the database.
 
+# Module Structure
 
-## Testing
-
-- `backend/tests/http` - API request samples.
-
-## Code Quality
-
-- `make ruff` - Run Python linter, auto-fix, and formatter (backend/)
-- `make mypy` - Run Python type checking (backend/)
-- `make biome` - Run JavaScript/TypeScript linter and formatter (frontend/)
+- `backend/`: Backend code implemented in Python (FastAPI)
+- `frontend/`: Frontend code implemented in TypeScript + React (Vite)
+- `docs/`: Documentation site implemented in TypeScript (Docusaurus)

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -1,0 +1,5 @@
+## Code Quality
+
+- `make ruff` - Run Python linter, auto-fix, and formatter (backend/)
+- `make mypy` - Run Python type checking (backend/)
+- `make biome` - Run JavaScript/TypeScript linter and formatter (frontend/)

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,0 +1,3 @@
+# Code Style
+
+- Use 2-space indentation for all TypeScript files


### PR DESCRIPTION
# 概要
CLAUDE.mdのプロジェクト説明を更新し、コード品質・スタイルのルールを`.claude/rules/`ディレクトリに分離しました。

# 変更点

- CLAUDE.mdのプロジェクト説明とモジュール構成を更新
- コード品質ルール（ruff, mypy, biome）を`.claude/rules/code-quality.md`に分離
- コードスタイルルール（TypeScriptインデント）を`.claude/rules/code-style.md`に追加

# 確認項目

- [x] CLAUDE.mdのプロジェクト説明が正しいこと
- [x] rulesディレクトリのルールファイルが正しく配置されていること