### PR TITLE
Fix `RuntimeError: Cannot send a request, as the client has been closed` 

### DIFF
--- a/backend/api/ee/auth/dependencies.py
+++ b/backend/api/ee/auth/dependencies.py
@@ -3,6 +3,7 @@ from typing import Annotated
 from uuid import UUID
 
 import httpx
+from anyio import to_thread
 from dependency_injector.wiring import Provide, inject
 from fastapi import Depends, Header, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -104,7 +105,7 @@ async def get_github_client(
     ],
     x_github_session: Annotated[str | None, Header()] = None,
 ) -> GithubClient:
-    token = _resolve_github_token(service, x_github_session)
+    token = await to_thread.run_sync(lambda: _resolve_github_token(service, x_github_session))
     return GithubClient(
         github_token=token,
         sync_session=github_sync_session,


### PR DESCRIPTION
## 背景と目的

`get_github_client` がFastAPIの依存注入としてリクエストスコープのasyncジェネレーターで実装されており、HTTPセッション（`httpx.Client` / `httpx.AsyncClient`）をリクエストごとに生成・破棄していました。研究タスクのように `asyncio.create_task()` で切り離される長時間バックグラウンドタスクでは、レスポンス返却時にセッションが閉じられ `RuntimeError: Cannot send a request, as the client has been closed` が発生していました。

- https://github.com/airas-org/airas/issues/842

## 変更内容

httpxのベストプラクティスに従い（https://www.python-httpx.org/advanced/clients/）、
HTTPセッションのライフサイクルをリクエスト単位からアプリ単位（Container Resource）に変更しました。httpxクライアントはスレッドセーフであるため、複数のリクエスト・バックグラウンドタスク間で安全に共有できます。

1. セッション管理の移行: `get_github_client` 内でのセッション生成・破棄（asyncジェネレーター + try/finally）を廃止し、Containerが管理する `github_sync_session` / `github_async_session` を依存注入で受け取る方式に変更
2. トークン解決ロジックの分離: EE/非EEのトークン取得ロジックを `_resolve_github_token` として切り出し、`get_github_client` はトークン解決とクライアント組み立てのみを担当する構成に整理
3. コードの簡素化:
   - 重複していたHTTPException生成を `_GITHUB_NOT_CONNECTED` 定数に集約
   - `get_github_owner` のネストしたif文をearly return パターンに統一

<details>
<summary><code>1. セッション管理の移行</code></summary>

**実装概要**

`backend/api/ee/auth/dependencies.py` の `get_github_client` を変更

- **変更前**: asyncジェネレーターとして `httpx.Client` / `httpx.AsyncClient` をリクエストごとに生成し、`yield` 後の `finally` ブロックで破棄
- **変更後**: Containerが管理する `github_sync_session` / `github_async_session`（アプリライフサイクル）を `Depends(Provide[...])` で受け取り、`GithubClient` を組み立てて `return` するだけの関数に変更
  - セッションの生成・破棄の責務はContainerに委譲

</details>

<details>
<summary><code>2. トークン解決ロジックの分離</code></summary>

**実装概要**

`backend/api/ee/auth/dependencies.py` に `_resolve_github_token` を追加

- EEモード: セッションIDからOAuthトークンを取得
- 非EEモード: `GH_PERSONAL_ACCESS_TOKEN` 環境変数から取得
- `get_github_client` はこの関数を呼び出してトークンを取得し、Containerのセッションと組み合わせて `GithubClient` を返す

</details>
