### PR TITLE
feat: Railway CLIをdevcontainerに追加

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -28,6 +28,9 @@ RUN apt-get install -y curl ca-certificates gnupg && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 
+# Railway CLI
+RUN npm install -g @railway/cli
+
 # ttyd (web terminal)
 RUN DPKG_ARCH=$(dpkg --print-architecture) && \
     if [ "$DPKG_ARCH" = "amd64" ]; then TTYD_ARCH="x86_64"; else TTYD_ARCH="aarch64"; fi && \


### PR DESCRIPTION
## Summary

- `dev.Dockerfile` に Railway CLI のインストールを追加

## 変更内容

Node.js 20.x がすでに devcontainer に含まれているため、`npm install -g @railway/cli` を使ってインストールする。

```dockerfile
# Railway CLI
RUN npm install -g @railway/cli
```

## Test plan

- [ ] devcontainer を再ビルドして `railway --version` が実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)