### PR TITLE
feat: 検証一覧ページのUI改善

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,26 @@
 // frontend/src/App.tsx
 
 import { SiDiscord, SiGithub, SiX } from "@icons-pack/react-simple-icons";
+import * as SubframeCore from "@subframe/core";
+import {
+  FeatherBell,
+  FeatherChevronUp,
+  FeatherFileText,
+  FeatherHelpCircle,
+  FeatherHome,
+  FeatherKey,
+  FeatherList,
+  FeatherLogOut,
+  FeatherMessageSquare,
+  FeatherPanelLeftClose,
+  FeatherPanelLeftOpen,
+  FeatherPlus,
+  FeatherSearch,
+  FeatherSettings,
+  FeatherShield,
+  FeatherUser,
+} from "@subframe/core";
 import axios from "axios";
-import { ChevronDown, ChevronRight, FileText, UserCircle } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import {
   AUTONOMOUS_SUB_NAVS,
@@ -15,33 +33,18 @@ import {
   type AutonomousSectionsMap,
   useAutonomousResearchSessions,
 } from "@/components/pages/autonomous-research/use-autonomous-research-sessions";
-import { SectionsSidebar } from "@/components/sections-sidebar";
+import { OnboardingOverlay } from "@/components/pages/onboarding";
+import {
+  mockVerifications,
+  type ProposedMethod,
+  type Verification,
+} from "@/components/pages/verification";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { isEnterpriseEnabled } from "@/ee/config";
 import { OpenAPI } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import type { FeatureType, ResearchSection, WorkflowNode, WorkflowTree } from "@/types/research";
-
-const mockResearchSections: ResearchSection[] = [
-  {
-    id: "1",
-    title: "Untitled Research",
-    createdAt: new Date("2024-01-15"),
-    status: "in-progress",
-  },
-  {
-    id: "2",
-    title: "GAN-based Image Generation",
-    createdAt: new Date("2024-01-10"),
-    status: "completed",
-  },
-  {
-    id: "3",
-    title: "Reinforcement Learning Study",
-    createdAt: new Date("2024-01-05"),
-    status: "completed",
-  },
-];
+import { Avatar, DropdownMenu, IconButton, SidebarWithSections, TopbarWithRightNav } from "@/ui";
 
 const initialWorkflowTree: WorkflowTree = {
   nodes: {},
@@ -106,12 +109,6 @@ function useEEComponents() {
 export default function App() {
   const eeComponents = useEEComponents();
 
-  // Assisted Research
-  const [assistedSections, setAssistedSections] = useState<ResearchSection[]>(mockResearchSections);
-  const [activeAssistedSection, setActiveAssistedSection] = useState<ResearchSection | null>(
-    mockResearchSections[0],
-  );
-
   // Autonomous Research
   const [autonomousSectionsMap, setAutonomousSectionsMap] = useState<AutonomousSectionsMap>(
     initialAutonomousSectionsMap,
@@ -119,16 +116,27 @@ export default function App() {
   const [autonomousActiveSectionMap, setAutonomousActiveSectionMap] =
     useState<AutonomousActiveSectionMap>(initialAutonomousActiveSectionMap);
 
-  // Assisted Research workflow
-  const [activeFeature, setActiveFeature] = useState<string | null>(null);
+  // Workflow
   const [workflowTree, setWorkflowTree] = useState<WorkflowTree>(initialWorkflowTree);
   const [activeNodeId, setActiveNodeId] = useState<string | null>(null);
 
-  // Navigation
-  const [activeNav, setActiveNav] = useState<NavKey>("autonomous-research");
-  const [isAutonomousExpanded, setIsAutonomousExpanded] = useState(true);
+  // Verification
+  const [verifications, setVerifications] = useState<Verification[]>(mockVerifications);
+  const [activeVerificationId, setActiveVerificationId] = useState<string | null>(null);
+  const activeVerification = verifications.find((v) => v.id === activeVerificationId) ?? null;
+
+  // Navigation — check URL params for post-checkout redirect
+  const [activeNav, setActiveNav] = useState<NavKey>(() => {
+    const params = new URLSearchParams(window.location.search);
+    const nav = params.get("nav");
+    if (nav === "user-plan" || nav === "integration") return nav;
+    return "home";
+  });
   const [autonomousSubNav, setAutonomousSubNav] = useState<AutonomousSubNav>("topic-driven");
-  const [sessionsExpanded, setSessionsExpanded] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [showOnboarding, setShowOnboarding] = useState(() => {
+    return !localStorage.getItem("airas-onboarding-done");
+  });
 
   const { fetchSections } = useAutonomousResearchSessions({
     setAutonomousSectionsMap,
@@ -136,33 +144,98 @@ export default function App() {
   });
 
   const handleCreateSection = () => {
-    const newSection: ResearchSection = {
-      id: Date.now().toString(),
-      title: "Untitled Research",
-      createdAt: new Date(),
-      status: "in-progress",
-    };
     if (activeNav === "autonomous-research") {
       setAutonomousActiveSectionMap((prev) => ({ ...prev, [autonomousSubNav]: null }));
-    } else {
-      setAssistedSections([newSection, ...assistedSections]);
-      setActiveAssistedSection(newSection);
     }
     setWorkflowTree(initialWorkflowTree);
     setActiveNodeId(null);
-    setActiveFeature(null);
   };
 
-  const handleToggleSessions = useCallback(() => {
-    setSessionsExpanded((prev) => !prev);
+  const handleCreateVerification = useCallback(() => {
+    const newVerification: Verification = {
+      id: `v-${Date.now()}`,
+      title: "新規検証",
+      query: "",
+      createdAt: new Date(),
+      phase: "initial",
+    };
+    setVerifications((prev) => [newVerification, ...prev]);
+    setActiveVerificationId(newVerification.id);
+    setActiveNav("verification");
   }, []);
+
+  const handleSelectVerification = useCallback((id: string) => {
+    setActiveVerificationId(id);
+    setActiveNav("verification");
+  }, []);
+
+  const handleUpdateVerification = useCallback((id: string, updates: Partial<Verification>) => {
+    setVerifications((prev) => prev.map((v) => (v.id === id ? { ...v, ...updates } : v)));
+  }, []);
+
+  const handleDeleteVerification = useCallback(
+    (id: string) => {
+      setVerifications((prev) => prev.filter((v) => v.id !== id));
+      if (activeVerificationId === id) {
+        setActiveVerificationId(null);
+        setActiveNav("home");
+      }
+    },
+    [activeVerificationId],
+  );
+
+  const handleDuplicateVerification = useCallback((id: string) => {
+    setVerifications((prev) => {
+      const source = prev.find((v) => v.id === id);
+      if (!source) return prev;
+      const copy: Verification = {
+        ...source,
+        id: `v-${Date.now()}`,
+        title: `${source.title} (コピー)`,
+        createdAt: new Date(),
+      };
+      return [copy, ...prev];
+    });
+  }, []);
+
+  const handleCreateWithMethod = useCallback(
+    (sourceVerification: Verification, method: ProposedMethod) => {
+      const newId = `v-${Date.now()}`;
+      const newVerification: Verification = {
+        id: newId,
+        title: method.title,
+        query: sourceVerification.query,
+        createdAt: new Date(),
+        phase: "plan-generated",
+        proposedMethods: [method],
+        selectedMethodId: method.id,
+        plan: {
+          whatToVerify: method.whatToVerify,
+          method: method.method,
+        },
+      };
+      setVerifications((prev) => [newVerification, ...prev]);
+      setActiveVerificationId(newId);
+      setActiveNav("verification");
+    },
+    [],
+  );
+
+  const handleSelectAutonomousSession = useCallback(
+    (section: ResearchSection) => {
+      setAutonomousActiveSectionMap((prev) => ({
+        ...prev,
+        [autonomousSubNav]: section,
+      }));
+    },
+    [autonomousSubNav],
+  );
 
   const handleNavigate = useCallback(
     (nodeId: string) => {
       const node = workflowTree.nodes[nodeId];
       if (node) {
         setActiveNodeId(nodeId);
-        setActiveFeature(node.type);
       }
     },
     [workflowTree],
@@ -268,23 +341,13 @@ export default function App() {
           if (!current) return prev;
           return { ...prev, [autonomousSubNav]: { ...current, title } };
         });
-      } else {
-        if (!activeAssistedSection) return;
-        setAssistedSections((prev) =>
-          prev.map((s) => (s.id === activeAssistedSection.id ? { ...s, title } : s)),
-        );
-        setActiveAssistedSection((prev) => (prev ? { ...prev, title } : prev));
       }
     },
-    [activeNav, autonomousSubNav, autonomousActiveSectionMap, activeAssistedSection],
+    [activeNav, autonomousSubNav, autonomousActiveSectionMap],
   );
 
   const handleNavChange = useCallback((key: NavKey) => {
     setActiveNav(key);
-    if (key === "assisted-research") {
-      setWorkflowTree(initialWorkflowTree);
-      setActiveNodeId(null);
-    }
   }, []);
 
   // Handle OAuth callback route
@@ -300,228 +363,303 @@ export default function App() {
   }
 
   const appContent = (
-    <div className="flex min-h-screen flex-col bg-background">
-      <header className="h-12 border-b border-border bg-card px-4 flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <img src="/airas_logo.png" alt="AIRAS logo" className="h-8 w-auto" />
-          <p className="text-base font-semibold text-foreground leading-none">AIRAS</p>
-        </div>
-        <div className="flex items-center gap-4">
-          <a
-            href="https://github.com/airas-org/airas"
-            target="_blank"
-            rel="noreferrer"
-            className="text-muted-foreground hover:text-foreground transition-colors"
-            aria-label="GitHub"
-          >
-            <SiGithub className="h-6 w-6" />
-          </a>
-          <a
-            href="https://airas-org.github.io/airas/"
-            target="_blank"
-            rel="noreferrer"
-            className="text-muted-foreground hover:text-foreground transition-colors"
-            aria-label="Documentation"
-            title="Documentation"
-          >
-            <FileText className="h-6 w-6" />
-          </a>
-          <a
-            href="https://discord.gg/KGm5FGY5"
-            target="_blank"
-            rel="noreferrer"
-            className="text-muted-foreground hover:text-foreground transition-colors"
-            aria-label="Discord"
-          >
-            <SiDiscord className="h-6 w-6" />
-          </a>
-          <a
-            href="https://x.com/fuyu_quant"
-            target="_blank"
-            rel="noreferrer"
-            className="text-muted-foreground hover:text-foreground transition-colors"
-            aria-label="X"
-          >
-            <SiX className="h-6 w-6" />
-          </a>
-          {eeComponents ? (
-            <eeComponents.UserMenu />
-          ) : (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span aria-disabled="true" className="inline-flex">
-                    <button
-                      type="button"
-                      disabled
-                      className="flex items-center gap-2 rounded-md border border-border px-3 py-1.5 text-sm text-muted-foreground opacity-50 cursor-not-allowed"
-                    >
-                      <UserCircle className="h-5 w-5" />
-                      <span>Login</span>
-                    </button>
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Enterprise Edition is not enabled</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
-        </div>
-      </header>
-
-      <div className="flex flex-1">
-        <aside className="w-52 border-r border-border bg-card/60 flex-shrink-0 flex flex-col">
-          <div className="flex flex-col gap-1 p-3">
-            <button
-              type="button"
-              onClick={() => handleNavChange("assisted-research")}
-              className={cn(
-                "w-full px-3 py-1.5 text-left text-sm transition-colors border-l-2 cursor-pointer",
-                activeNav === "assisted-research"
-                  ? "text-foreground font-semibold border-blue-700"
-                  : "text-muted-foreground hover:text-foreground hover:bg-muted/40 border-transparent",
-              )}
-            >
-              Assisted Research
-            </button>
-            <button
-              type="button"
-              onClick={() => setIsAutonomousExpanded((prev) => !prev)}
-              aria-expanded={isAutonomousExpanded}
-              className={cn(
-                "w-full px-3 py-1.5 text-left text-sm transition-colors border-l-2 border-transparent flex items-center justify-between cursor-pointer",
-                activeNav === "autonomous-research"
-                  ? "text-foreground"
-                  : "text-muted-foreground hover:text-foreground hover:bg-muted/40",
-              )}
-            >
-              <span>Autonomous Research</span>
-              {isAutonomousExpanded ? (
-                <ChevronDown className="h-4 w-4 shrink-0" />
-              ) : (
-                <ChevronRight className="h-4 w-4 shrink-0" />
-              )}
-            </button>
-            <div
-              className={cn(
-                "grid transition-all duration-200 ease-in-out",
-                isAutonomousExpanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
-              )}
-            >
-              <div className="overflow-hidden flex flex-col gap-1">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setAutonomousSubNav("topic-driven");
-                    handleNavChange("autonomous-research");
-                  }}
-                  className={cn(
-                    "w-full pl-6 pr-3 py-1.5 text-left text-sm transition-colors border-l-2 hover:text-foreground hover:bg-muted/40 cursor-pointer",
-                    activeNav === "autonomous-research" && autonomousSubNav === "topic-driven"
-                      ? "text-foreground font-semibold border-blue-700"
-                      : "text-muted-foreground border-transparent",
-                  )}
-                >
-                  Topic-Driven
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setAutonomousSubNav("hypothesis-driven");
-                    handleNavChange("autonomous-research");
-                  }}
-                  className={cn(
-                    "w-full pl-6 pr-3 py-1.5 text-left text-sm transition-colors border-l-2 hover:text-foreground hover:bg-muted/40 cursor-pointer",
-                    activeNav === "autonomous-research" && autonomousSubNav === "hypothesis-driven"
-                      ? "text-foreground font-semibold border-blue-700"
-                      : "text-muted-foreground border-transparent",
-                  )}
-                >
-                  Hypothesis-Driven
-                </button>
+    <div className="flex min-h-screen bg-default-background">
+      <aside
+        className={cn(
+          "fixed left-0 top-0 h-screen z-30 bg-default-background transition-[width] duration-200 ease-in-out overflow-hidden",
+          sidebarOpen ? "w-52" : "w-0",
+        )}
+      >
+        <SidebarWithSections
+          className="min-w-[13rem]"
+          header={
+            <div className="flex w-full items-center justify-between">
+              <div className="flex items-center gap-3">
+                <img src="/airas_logo.png" alt="AIRAS logo" className="h-7 w-auto" />
+                <span className="text-heading-3 font-heading-3 text-default-font">AIRAS</span>
               </div>
-            </div>
-            <button
-              type="button"
-              onClick={() => handleNavChange("settings")}
-              className={cn(
-                "w-full px-3 py-1.5 text-left text-sm transition-colors border-l-2 cursor-pointer",
-                activeNav === "settings"
-                  ? "text-foreground font-semibold border-blue-700"
-                  : "text-muted-foreground hover:text-foreground hover:bg-muted/40 border-transparent",
-              )}
-            >
-              Settings
-            </button>
-          </div>
-        </aside>
-
-        {(activeNav === "assisted-research" || activeNav === "autonomous-research") && (
-          <div
-            className={cn(
-              "relative flex-shrink-0 h-full transition-[width] duration-200 ease-in-out",
-              sessionsExpanded ? "w-56" : "w-0",
-            )}
-          >
-            <div
-              className={cn(
-                "overflow-hidden transition-[width,opacity] duration-200 ease-in-out h-full",
-                sessionsExpanded ? "w-56 opacity-100" : "w-0 opacity-0",
-              )}
-            >
-              <SectionsSidebar
-                sections={
-                  activeNav === "autonomous-research"
-                    ? autonomousSectionsMap[autonomousSubNav]
-                    : assistedSections
-                }
-                activeSection={
-                  activeNav === "autonomous-research"
-                    ? autonomousActiveSectionMap[autonomousSubNav]
-                    : activeAssistedSection
-                }
-                onSelectSection={
-                  activeNav === "autonomous-research"
-                    ? (section) =>
-                        setAutonomousActiveSectionMap((prev) => ({
-                          ...prev,
-                          [autonomousSubNav]: section,
-                        }))
-                    : setActiveAssistedSection
-                }
+              <IconButton
+                size="small"
+                variant="neutral-tertiary"
+                icon={<FeatherPanelLeftClose />}
+                onClick={() => setSidebarOpen(false)}
               />
             </div>
-          </div>
+          }
+          footer={
+            <SubframeCore.DropdownMenu.Root>
+              <SubframeCore.DropdownMenu.Trigger asChild>
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-3 rounded-md px-1 py-1 -mx-1 hover:bg-neutral-100 transition-colors cursor-pointer"
+                >
+                  <Avatar variant="brand" size="small">
+                    Dev
+                  </Avatar>
+                  <span className="flex-1 text-body font-body text-default-font text-left">
+                    開発者
+                  </span>
+                  <FeatherChevronUp className="h-4 w-4 text-subtext-color" />
+                </button>
+              </SubframeCore.DropdownMenu.Trigger>
+              <SubframeCore.DropdownMenu.Portal>
+                <SubframeCore.DropdownMenu.Content side="top" align="start" sideOffset={8}>
+                  <DropdownMenu>
+                    <DropdownMenu.DropdownItem
+                      icon={<FeatherUser />}
+                      onSelect={() => handleNavChange("profile")}
+                    >
+                      プロフィール
+                    </DropdownMenu.DropdownItem>
+                    <DropdownMenu.DropdownItem
+                      icon={<FeatherKey />}
+                      onSelect={() => handleNavChange("api-token")}
+                    >
+                      API Token
+                    </DropdownMenu.DropdownItem>
+                    <DropdownMenu.DropdownItem
+                      icon={<FeatherSettings />}
+                      onSelect={() => handleNavChange("integration")}
+                    >
+                      インテグレーション
+                    </DropdownMenu.DropdownItem>
+                    <DropdownMenu.DropdownDivider />
+                    <DropdownMenu.DropdownItem icon={<FeatherLogOut />}>
+                      ログアウト
+                    </DropdownMenu.DropdownItem>
+                  </DropdownMenu>
+                </SubframeCore.DropdownMenu.Content>
+              </SubframeCore.DropdownMenu.Portal>
+            </SubframeCore.DropdownMenu.Root>
+          }
+        >
+          <SidebarWithSections.NavItem
+            icon={<FeatherHome />}
+            selected={activeNav === "dashboard"}
+            onClick={() => handleNavChange("dashboard")}
+          >
+            ダッシュボード
+          </SidebarWithSections.NavItem>
+          <SidebarWithSections.NavItem
+            icon={<FeatherPlus />}
+            onClick={handleCreateVerification}
+            className="bg-brand-50"
+          >
+            新規検証
+          </SidebarWithSections.NavItem>
+          <SidebarWithSections.NavItem
+            icon={<FeatherList />}
+            selected={activeNav === "home"}
+            onClick={() => handleNavChange("home")}
+          >
+            検証一覧
+          </SidebarWithSections.NavItem>
+          <SidebarWithSections.NavItem
+            icon={<FeatherSearch />}
+            selected={activeNav === "search"}
+            onClick={() => handleNavChange("search")}
+          >
+            検索
+          </SidebarWithSections.NavItem>
+          <SidebarWithSections.NavItem
+            icon={<FeatherBell />}
+            selected={activeNav === "notifications"}
+            onClick={() => handleNavChange("notifications")}
+          >
+            通知
+          </SidebarWithSections.NavItem>
+          <SidebarWithSections.NavSection
+            label={
+              <>
+                自動研究{" "}
+                <span className="text-[10px] font-normal text-neutral-400">Experimental</span>
+              </>
+            }
+          >
+            <SidebarWithSections.NavItem
+              icon={<span className="inline-block h-1.5 w-1.5 rounded-full bg-current" />}
+              selected={activeNav === "autonomous-research" && autonomousSubNav === "topic-driven"}
+              onClick={() => {
+                setAutonomousSubNav("topic-driven");
+                handleNavChange("autonomous-research");
+              }}
+            >
+              Topic-Driven
+            </SidebarWithSections.NavItem>
+            <SidebarWithSections.NavItem
+              icon={<span className="inline-block h-1.5 w-1.5 rounded-full bg-current" />}
+              selected={
+                activeNav === "autonomous-research" && autonomousSubNav === "hypothesis-driven"
+              }
+              onClick={() => {
+                setAutonomousSubNav("hypothesis-driven");
+                handleNavChange("autonomous-research");
+              }}
+            >
+              Hypothesis-Driven
+            </SidebarWithSections.NavItem>
+          </SidebarWithSections.NavSection>
+          <SidebarWithSections.NavSection label="Settings">
+            <SidebarWithSections.NavItem
+              icon={<FeatherSettings />}
+              selected={activeNav === "integration"}
+              onClick={() => handleNavChange("integration")}
+            >
+              Integration
+            </SidebarWithSections.NavItem>
+            <SidebarWithSections.NavItem
+              icon={<FeatherUser />}
+              selected={activeNav === "user-plan"}
+              onClick={() => handleNavChange("user-plan")}
+            >
+              User Plan
+            </SidebarWithSections.NavItem>
+            <SidebarWithSections.NavItem
+              icon={<FeatherUser />}
+              selected={activeNav === "profile"}
+              onClick={() => handleNavChange("profile")}
+            >
+              プロフィール
+            </SidebarWithSections.NavItem>
+          </SidebarWithSections.NavSection>
+          <SidebarWithSections.NavSection label="Support">
+            <SidebarWithSections.NavItem
+              icon={<FeatherMessageSquare />}
+              selected={activeNav === "feedback"}
+              onClick={() => handleNavChange("feedback")}
+            >
+              お問い合わせ
+            </SidebarWithSections.NavItem>
+            <SidebarWithSections.NavItem
+              icon={<FeatherHelpCircle />}
+              selected={activeNav === "help"}
+              onClick={() => handleNavChange("help")}
+            >
+              ヘルプ
+            </SidebarWithSections.NavItem>
+            <SidebarWithSections.NavItem
+              icon={<FeatherFileText />}
+              onClick={() => window.open("https://airas-org.github.io/airas/", "_blank")}
+            >
+              ドキュメント
+            </SidebarWithSections.NavItem>
+            <SidebarWithSections.NavItem
+              icon={<FeatherShield />}
+              selected={activeNav === "legal"}
+              onClick={() => handleNavChange("legal")}
+            >
+              利用規約
+            </SidebarWithSections.NavItem>
+          </SidebarWithSections.NavSection>
+        </SidebarWithSections>
+      </aside>
+
+      <div
+        className={cn(
+          "flex-1 flex flex-col min-w-0 transition-[margin-left] duration-200 ease-in-out",
+          sidebarOpen ? "ml-52" : "ml-0",
         )}
-        <MainContent
-          assistedSection={activeAssistedSection}
-          autonomousSection={autonomousActiveSectionMap[autonomousSubNav]}
-          activeFeature={activeFeature}
-          activeNav={activeNav}
-          autonomousSubNav={autonomousSubNav}
-          assistedResearchProps={{
-            workflowTree,
-            activeNodeId,
-            setActiveNodeId,
-            addWorkflowNode,
-            updateNodeSnapshot,
-            resetDownstreamSessions,
-            onNavigate: handleNavigate,
-          }}
-          sessionsExpanded={sessionsExpanded}
-          onToggleSessions={handleToggleSessions}
-          onCreateSection={handleCreateSection}
-          onUpdateSectionTitle={handleUpdateSectionTitle}
-          onRefreshSessions={(preferredId) => fetchSections(autonomousSubNav, preferredId)}
+      >
+        <TopbarWithRightNav
+          leftSlot={
+            !sidebarOpen ? (
+              <IconButton
+                size="small"
+                variant="neutral-tertiary"
+                icon={<FeatherPanelLeftOpen />}
+                onClick={() => setSidebarOpen(true)}
+              />
+            ) : undefined
+          }
+          rightSlot={
+            <>
+              <IconButton
+                variant="neutral-tertiary"
+                icon={<SiGithub className="h-4 w-4" />}
+                onClick={() => window.open("https://github.com/airas-org/airas", "_blank")}
+              />
+              <IconButton
+                variant="neutral-tertiary"
+                icon={<FeatherFileText />}
+                onClick={() => window.open("https://airas-org.github.io/airas/", "_blank")}
+              />
+              <IconButton
+                variant="neutral-tertiary"
+                icon={<SiDiscord className="h-4 w-4" />}
+                onClick={() => window.open("https://discord.gg/KGm5FGY5", "_blank")}
+              />
+              <IconButton
+                variant="neutral-tertiary"
+                icon={<SiX className="h-4 w-4" />}
+                onClick={() => window.open("https://x.com/fuyu_quant", "_blank")}
+              />
+              {eeComponents ? (
+                <eeComponents.UserMenu />
+              ) : (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span>
+                        <IconButton disabled variant="neutral-secondary" icon={<FeatherUser />} />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Enterprise Edition is not enabled</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              )}
+            </>
+          }
         />
+        <div className="flex-1 flex min-h-0">
+          <MainContent
+            autonomousSection={autonomousActiveSectionMap[autonomousSubNav]}
+            autonomousSessions={autonomousSectionsMap[autonomousSubNav]}
+            onSelectAutonomousSession={handleSelectAutonomousSession}
+            activeNav={activeNav}
+            autonomousSubNav={autonomousSubNav}
+            assistedResearchProps={{
+              workflowTree,
+              activeNodeId,
+              setActiveNodeId,
+              addWorkflowNode,
+              updateNodeSnapshot,
+              resetDownstreamSessions,
+              onNavigate: handleNavigate,
+            }}
+            onCreateSection={handleCreateSection}
+            onUpdateSectionTitle={handleUpdateSectionTitle}
+            onRefreshSessions={(preferredId) => fetchSections(autonomousSubNav, preferredId)}
+            verifications={verifications}
+            activeVerification={activeVerification}
+            onSelectVerification={handleSelectVerification}
+            onDeleteVerification={handleDeleteVerification}
+            onDuplicateVerification={handleDuplicateVerification}
+            onUpdateVerification={handleUpdateVerification}
+            onCreateWithMethod={handleCreateWithMethod}
+            onNavChange={handleNavChange}
+          />
+        </div>
       </div>
     </div>
   );
 
+  const handleOnboardingComplete = () => {
+    localStorage.setItem("airas-onboarding-done", "true");
+    setShowOnboarding(false);
+  };
+
+  const content = (
+    <>
+      {appContent}
+      {showOnboarding && <OnboardingOverlay onComplete={handleOnboardingComplete} />}
+    </>
+  );
+
   if (eeComponents) {
-    return <eeComponents.AuthGuard>{appContent}</eeComponents.AuthGuard>;
+    return <eeComponents.AuthGuard>{content}</eeComponents.AuthGuard>;
   }
 
-  return appContent;
+  return content;
 }

--- a/frontend/src/components/pages/verification/home/index.tsx
+++ b/frontend/src/components/pages/verification/home/index.tsx
@@ -1,0 +1,158 @@
+import { FeatherSearch } from "@subframe/core";
+import { useMemo, useState } from "react";
+import type { Verification } from "../types";
+import { VerificationCard } from "./verification-card";
+
+interface VerificationHomePageProps {
+  verifications: Verification[];
+  onSelectVerification: (id: string) => void;
+  onDeleteVerification: (id: string) => void;
+  onDuplicateVerification: (id: string) => void;
+}
+
+interface CategoryColumnProps {
+  label: string;
+  count: number;
+  verifications: Verification[];
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
+  onDuplicate: (id: string) => void;
+}
+
+function CategoryColumn({
+  label,
+  count,
+  verifications,
+  onSelect,
+  onDelete,
+  onDuplicate,
+}: CategoryColumnProps) {
+  return (
+    <div className="min-w-[180px] flex-1 rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center gap-2 mb-3">
+        <h2 className="text-caption-bold font-caption-bold text-subtext-color uppercase tracking-wider whitespace-nowrap">
+          {label}
+        </h2>
+        <span className="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-neutral-200 px-1.5 text-[10px] font-medium text-neutral-600">
+          {count}
+        </span>
+      </div>
+      <div className="flex flex-col gap-2">
+        {verifications.map((v) => (
+          <VerificationCard
+            key={v.id}
+            verification={v}
+            onClick={() => onSelect(v.id)}
+            onDelete={() => onDelete(v.id)}
+            onDuplicate={() => onDuplicate(v.id)}
+          />
+        ))}
+        {verifications.length === 0 && (
+          <p className="py-6 text-center text-caption font-caption text-neutral-400">No items</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+type CategoryKey =
+  | "hypothesis"
+  | "plan-decided"
+  | "implementation-done"
+  | "experiments-done"
+  | "paper-done";
+
+const categories: { key: CategoryKey; label: string }[] = [
+  { key: "hypothesis", label: "仮説入力済み" },
+  { key: "plan-decided", label: "方針決定済み" },
+  { key: "implementation-done", label: "実装完了" },
+  { key: "experiments-done", label: "実験完了" },
+  { key: "paper-done", label: "論文生成が完了" },
+];
+
+function getCategoryKey(v: Verification): CategoryKey {
+  switch (v.phase) {
+    case "initial":
+    case "methods-proposed":
+      return "hypothesis";
+    case "plan-generated":
+      return "plan-decided";
+    case "code-generating":
+    case "code-generated":
+      return "implementation-done";
+    case "experiments-done":
+      return "experiments-done";
+    case "paper-writing":
+      return v.paperDraft?.status === "ready" ? "paper-done" : "experiments-done";
+  }
+}
+
+export function VerificationHomePage({
+  verifications,
+  onSelectVerification,
+  onDeleteVerification,
+  onDuplicateVerification,
+}: VerificationHomePageProps) {
+  const [search, setSearch] = useState("");
+
+  const filtered = search
+    ? verifications.filter(
+        (v) =>
+          v.title.toLowerCase().includes(search.toLowerCase()) ||
+          v.query.toLowerCase().includes(search.toLowerCase()),
+      )
+    : verifications;
+
+  const grouped = useMemo(() => {
+    const map: Record<CategoryKey, Verification[]> = {
+      hypothesis: [],
+      "plan-decided": [],
+      "implementation-done": [],
+      "experiments-done": [],
+      "paper-done": [],
+    };
+    for (const v of filtered) {
+      map[getCategoryKey(v)].push(v);
+    }
+    return map;
+  }, [filtered]);
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-full mx-auto px-8 py-8">
+        <div className="flex items-end justify-between gap-4">
+          <div>
+            <h1 className="text-heading-2 font-heading-2 text-default-font">検証一覧</h1>
+            <p className="text-caption font-caption text-subtext-color mt-1">
+              {verifications.length} projects
+            </p>
+          </div>
+          <div className="w-56 rounded-lg border border-border bg-card px-3 py-1.5 flex items-center gap-2">
+            <FeatherSearch className="h-4 w-4 text-subtext-color shrink-0" />
+            <input
+              type="text"
+              placeholder="Search..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full bg-transparent text-body font-body text-default-font outline-none placeholder:text-neutral-400"
+            />
+          </div>
+        </div>
+
+        <div className="mt-6 flex gap-4 items-start overflow-x-auto">
+          {categories.map((cat) => (
+            <CategoryColumn
+              key={cat.key}
+              label={cat.label}
+              count={grouped[cat.key].length}
+              verifications={grouped[cat.key]}
+              onSelect={onSelectVerification}
+              onDelete={onDeleteVerification}
+              onDuplicate={onDuplicateVerification}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/ui/components/SidebarWithSections.tsx
+++ b/frontend/src/ui/components/SidebarWithSections.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+/*
+ * Documentation:
+ * Sidebar with sections — https://app.subframe.com/32f8a386b602/library?component=Sidebar+with+sections_f4047c8b-cfb4-4761-b9cf-fbcae8a9b9b5
+ */
+
+import * as SubframeCore from "@subframe/core";
+import { FeatherCircleDashed } from "@subframe/core";
+import React from "react";
+import * as SubframeUtils from "../utils";
+
+interface NavItemProps extends React.HTMLAttributes<HTMLDivElement> {
+  icon?: React.ReactNode;
+  children?: React.ReactNode;
+  selected?: boolean;
+  rightSlot?: React.ReactNode;
+  className?: string;
+}
+
+const NavItem = React.forwardRef<HTMLDivElement, NavItemProps>(function NavItem(
+  {
+    icon = <FeatherCircleDashed />,
+    children,
+    selected = false,
+    rightSlot,
+    className,
+    ...otherProps
+  }: NavItemProps,
+  ref,
+) {
+  return (
+    <div
+      className={SubframeUtils.twClassNames(
+        "group/2713e17b flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-2 hover:bg-neutral-50 active:bg-neutral-100",
+        { "bg-brand-50 hover:bg-brand-50 active:bg-brand-100": selected },
+        className,
+      )}
+      ref={ref}
+      {...otherProps}
+    >
+      {icon ? (
+        <SubframeCore.IconWrapper
+          className={SubframeUtils.twClassNames("text-sm text-neutral-600", {
+            "text-brand-700": selected,
+          })}
+        >
+          {icon}
+        </SubframeCore.IconWrapper>
+      ) : null}
+      {children ? (
+        <span
+          className={SubframeUtils.twClassNames(
+            "line-clamp-1 grow shrink-0 basis-0 text-sm font-medium text-neutral-600",
+            { "text-brand-700": selected },
+          )}
+        >
+          {children}
+        </span>
+      ) : null}
+      {rightSlot ? <div className="flex items-center">{rightSlot}</div> : null}
+    </div>
+  );
+});
+
+interface NavSectionProps extends React.HTMLAttributes<HTMLDivElement> {
+  children?: React.ReactNode;
+  label?: React.ReactNode;
+  className?: string;
+}
+
+const NavSection = React.forwardRef<HTMLDivElement, NavSectionProps>(function NavSection(
+  { children, label, className, ...otherProps }: NavSectionProps,
+  ref,
+) {
+  return (
+    <div
+      className={SubframeUtils.twClassNames(
+        "flex w-full flex-col items-start gap-1 pt-6",
+        className,
+      )}
+      ref={ref}
+      {...otherProps}
+    >
+      <div className="flex w-full flex-col items-start gap-4 px-3 py-1">
+        {label ? (
+          <span className="w-full text-caption-bold font-caption-bold text-subtext-color">
+            {label}
+          </span>
+        ) : null}
+      </div>
+      {children ? (
+        <div className="flex w-full grow shrink-0 basis-0 flex-col items-start gap-1">
+          {children}
+        </div>
+      ) : null}
+    </div>
+  );
+});
+
+interface SidebarWithSectionsRootProps extends React.HTMLAttributes<HTMLElement> {
+  header?: React.ReactNode;
+  footer?: React.ReactNode;
+  children?: React.ReactNode;
+  className?: string;
+}
+
+const SidebarWithSectionsRoot = React.forwardRef<HTMLElement, SidebarWithSectionsRootProps>(
+  function SidebarWithSectionsRoot(
+    { header, footer, children, className, ...otherProps }: SidebarWithSectionsRootProps,
+    ref,
+  ) {
+    return (
+      <nav
+        className={SubframeUtils.twClassNames(
+          "flex h-full w-52 flex-col items-start border-r border-solid border-neutral-border bg-default-background",
+          className,
+        )}
+        ref={ref}
+        {...otherProps}
+      >
+        {header ? (
+          <div className="flex w-full flex-col items-start gap-2 px-6 py-6">{header}</div>
+        ) : null}
+        {children ? (
+          <div className="flex w-full grow shrink-0 basis-0 flex-col items-start px-4 py-4 overflow-auto">
+            {children}
+          </div>
+        ) : null}
+        {footer ? (
+          <div className="flex w-full items-center gap-4 border-t border-solid border-neutral-border px-6 py-6">
+            {footer}
+          </div>
+        ) : null}
+      </nav>
+    );
+  },
+);
+
+export const SidebarWithSections = Object.assign(SidebarWithSectionsRoot, {
+  NavItem,
+  NavSection,
+});


### PR DESCRIPTION
## Summary
- サイドバーの透過問題を修正（`bg-default-background`を`<aside>`に追加し、横スクロール時にコンテンツが透けないようにした）
- 検証一覧ページの見出しを「Verifications」から「検証一覧」に変更
- カテゴリを7つから5つに削減（仮説入力済み / 方針決定済み / 実装完了 / 実験完了 / 論文生成が完了）
- サイドバーの幅を縮小（`w-60` → `w-52`）

## 変更ファイル
- `frontend/src/App.tsx` — サイドバー背景色・幅の修正
- `frontend/src/components/pages/verification/home/index.tsx` — 見出し・カテゴリの変更
- `frontend/src/ui/components/SidebarWithSections.tsx` — サイドバー幅の修正

## Test plan
- [ ] 検証一覧ページで横スクロールしてサイドバーが透過しないことを確認
- [ ] 検証一覧ページの左上が「検証一覧」と表示されていることを確認
- [ ] カテゴリが5つ（仮説入力済み/方針決定済み/実装完了/実験完了/論文生成が完了）であることを確認
- [ ] サイドバーの幅が以前より狭くなっていることを確認

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)