### PR TITLE
fix: update make up to run locally in devcontainer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
-# Local development commands:
-#   make up       - Build and start all services
-#   make down      - Stop all services
-#   make logs      - Show service logs
-#   make ps        - Show service status
-#   make migrate   - Apply database migrations
-#   make db-reset  - Reset database (delete volumes)
-#   make update-api- Regenerate OpenAPI and frontend client
+# Local development commands (devcontainer mode, DB provided by devcontainer):
+#   make up        - Start backend (port 8000) and frontend (port 5173)
+#   make down      - Stop backend and frontend processes
+#   make ps        - Show running status of backend and frontend
+#   make migrate   - (no-op: tables are created automatically on backend startup)
+#   make db-reset  - (not supported in devcontainer mode)
+#   make update-api- Regenerate OpenAPI schema and frontend client
 
 SHELL := /bin/bash
 
@@ -22,24 +21,31 @@ COMPOSE_CMD := $(COMPOSE) -f $(COMPOSE_FILE) -p $(PROJECT)
 .PHONY: up down logs ps migrate db-reset update-api generate-openapi ruff mypy biome
 
 up:
-	$(COMPOSE_CMD) up --build
+	@echo "Starting backend and frontend locally (DB is provided by devcontainer)..."
+	@trap 'kill 0' EXIT; \
+	(cd backend && uv run uvicorn api.main:app --host 0.0.0.0 --port 8000 --reload) & \
+	(cd frontend && npm run dev) & \
+	wait
 
 down:
-	$(COMPOSE_CMD) down
+	@echo "Stopping local processes..."
+	@pkill -f "uvicorn api.main:app" 2>/dev/null || true
+	@pkill -f "vite" 2>/dev/null || true
+	@echo "Done."
 
 logs:
 	$(COMPOSE_CMD) logs -f --tail=200
 
 ps:
-	$(COMPOSE_CMD) ps
+	@echo "=== Backend ===" && pgrep -a -f "uvicorn api.main:app" || echo "not running"
+	@echo "=== Frontend ===" && pgrep -a -f "vite" || echo "not running"
 
 migrate:
-	$(COMPOSE_CMD) run --rm $(MIGRATE_SERVICE)
+	@echo "Tables are created automatically by SQLModel.metadata.create_all() on backend startup."
 
 db-reset:
-	$(COMPOSE_CMD) down -v
-	$(COMPOSE_CMD) up -d $(DB_SERVICE)
-	$(MAKE) migrate
+	@echo "db-reset is not supported in devcontainer mode."
+	@echo "To reset: drop and recreate the airas database from a PostgreSQL client."
 
 update-api: generate-openapi
 


### PR DESCRIPTION
## Summary

- `make up` が devcontainer 内で `docker: command not found` エラーで起動できない問題を修正
- devcontainer では Docker が使えないため、バックエンド（uvicorn）とフロントエンド（vite）をローカルで直接起動するように変更
- DB は `.devcontainer/compose.yaml` が提供する PostgreSQL サービス（`db` ホスト）を使用

## 変更内容

| コマンド | 変更前 | 変更後 |
|---|---|---|
| `make up` | `docker compose up --build` | uvicorn + vite をローカルで直接起動 |
| `make down` | `docker compose down` | `pkill` でプロセスを停止 |
| `make ps` | `docker compose ps` | `pgrep` でプロセス状態を確認 |
| `make migrate` | `docker compose run migrate` | no-op（`main.py` が起動時に `SQLModel.metadata.create_all()` でテーブルを自動作成） |

## Test plan

- [ ] `make up` を実行してバックエンド（port 8000）とフロントエンド（port 5173）が起動することを確認
- [ ] `make down` でプロセスが停止することを確認
- [ ] `make ps` でプロセス状態が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)