### PR TITLE
fix: consolidate localhost CORS origins into regex pattern

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -85,10 +85,8 @@ app.add_middleware(
     allow_origins=[
         "https://app.airas.io",
         "https://app-dev.airas.io",
-        "http://localhost:5173",
-        "http://127.0.0.1:5173",
     ],
-    allow_origin_regex=r"https://(airas.*\.vercel\.app|.*\.trycloudflare\.com)",
+    allow_origin_regex=r"https://(airas.*\.vercel\.app|.*\.trycloudflare\.com)|http://(localhost|127\.0\.0\.1):\d+",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- `http://localhost:5173` と `http://127.0.0.1:5173` のハードコードされたオリジンを削除
- `allow_origin_regex` にlocalhostパターンを追加し、任意のポートのlocalhostを許可するよう統合

## Test plan
- [x] ローカル開発環境でフロントエンドからAPIへのリクエストが正常に通ることを確認
- [x] 本番環境のCORSが引き続き正常に機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)