### PR TITLE
docs: update CONTRIBUTING.md with CLA section and core team MCP setup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -59,11 +59,17 @@ For core team development, we use the following. If you need access, please cont
 - [Subframe](https://docs.subframe.com/guides/mcp-server#installation)
 
     ```bash
-    claude mcp add --transport http supabase "https://mcp.supabase.com/mcp"
+    claude plugin marketplace add https://github.com/SubframeApp/subframe && claude plugin install subframe@subframe
     ```
 
-- [Subframe](https://docs.subframe.com/guides/mcp-server#installation)
+- [Supabase](https://supabase.com/docs/guides/getting-started/mcp)
 
     ```bash
-    claude plugin marketplace add https://github.com/SubframeApp/subframe && claude plugin install subframe@subframe
+    claude mcp add --scope project --transport http supabase "https://mcp.supabase.com/mcp"
+    ```
+
+- [Stripe](https://docs.stripe.com/mcp?locale=ja-JP&mcp-client=claudecode#connect)
+
+    ```bash
+    claude mcp add --transport http stripe https://mcp.stripe.com/
     ```


### PR DESCRIPTION
# 概要

CONTRIBUTING.md を更新し、CLA セクションの移動とコアチーム向け MCP サーバーのセットアップ手順を追加しました。

# 変更点

- CLA セクションをコードスタイルセクションの前に移動
- コアチーム向けセクション「For Core Team」を追加
- MCP サーバー・プラグインのセットアップ手順を追加（Vercel, Railway, Subframe, Supabase, Stripe）
- 「How to Contribute」セクションを削除（CLA セクションに統合）

# 確認項目

- [x] ドキュメントの内容が正確である
- [x] リンクが正しく設定されている
