### PR TITLE
feat: フロントエンドのページ遷移をstate遷移からURLベースのルーティングに変更

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -59,6 +59,7 @@
         "react-hook-form": "^7.60.0",
         "react-markdown": "10.1.0",
         "react-resizable-panels": "^2.1.7",
+        "react-router-dom": "^7.13.1",
         "recharts": "2.15.4",
         "sonner": "^1.7.4",
         "tailwind-merge": "^3.3.1",
@@ -3963,6 +3964,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
@@ -6122,6 +6136,44 @@
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
+      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/react-smooth": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
@@ -6310,6 +6362,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/sonner": {
       "version": "1.7.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,6 +62,7 @@
     "react-hook-form": "^7.60.0",
     "react-markdown": "10.1.0",
     "react-resizable-panels": "^2.1.7",
+    "react-router-dom": "^7.13.1",
     "recharts": "2.15.4",
     "sonner": "^1.7.4",
     "tailwind-merge": "^3.3.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,12 +22,8 @@ import {
 } from "@subframe/core";
 import axios from "axios";
 import { useCallback, useEffect, useState } from "react";
-import {
-  AUTONOMOUS_SUB_NAVS,
-  type AutonomousSubNav,
-  MainContent,
-  type NavKey,
-} from "@/components/main-content";
+import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
+import { AUTONOMOUS_SUB_NAVS, type AutonomousSubNav, MainContent } from "@/components/main-content";
 import {
   type AutonomousActiveSectionMap,
   type AutonomousSectionsMap,
@@ -108,8 +104,56 @@ function useEEComponents() {
   return eeComponents;
 }
 
+const SETTINGS_TABS: SettingsTab[] = [
+  "profile",
+  "feedback",
+  "integration",
+  "api-token",
+  "user-plan",
+  "receipts",
+  "usage",
+];
+
+function getActiveSection(pathname: string): string {
+  if (pathname.startsWith("/autonomous-research")) return "autonomous-research";
+  if (pathname.startsWith("/settings")) return "settings";
+  if (pathname.startsWith("/verification")) return "verification";
+  if (pathname.startsWith("/notifications")) return "notifications";
+  if (pathname.startsWith("/papers")) return "papers";
+  return "home";
+}
+
+function getAutonomousSubNav(pathname: string): AutonomousSubNav {
+  if (pathname.includes("hypothesis-driven")) return "hypothesis-driven";
+  return "topic-driven";
+}
+
+function getSettingsTab(pathname: string): SettingsTab {
+  const tab = pathname.split("/settings/")[1] as SettingsTab | undefined;
+  if (tab && SETTINGS_TABS.includes(tab)) return tab;
+  return "profile";
+}
+
+function GitHubOAuthCallbackRoute() {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const code = params.get("code");
+  const state = params.get("state");
+  const savedState = sessionStorage.getItem("github_oauth_state");
+
+  if (code && state && state === savedState) {
+    return <GitHubOAuthCallback code={code} />;
+  }
+  return <Navigate to="/" replace />;
+}
+
 export default function App() {
   const eeComponents = useEEComponents();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const activeSection = getActiveSection(location.pathname);
+  const autonomousSubNav = getAutonomousSubNav(location.pathname);
 
   // Autonomous Research
   const [autonomousSectionsMap, setAutonomousSectionsMap] = useState<AutonomousSectionsMap>(
@@ -124,19 +168,11 @@ export default function App() {
 
   // Verification
   const [verifications, setVerifications] = useState<Verification[]>(mockVerifications);
-  const [activeVerificationId, setActiveVerificationId] = useState<string | null>(null);
-  const activeVerification = verifications.find((v) => v.id === activeVerificationId) ?? null;
 
-  // Navigation — check URL params for post-checkout redirect
-  const [activeNav, setActiveNav] = useState<NavKey>(() => {
-    const params = new URLSearchParams(window.location.search);
-    const nav = params.get("nav");
-    if (nav === "user-plan" || nav === "integration") return "settings" as NavKey;
-    return "verification";
-  });
-  const [autonomousSubNav, setAutonomousSubNav] = useState<AutonomousSubNav>("topic-driven");
-  const [settingsTab, setSettingsTab] = useState<SettingsTab>("profile");
+  // autonomousListViewKey forces list remount when clicking the same sub-nav
   const [autonomousListViewKey, setAutonomousListViewKey] = useState(0);
+
+  // UI state
   const isMobile = useIsMobile();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
@@ -149,22 +185,6 @@ export default function App() {
     setAutonomousActiveSectionMap,
   });
 
-  // 初回起動時に新規検証を自動作成
-  // biome-ignore lint/correctness/useExhaustiveDependencies: 初回マウント時のみ実行
-  useEffect(() => {
-    if (activeNav === "verification" && !activeVerificationId) {
-      handleCreateVerification();
-    }
-  }, []);
-
-  const handleCreateSection = () => {
-    if (activeNav === "autonomous-research") {
-      setAutonomousActiveSectionMap((prev) => ({ ...prev, [autonomousSubNav]: null }));
-    }
-    setWorkflowTree(initialWorkflowTree);
-    setActiveNodeId(null);
-  };
-
   const handleCreateVerification = useCallback(() => {
     const newVerification: Verification = {
       id: `v-${Date.now()}`,
@@ -174,14 +194,8 @@ export default function App() {
       phase: "initial",
     };
     setVerifications((prev) => [newVerification, ...prev]);
-    setActiveVerificationId(newVerification.id);
-    setActiveNav("verification");
-  }, []);
-
-  const handleSelectVerification = useCallback((id: string) => {
-    setActiveVerificationId(id);
-    setActiveNav("verification");
-  }, []);
+    navigate(`/verification/${newVerification.id}`);
+  }, [navigate]);
 
   const handleUpdateVerification = useCallback((id: string, updates: Partial<Verification>) => {
     setVerifications((prev) => prev.map((v) => (v.id === id ? { ...v, ...updates } : v)));
@@ -190,12 +204,11 @@ export default function App() {
   const handleDeleteVerification = useCallback(
     (id: string) => {
       setVerifications((prev) => prev.filter((v) => v.id !== id));
-      if (activeVerificationId === id) {
-        setActiveVerificationId(null);
-        setActiveNav("home");
+      if (location.pathname === `/verification/${id}`) {
+        navigate("/home");
       }
     },
-    [activeVerificationId],
+    [location.pathname, navigate],
   );
 
   const handleDuplicateVerification = useCallback((id: string) => {
@@ -229,21 +242,26 @@ export default function App() {
         },
       };
       setVerifications((prev) => [newVerification, ...prev]);
-      setActiveVerificationId(newId);
-      setActiveNav("verification");
+      navigate(`/verification/${newId}`);
+    },
+    [navigate],
+  );
+
+  const handleSelectAutonomousSession = useCallback(
+    (subNav: AutonomousSubNav, section: ResearchSection) => {
+      setAutonomousActiveSectionMap((prev) => ({
+        ...prev,
+        [subNav]: section,
+      }));
     },
     [],
   );
 
-  const handleSelectAutonomousSession = useCallback(
-    (section: ResearchSection) => {
-      setAutonomousActiveSectionMap((prev) => ({
-        ...prev,
-        [autonomousSubNav]: section,
-      }));
-    },
-    [autonomousSubNav],
-  );
+  const handleCreateSection = useCallback((subNav: AutonomousSubNav) => {
+    setAutonomousActiveSectionMap((prev) => ({ ...prev, [subNav]: null }));
+    setWorkflowTree(initialWorkflowTree);
+    setActiveNodeId(null);
+  }, []);
 
   const handleNavigate = useCallback(
     (nodeId: string) => {
@@ -342,57 +360,27 @@ export default function App() {
   }, []);
 
   const handleUpdateSectionTitle = useCallback(
-    (title: string) => {
-      if (activeNav === "autonomous-research") {
-        setAutonomousSectionsMap((prev) => ({
-          ...prev,
-          [autonomousSubNav]: prev[autonomousSubNav].map((s) =>
-            s.id === autonomousActiveSectionMap[autonomousSubNav]?.id ? { ...s, title } : s,
-          ),
-        }));
-        setAutonomousActiveSectionMap((prev) => {
-          const current = prev[autonomousSubNav];
-          if (!current) return prev;
-          return { ...prev, [autonomousSubNav]: { ...current, title } };
-        });
-      }
+    (subNav: AutonomousSubNav, title: string) => {
+      setAutonomousSectionsMap((prev) => ({
+        ...prev,
+        [subNav]: prev[subNav].map((s) =>
+          s.id === autonomousActiveSectionMap[subNav]?.id ? { ...s, title } : s,
+        ),
+      }));
+      setAutonomousActiveSectionMap((prev) => {
+        const current = prev[subNav];
+        if (!current) return prev;
+        return { ...prev, [subNav]: { ...current, title } };
+      });
     },
-    [activeNav, autonomousSubNav, autonomousActiveSectionMap],
+    [autonomousActiveSectionMap],
   );
-
-  const handleNavChange = useCallback((key: NavKey) => {
-    setActiveNav(key);
-  }, []);
 
   const handleMobileNavClose = useCallback(() => {
     if (isMobile) setSidebarOpen(false);
   }, [isMobile]);
 
-  // Handle GitHub OAuth callback route
-  if (window.location.pathname === "/auth/github/callback") {
-    const params = new URLSearchParams(window.location.search);
-    const code = params.get("code");
-    const state = params.get("state");
-    const savedState = sessionStorage.getItem("github_oauth_state");
-
-    if (code && state && state === savedState) {
-      return <GitHubOAuthCallback code={code} />;
-    }
-    window.location.href = "/";
-    return null;
-  }
-
-  // Handle OAuth callback route
-  if (isEnterpriseEnabled() && window.location.pathname === "/auth/callback") {
-    if (!eeComponents) {
-      return (
-        <div className="flex min-h-screen items-center justify-center">
-          <div className="text-muted-foreground">Loading...</div>
-        </div>
-      );
-    }
-    return <eeComponents.AuthCallback />;
-  }
+  const isSettingsView = activeSection === "settings";
 
   const appContent = (
     <div className="flex min-h-screen bg-default-background">
@@ -424,23 +412,21 @@ export default function App() {
               type="button"
               className={cn(
                 "flex w-full items-center gap-2.5 rounded-md px-1 py-1 -mx-1 transition-colors cursor-pointer",
-                activeNav === "settings"
-                  ? "text-brand-700"
-                  : "text-neutral-600 hover:bg-neutral-100",
+                isSettingsView ? "text-brand-700" : "text-neutral-600 hover:bg-neutral-100",
               )}
-              onClick={() => handleNavChange("settings")}
+              onClick={() => navigate("/settings/profile")}
             >
               <FeatherSettings className="h-4 w-4" />
               <span className="text-sm font-medium">設定</span>
             </button>
           }
         >
-          {activeNav === "settings" ? (
+          {isSettingsView ? (
             <>
               <button
                 type="button"
                 className="flex w-full items-center gap-2 rounded-md px-1 py-1 -mx-1 text-neutral-600 hover:bg-neutral-100 transition-colors cursor-pointer mb-1"
-                onClick={() => handleNavChange("home")}
+                onClick={() => navigate("/home")}
               >
                 <FeatherArrowLeft className="h-4 w-4" />
                 <span className="text-sm font-medium">設定</span>
@@ -450,8 +436,8 @@ export default function App() {
               >
                 <SidebarWithSections.NavItem
                   icon={<FeatherUser />}
-                  selected={settingsTab === "profile"}
-                  onClick={() => setSettingsTab("profile")}
+                  selected={getSettingsTab(location.pathname) === "profile"}
+                  onClick={() => navigate("/settings/profile")}
                 >
                   プロフィール
                 </SidebarWithSections.NavItem>
@@ -477,8 +463,8 @@ export default function App() {
                 </SidebarWithSections.NavItem>
                 <SidebarWithSections.NavItem
                   icon={<FeatherMessageSquare />}
-                  selected={settingsTab === "feedback"}
-                  onClick={() => setSettingsTab("feedback")}
+                  selected={getSettingsTab(location.pathname) === "feedback"}
+                  onClick={() => navigate("/settings/feedback")}
                 >
                   お問い合わせ
                 </SidebarWithSections.NavItem>
@@ -488,15 +474,15 @@ export default function App() {
               >
                 <SidebarWithSections.NavItem
                   icon={<FeatherLink />}
-                  selected={settingsTab === "integration"}
-                  onClick={() => setSettingsTab("integration")}
+                  selected={getSettingsTab(location.pathname) === "integration"}
+                  onClick={() => navigate("/settings/integration")}
                 >
                   接続
                 </SidebarWithSections.NavItem>
                 <SidebarWithSections.NavItem
                   icon={<FeatherKey />}
-                  selected={settingsTab === "api-token"}
-                  onClick={() => setSettingsTab("api-token")}
+                  selected={getSettingsTab(location.pathname) === "api-token"}
+                  onClick={() => navigate("/settings/api-token")}
                 >
                   シークレット
                 </SidebarWithSections.NavItem>
@@ -506,22 +492,22 @@ export default function App() {
               >
                 <SidebarWithSections.NavItem
                   icon={<FeatherCreditCard />}
-                  selected={settingsTab === "user-plan"}
-                  onClick={() => setSettingsTab("user-plan")}
+                  selected={getSettingsTab(location.pathname) === "user-plan"}
+                  onClick={() => navigate("/settings/user-plan")}
                 >
                   プラン
                 </SidebarWithSections.NavItem>
                 <SidebarWithSections.NavItem
                   icon={<FeatherReceipt />}
-                  selected={settingsTab === "receipts"}
-                  onClick={() => setSettingsTab("receipts")}
+                  selected={getSettingsTab(location.pathname) === "receipts"}
+                  onClick={() => navigate("/settings/receipts")}
                 >
                   領収書 / 請求書
                 </SidebarWithSections.NavItem>
                 <SidebarWithSections.NavItem
                   icon={<FeatherBarChart2 />}
-                  selected={settingsTab === "usage"}
-                  onClick={() => setSettingsTab("usage")}
+                  selected={getSettingsTab(location.pathname) === "usage"}
+                  onClick={() => navigate("/settings/usage")}
                 >
                   利用量
                 </SidebarWithSections.NavItem>
@@ -531,7 +517,7 @@ export default function App() {
             <>
               <SidebarWithSections.NavItem
                 icon={<FeatherPlus />}
-                selected={activeNav === "verification"}
+                selected={activeSection === "verification"}
                 onClick={() => {
                   handleCreateVerification();
                   handleMobileNavClose();
@@ -541,9 +527,9 @@ export default function App() {
               </SidebarWithSections.NavItem>
               <SidebarWithSections.NavItem
                 icon={<FeatherList />}
-                selected={activeNav === "home"}
+                selected={activeSection === "home"}
                 onClick={() => {
-                  handleNavChange("home");
+                  navigate("/home");
                   handleMobileNavClose();
                 }}
               >
@@ -551,7 +537,7 @@ export default function App() {
               </SidebarWithSections.NavItem>
               <SidebarWithSections.NavItem
                 icon={<FeatherBeaker />}
-                selected={activeNav === "autonomous-research"}
+                selected={activeSection === "autonomous-research"}
                 className="cursor-default hover:bg-transparent active:bg-transparent"
               >
                 自動研究
@@ -560,14 +546,13 @@ export default function App() {
                 <button
                   type="button"
                   className={`flex items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors cursor-pointer ${
-                    activeNav === "autonomous-research" && autonomousSubNav === "topic-driven"
+                    activeSection === "autonomous-research" && autonomousSubNav === "topic-driven"
                       ? "text-brand-700 bg-brand-50"
                       : "text-neutral-600 hover:bg-neutral-100"
                   }`}
                   onClick={() => {
-                    setAutonomousSubNav("topic-driven");
                     setAutonomousListViewKey((k) => k + 1);
-                    handleNavChange("autonomous-research");
+                    navigate("/autonomous-research/topic-driven");
                     handleMobileNavClose();
                   }}
                 >
@@ -577,14 +562,14 @@ export default function App() {
                 <button
                   type="button"
                   className={`flex items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors cursor-pointer ${
-                    activeNav === "autonomous-research" && autonomousSubNav === "hypothesis-driven"
+                    activeSection === "autonomous-research" &&
+                    autonomousSubNav === "hypothesis-driven"
                       ? "text-brand-700 bg-brand-50"
                       : "text-neutral-600 hover:bg-neutral-100"
                   }`}
                   onClick={() => {
-                    setAutonomousSubNav("hypothesis-driven");
                     setAutonomousListViewKey((k) => k + 1);
-                    handleNavChange("autonomous-research");
+                    navigate("/autonomous-research/hypothesis-driven");
                     handleMobileNavClose();
                   }}
                 >
@@ -638,9 +623,11 @@ export default function App() {
                 />
               </div>
               <IconButton
-                variant={activeNav === "notifications" ? "neutral-secondary" : "neutral-tertiary"}
+                variant={
+                  activeSection === "notifications" ? "neutral-secondary" : "neutral-tertiary"
+                }
                 icon={<FeatherBell className="h-4 w-4" />}
-                onClick={() => handleNavChange("notifications")}
+                onClick={() => navigate("/notifications")}
               />
               {eeComponents ? (
                 <eeComponents.UserMenu />
@@ -663,11 +650,9 @@ export default function App() {
         />
         <div className="flex-1 flex min-h-0">
           <MainContent
-            autonomousSection={autonomousActiveSectionMap[autonomousSubNav]}
-            autonomousSessions={autonomousSectionsMap[autonomousSubNav]}
+            autonomousSectionMap={autonomousActiveSectionMap}
+            autonomousSessions={autonomousSectionsMap}
             onSelectAutonomousSession={handleSelectAutonomousSession}
-            activeNav={activeNav}
-            autonomousSubNav={autonomousSubNav}
             assistedResearchProps={{
               workflowTree,
               activeNodeId,
@@ -679,15 +664,12 @@ export default function App() {
             }}
             onCreateSection={handleCreateSection}
             onUpdateSectionTitle={handleUpdateSectionTitle}
-            onRefreshSessions={(preferredId) => fetchSections(autonomousSubNav, preferredId)}
+            onRefreshSessions={(subNav, preferredId) => fetchSections(subNav, preferredId)}
             verifications={verifications}
-            activeVerification={activeVerification}
-            onSelectVerification={handleSelectVerification}
             onDeleteVerification={handleDeleteVerification}
             onDuplicateVerification={handleDuplicateVerification}
             onUpdateVerification={handleUpdateVerification}
             onCreateWithMethod={handleCreateWithMethod}
-            settingsTab={settingsTab}
             autonomousListViewKey={autonomousListViewKey}
           />
         </div>
@@ -695,11 +677,30 @@ export default function App() {
     </div>
   );
 
-  const content = appContent;
+  const guardedContent = eeComponents ? (
+    <eeComponents.AuthGuard>{appContent}</eeComponents.AuthGuard>
+  ) : (
+    appContent
+  );
 
-  if (eeComponents) {
-    return <eeComponents.AuthGuard>{content}</eeComponents.AuthGuard>;
-  }
-
-  return content;
+  return (
+    <Routes>
+      <Route path="/auth/github/callback" element={<GitHubOAuthCallbackRoute />} />
+      {isEnterpriseEnabled() && (
+        <Route
+          path="/auth/callback"
+          element={
+            eeComponents ? (
+              <eeComponents.AuthCallback />
+            ) : (
+              <div className="flex min-h-screen items-center justify-center">
+                <div className="text-muted-foreground">Loading...</div>
+              </div>
+            )
+          }
+        />
+      )}
+      <Route path="*" element={guardedContent} />
+    </Routes>
+  );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -197,6 +197,13 @@ export default function App() {
     navigate(`/verification/${newVerification.id}`);
   }, [navigate]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: 初回マウント時のみ実行
+  useEffect(() => {
+    if (location.pathname === "/") {
+      handleCreateVerification();
+    }
+  }, []);
+
   const handleUpdateVerification = useCallback((id: string, updates: Partial<Verification>) => {
     setVerifications((prev) => prev.map((v) => (v.id === id ? { ...v, ...updates } : v)));
   }, []);

--- a/frontend/src/components/main-content.tsx
+++ b/frontend/src/components/main-content.tsx
@@ -169,7 +169,7 @@ export function MainContent({
   return (
     <div className="flex-1 flex min-w-0">
       <Routes>
-        <Route path="/" element={<Navigate to="/home" replace />} />
+        <Route path="/" element={null} />
         <Route
           path="/home"
           element={

--- a/frontend/src/components/main-content.tsx
+++ b/frontend/src/components/main-content.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useState } from "react";
+import { Navigate, Route, Routes, useNavigate, useParams } from "react-router-dom";
 import { AutonomousResearchPage } from "@/components/pages/autonomous-research";
 import { HypothesisDrivenResearchPage } from "@/components/pages/hypothesis-driven-research";
 import { NotificationsPage } from "@/components/pages/notifications";
 import { PapersPage } from "@/components/pages/papers";
-import { SettingsPage, type SettingsTab } from "@/components/pages/settings";
+import { SettingsPage } from "@/components/pages/settings";
 import {
   type ProposedMethod,
   type Verification,
@@ -18,13 +19,6 @@ import type {
   WorkflowTree as WorkflowTreeType,
 } from "@/types/research";
 
-export type NavKey =
-  | "home"
-  | "papers"
-  | "autonomous-research"
-  | "verification"
-  | "notifications"
-  | "settings";
 export const AUTONOMOUS_SUB_NAVS = ["topic-driven", "hypothesis-driven"] as const;
 export type AutonomousSubNav = (typeof AUTONOMOUS_SUB_NAVS)[number];
 
@@ -45,46 +39,91 @@ interface AssistedResearchProps {
 }
 
 interface MainContentProps {
-  autonomousSection: ResearchSection | null;
-  autonomousSessions: ResearchSection[];
-  onSelectAutonomousSession: (section: ResearchSection) => void;
-  activeNav: NavKey;
-  autonomousSubNav: AutonomousSubNav;
+  autonomousSectionMap: Record<AutonomousSubNav, ResearchSection | null>;
+  autonomousSessions: Record<AutonomousSubNav, ResearchSection[]>;
+  onSelectAutonomousSession: (subNav: AutonomousSubNav, section: ResearchSection) => void;
   assistedResearchProps: AssistedResearchProps;
-  onCreateSection: () => void;
-  onUpdateSectionTitle: (title: string) => void;
-  onRefreshSessions: (preferredId?: string) => Promise<void>;
+  onCreateSection: (subNav: AutonomousSubNav) => void;
+  onUpdateSectionTitle: (subNav: AutonomousSubNav, title: string) => void;
+  onRefreshSessions: (subNav: AutonomousSubNav, preferredId?: string) => Promise<void>;
   verifications: Verification[];
-  activeVerification: Verification | null;
-  onSelectVerification: (id: string) => void;
   onDeleteVerification: (id: string) => void;
   onDuplicateVerification: (id: string) => void;
   onUpdateVerification: (id: string, updates: Partial<Verification>) => void;
   onCreateWithMethod: (sourceVerification: Verification, method: ProposedMethod) => void;
-  settingsTab: SettingsTab;
   autonomousListViewKey: number;
 }
 
-export function MainContent({
-  autonomousSection,
+function VerificationDetailRoute({
+  verifications,
+  onUpdateVerification,
+  onCreateWithMethod,
+}: {
+  verifications: Verification[];
+  onUpdateVerification: (id: string, updates: Partial<Verification>) => void;
+  onCreateWithMethod: (sourceVerification: Verification, method: ProposedMethod) => void;
+}) {
+  const { id } = useParams<{ id: string }>();
+  const verification = verifications.find((v) => v.id === id) ?? null;
+  return (
+    <VerificationDetailPage
+      verification={verification}
+      onUpdateVerification={onUpdateVerification}
+      onCreateWithMethod={onCreateWithMethod}
+    />
+  );
+}
+
+function AutonomousResearchRoute({
+  subNav,
+  autonomousSectionMap,
   autonomousSessions,
   onSelectAutonomousSession,
-  activeNav,
-  autonomousSubNav,
+  onCreateSection,
+  onUpdateSectionTitle,
+  onRefreshSessions,
+  listViewKey,
+}: {
+  subNav: AutonomousSubNav;
+  autonomousSectionMap: Record<AutonomousSubNav, ResearchSection | null>;
+  autonomousSessions: Record<AutonomousSubNav, ResearchSection[]>;
+  onSelectAutonomousSession: (subNav: AutonomousSubNav, section: ResearchSection) => void;
+  onCreateSection: (subNav: AutonomousSubNav) => void;
+  onUpdateSectionTitle: (subNav: AutonomousSubNav, title: string) => void;
+  onRefreshSessions: (subNav: AutonomousSubNav, preferredId?: string) => Promise<void>;
+  listViewKey: number;
+}) {
+  const PageComponent =
+    subNav === "topic-driven" ? AutonomousResearchPage : HypothesisDrivenResearchPage;
+  return (
+    <PageComponent
+      section={autonomousSectionMap[subNav]}
+      sessions={autonomousSessions[subNav]}
+      onSelectSession={(section) => onSelectAutonomousSession(subNav, section)}
+      onCreateSection={() => onCreateSection(subNav)}
+      onUpdateSectionTitle={(title) => onUpdateSectionTitle(subNav, title)}
+      onRefreshSessions={(preferredId) => onRefreshSessions(subNav, preferredId)}
+      listViewKey={listViewKey}
+    />
+  );
+}
+
+export function MainContent({
+  autonomousSectionMap,
+  autonomousSessions,
+  onSelectAutonomousSession,
   assistedResearchProps,
   onCreateSection,
   onUpdateSectionTitle,
   onRefreshSessions,
   verifications,
-  activeVerification,
-  onSelectVerification,
   onDeleteVerification,
   onDuplicateVerification,
   onUpdateVerification,
   onCreateWithMethod,
-  settingsTab,
   autonomousListViewKey,
 }: MainContentProps) {
+  const navigate = useNavigate();
   const [selectedPapers, setSelectedPapers] = useState<Paper[]>([]);
 
   const handlePapersStepExecuted = useCallback(
@@ -129,62 +168,96 @@ export function MainContent({
 
   return (
     <div className="flex-1 flex min-w-0">
-      <div className={activeNav === "home" ? "flex-1 flex min-w-0" : "hidden"}>
-        <VerificationHomePage
-          verifications={verifications}
-          onSelectVerification={onSelectVerification}
-          onDeleteVerification={onDeleteVerification}
-          onDuplicateVerification={onDuplicateVerification}
+      <Routes>
+        <Route path="/" element={<Navigate to="/home" replace />} />
+        <Route
+          path="/home"
+          element={
+            <VerificationHomePage
+              verifications={verifications}
+              onSelectVerification={(id) => navigate(`/verification/${id}`)}
+              onDeleteVerification={onDeleteVerification}
+              onDuplicateVerification={onDuplicateVerification}
+            />
+          }
         />
-      </div>
-
-      <div className={activeNav === "verification" ? "flex-1 flex" : "hidden"}>
-        <VerificationDetailPage
-          verification={activeVerification}
-          onUpdateVerification={onUpdateVerification}
-          onCreateWithMethod={onCreateWithMethod}
+        <Route
+          path="/verification/:id"
+          element={
+            <VerificationDetailRoute
+              verifications={verifications}
+              onUpdateVerification={onUpdateVerification}
+              onCreateWithMethod={onCreateWithMethod}
+            />
+          }
         />
-      </div>
-
-      <div className={activeNav === "papers" ? "flex-1 flex" : "hidden"}>
-        <PapersPage
-          selectedPapers={selectedPapers}
-          onPapersChange={setSelectedPapers}
-          onStepExecuted={handlePapersStepExecuted}
-          onSave={handleSavePapersSnapshot}
+        <Route
+          path="/papers"
+          element={
+            <PapersPage
+              selectedPapers={selectedPapers}
+              onPapersChange={setSelectedPapers}
+              onStepExecuted={handlePapersStepExecuted}
+              onSave={handleSavePapersSnapshot}
+            />
+          }
         />
-      </div>
-
-      <div className={activeNav === "autonomous-research" ? "flex-1 flex" : "hidden"}>
-        {autonomousSubNav === "topic-driven" ? (
-          <AutonomousResearchPage
-            section={autonomousSection}
-            sessions={autonomousSessions}
-            onSelectSession={onSelectAutonomousSession}
-            onCreateSection={onCreateSection}
-            onUpdateSectionTitle={onUpdateSectionTitle}
-            onRefreshSessions={onRefreshSessions}
-            listViewKey={autonomousListViewKey}
-          />
-        ) : (
-          <HypothesisDrivenResearchPage
-            section={autonomousSection}
-            sessions={autonomousSessions}
-            onSelectSession={onSelectAutonomousSession}
-            onCreateSection={onCreateSection}
-            onUpdateSectionTitle={onUpdateSectionTitle}
-            onRefreshSessions={onRefreshSessions}
-            listViewKey={autonomousListViewKey}
-          />
-        )}
-      </div>
-
-      <div className={activeNav === "notifications" ? "flex-1 flex" : "hidden"}>
-        <NotificationsPage />
-      </div>
-      <div className={activeNav === "settings" ? "flex-1 flex" : "hidden"}>
-        <SettingsPage activeTab={settingsTab} />
-      </div>
+        <Route
+          path="/autonomous-research/topic-driven"
+          element={
+            <AutonomousResearchRoute
+              subNav="topic-driven"
+              autonomousSectionMap={autonomousSectionMap}
+              autonomousSessions={autonomousSessions}
+              onSelectAutonomousSession={onSelectAutonomousSession}
+              onCreateSection={onCreateSection}
+              onUpdateSectionTitle={onUpdateSectionTitle}
+              onRefreshSessions={onRefreshSessions}
+              listViewKey={autonomousListViewKey}
+            />
+          }
+        />
+        <Route
+          path="/autonomous-research/hypothesis-driven"
+          element={
+            <AutonomousResearchRoute
+              subNav="hypothesis-driven"
+              autonomousSectionMap={autonomousSectionMap}
+              autonomousSessions={autonomousSessions}
+              onSelectAutonomousSession={onSelectAutonomousSession}
+              onCreateSection={onCreateSection}
+              onUpdateSectionTitle={onUpdateSectionTitle}
+              onRefreshSessions={onRefreshSessions}
+              listViewKey={autonomousListViewKey}
+            />
+          }
+        />
+        <Route
+          path="/autonomous-research"
+          element={<Navigate to="/autonomous-research/topic-driven" replace />}
+        />
+        <Route path="/notifications" element={<NotificationsPage />} />
+        <Route path="/settings/:tab" element={<SettingsRoute />} />
+        <Route path="/settings" element={<Navigate to="/settings/profile" replace />} />
+        <Route path="*" element={<Navigate to="/home" replace />} />
+      </Routes>
     </div>
   );
+}
+
+function SettingsRoute() {
+  const { tab } = useParams<{ tab: string }>();
+  const VALID_TABS = [
+    "profile",
+    "feedback",
+    "integration",
+    "api-token",
+    "user-plan",
+    "receipts",
+    "usage",
+  ];
+  const activeTab = VALID_TABS.includes(tab ?? "")
+    ? (tab as Parameters<typeof SettingsPage>[0]["activeTab"])
+    : "profile";
+  return <SettingsPage activeTab={activeTab} />;
 }

--- a/frontend/src/components/pages/integration.tsx
+++ b/frontend/src/components/pages/integration.tsx
@@ -44,7 +44,7 @@ export function GitHubOAuthCallback({ code }: { code: string }) {
         sessionStorage.removeItem("github_oauth_state");
         setStatus("success");
         setTimeout(() => {
-          window.location.href = "/?nav=integration";
+          window.location.href = "/settings/integration";
         }, 1500);
       })
       .catch(() => {
@@ -66,7 +66,7 @@ export function GitHubOAuthCallback({ code }: { code: string }) {
               type="button"
               className="mt-2 text-sm underline"
               onClick={() => {
-                window.location.href = "/?nav=integration";
+                window.location.href = "/settings/integration";
               }}
             >
               Integrationページに戻る

--- a/frontend/src/components/pages/user-plan.tsx
+++ b/frontend/src/components/pages/user-plan.tsx
@@ -104,7 +104,7 @@ export function UserPlanPage() {
       const data = await apiFetch<{ checkout_url: string }>("/stripe/checkout", {
         method: "POST",
         body: JSON.stringify({
-          success_url: `${window.location.origin}?plan=upgraded&nav=user-plan`,
+          success_url: `${window.location.origin}/settings/user-plan?plan=upgraded`,
           cancel_url: window.location.href,
         }),
       });

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,6 @@
-// frontend/src/main.tsx
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import "./index.css"; // ここで globals.css の中身を読み込む
 import App from "./App";
 import { OpenAPI } from "./lib/api";
@@ -9,6 +9,8 @@ OpenAPI.BASE = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? "htt
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary

- `useState` による画面遷移管理を `react-router-dom` のURLベースルーティングに移行
- `activeNav` / `autonomousSubNav` / `activeVerificationId` / `settingsTab` の state を削除し、URLから直接導出するように変更
- `BrowserRouter` を `main.tsx` でラップし、`Routes` / `Route` / `Navigate` / `useNavigate` / `useParams` を活用
- アプリ起動時（`/`）に自動で新規検証を作成し、その検証ページへ遷移するデフォルト動作を追加
- `integration.tsx` / `user-plan.tsx` の旧クエリパラメータ形式 (`?nav=*`) を新URLパス形式 (`/settings/*`) に更新

## 追加パッケージ

- `react-router-dom ^7.13.1`

## Test plan

- [ ] 各ナビゲーション項目（Home、Autonomous Research、Papers、Notifications、Settings）をクリックしてURLが正しく変わることを確認
- [ ] ブラウザの戻る・進むボタンで正しく遷移できることを確認
- [ ] `/autonomous-research` が `/autonomous-research/topic-driven` にリダイレクトされることを確認
- [ ] `/settings` が `/settings/profile` にリダイレクトされることを確認
- [ ] アプリ起動時（`/`）に新規検証ページへ自動遷移することを確認
- [ ] GitHub OAuth完了後に `/settings/integration` へ正しく遷移することを確認
- [ ] Stripeチェックアウト完了後に `/settings/user-plan` へ正しく遷移することを確認
- [ ] URLを直接入力してページへアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)