### PR TITLE
Feature/#855 support explicit api key injection in langchainclient and litellmclient

### DIFF
--- a/backend/api/ee/auth/dependencies.py
+++ b/backend/api/ee/auth/dependencies.py
@@ -1,5 +1,4 @@
 import os
-from collections.abc import Callable
 from typing import Annotated
 from uuid import UUID
 
@@ -10,7 +9,6 @@ from fastapi import Depends, Header, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from airas.container import Container
-from airas.core.types.llm_provider import LLMProvider
 from airas.infra.github_client import GithubClient
 from airas.infra.langchain_client import (
     PROVIDER_REQUIRED_ENV_VARS as LANGCHAIN_REQUIRED_ENV_VARS,
@@ -104,17 +102,10 @@ def _resolve_github_token(
     return token
 
 
-def _resolve_for_ee(
-    resolver: ApiKeyResolver,
-    user_id: UUID,
-) -> tuple[Callable[[str], str | None] | None, dict[str, str] | None]:
-    """Return (get_api_key, api_keys) when EE is enabled, else (None, None)."""
-    settings = get_ee_settings()
-    if not settings.enabled:
-        return None, None
-    keys = resolver.resolve_keys(user_id)
-    key_fn = resolver.create_key_fn(keys)
-    return key_fn, keys
+_NO_LLM_PROVIDERS = HTTPException(
+    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+    detail="No LLM provider API keys are configured. Set at least one provider's API key.",
+)
 
 
 @inject
@@ -123,11 +114,19 @@ def get_langchain_client(
     resolver: Annotated[ApiKeyResolver, Depends(Provide[Container.api_key_resolver])],
 ) -> LangChainClient:
     """Create a LangChainClient with per-request API keys (EE) or env-var fallback."""
-    key_fn, api_keys = _resolve_for_ee(resolver, user_id)
-    available: set[LLMProvider] | None = None
-    if api_keys is not None:
-        available = detect_available_providers(LANGCHAIN_REQUIRED_ENV_VARS, api_keys)
-    return LangChainClient(get_api_key=key_fn, available_providers=available)
+    if not get_ee_settings().enabled:
+        client = LangChainClient()
+        if not client.available_providers:
+            raise _NO_LLM_PROVIDERS
+        return client
+    keys = resolver.resolve_keys(user_id)
+    available = detect_available_providers(LANGCHAIN_REQUIRED_ENV_VARS, keys)
+    if not available:
+        raise _NO_LLM_PROVIDERS
+    return LangChainClient(
+        get_api_key=resolver.create_key_fn(keys),
+        available_providers=available,
+    )
 
 
 @inject
@@ -136,11 +135,19 @@ def get_litellm_client(
     resolver: Annotated[ApiKeyResolver, Depends(Provide[Container.api_key_resolver])],
 ) -> LiteLLMClient:
     """Create a LiteLLMClient with per-request API keys (EE) or env-var fallback."""
-    key_fn, api_keys = _resolve_for_ee(resolver, user_id)
-    available: set[LLMProvider] | None = None
-    if api_keys is not None:
-        available = detect_available_providers(LITELLM_REQUIRED_ENV_VARS, api_keys)
-    return LiteLLMClient(get_api_key=key_fn, available_providers=available)
+    if not get_ee_settings().enabled:
+        client = LiteLLMClient()
+        if not client.available_providers:
+            raise _NO_LLM_PROVIDERS
+        return client
+    keys = resolver.resolve_keys(user_id)
+    available = detect_available_providers(LITELLM_REQUIRED_ENV_VARS, keys)
+    if not available:
+        raise _NO_LLM_PROVIDERS
+    return LiteLLMClient(
+        get_api_key=resolver.create_key_fn(keys),
+        available_providers=available,
+    )
 
 
 @inject

--- a/backend/api/ee/auth/dependencies.py
+++ b/backend/api/ee/auth/dependencies.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Callable
 from typing import Annotated
 from uuid import UUID
 
@@ -9,7 +10,18 @@ from fastapi import Depends, Header, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from airas.container import Container
+from airas.core.types.llm_provider import LLMProvider
 from airas.infra.github_client import GithubClient
+from airas.infra.langchain_client import (
+    PROVIDER_REQUIRED_ENV_VARS as LANGCHAIN_REQUIRED_ENV_VARS,
+)
+from airas.infra.langchain_client import LangChainClient
+from airas.infra.litellm_client import (
+    PROVIDER_REQUIRED_ENV_VARS as LITELLM_REQUIRED_ENV_VARS,
+)
+from airas.infra.litellm_client import LiteLLMClient
+from airas.infra.llm_provider_resolver import detect_available_providers
+from airas.usecases.ee.api_key_resolver import ApiKeyResolver
 from airas.usecases.ee.github_oauth_service import GitHubOAuthService
 from api.ee.auth.middleware import extract_user_id_from_request
 from api.ee.settings import get_ee_settings
@@ -92,6 +104,45 @@ def _resolve_github_token(
     return token
 
 
+def _resolve_for_ee(
+    resolver: ApiKeyResolver,
+    user_id: UUID,
+) -> tuple[Callable[[str], str | None] | None, dict[str, str] | None]:
+    """Return (get_api_key, api_keys) when EE is enabled, else (None, None)."""
+    settings = get_ee_settings()
+    if not settings.enabled:
+        return None, None
+    keys = resolver.resolve_keys(user_id)
+    key_fn = resolver.create_key_fn(keys)
+    return key_fn, keys
+
+
+@inject
+def get_langchain_client(
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    resolver: Annotated[ApiKeyResolver, Depends(Provide[Container.api_key_resolver])],
+) -> LangChainClient:
+    """Create a LangChainClient with per-request API keys (EE) or env-var fallback."""
+    key_fn, api_keys = _resolve_for_ee(resolver, user_id)
+    available: set[LLMProvider] | None = None
+    if api_keys is not None:
+        available = detect_available_providers(LANGCHAIN_REQUIRED_ENV_VARS, api_keys)
+    return LangChainClient(get_api_key=key_fn, available_providers=available)
+
+
+@inject
+def get_litellm_client(
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    resolver: Annotated[ApiKeyResolver, Depends(Provide[Container.api_key_resolver])],
+) -> LiteLLMClient:
+    """Create a LiteLLMClient with per-request API keys (EE) or env-var fallback."""
+    key_fn, api_keys = _resolve_for_ee(resolver, user_id)
+    available: set[LLMProvider] | None = None
+    if api_keys is not None:
+        available = detect_available_providers(LITELLM_REQUIRED_ENV_VARS, api_keys)
+    return LiteLLMClient(get_api_key=key_fn, available_providers=available)
+
+
 @inject
 async def get_github_client(
     service: Annotated[
@@ -105,7 +156,9 @@ async def get_github_client(
     ],
     x_github_session: Annotated[str | None, Header()] = None,
 ) -> GithubClient:
-    token = await to_thread.run_sync(lambda: _resolve_github_token(service, x_github_session))
+    token = await to_thread.run_sync(
+        lambda: _resolve_github_token(service, x_github_session)
+    )
     return GithubClient(
         github_token=token,
         sync_session=github_sync_session,

--- a/backend/api/ee/auth/dependencies.py
+++ b/backend/api/ee/auth/dependencies.py
@@ -1,10 +1,11 @@
 import os
+from collections.abc import Callable
 from typing import Annotated
 from uuid import UUID
 
 import httpx
 from anyio import to_thread
-from dependency_injector.wiring import Provide, inject
+from dependency_injector.wiring import Provide, Provider, inject
 from fastapi import Depends, Header, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
@@ -112,18 +113,18 @@ _NO_LLM_PROVIDERS = HTTPException(
 def get_langchain_client(
     user_id: Annotated[UUID, Depends(get_current_user_id)],
     resolver: Annotated[ApiKeyResolver, Depends(Provide[Container.api_key_resolver])],
+    langchain_client_factory: Annotated[
+        Callable[..., LangChainClient],
+        Depends(Provider[Container.langchain_client]),
+    ],
 ) -> LangChainClient:
-    """Create a LangChainClient with per-request API keys (EE) or env-var fallback."""
-    if not get_ee_settings().enabled:
-        client = LangChainClient()
-        if not client.available_providers:
-            raise _NO_LLM_PROVIDERS
-        return client
-    keys = resolver.resolve_keys(user_id)
+    """Create a LangChainClient via Container with resolved API keys."""
+    resolved_user_id = user_id if get_ee_settings().enabled else None
+    keys = resolver.resolve_keys(resolved_user_id)
     available = detect_available_providers(LANGCHAIN_REQUIRED_ENV_VARS, keys)
     if not available:
         raise _NO_LLM_PROVIDERS
-    return LangChainClient(
+    return langchain_client_factory(
         get_api_key=resolver.create_key_fn(keys),
         available_providers=available,
     )
@@ -133,18 +134,18 @@ def get_langchain_client(
 def get_litellm_client(
     user_id: Annotated[UUID, Depends(get_current_user_id)],
     resolver: Annotated[ApiKeyResolver, Depends(Provide[Container.api_key_resolver])],
+    litellm_client_factory: Annotated[
+        Callable[..., LiteLLMClient],
+        Depends(Provider[Container.litellm_client]),
+    ],
 ) -> LiteLLMClient:
-    """Create a LiteLLMClient with per-request API keys (EE) or env-var fallback."""
-    if not get_ee_settings().enabled:
-        client = LiteLLMClient()
-        if not client.available_providers:
-            raise _NO_LLM_PROVIDERS
-        return client
-    keys = resolver.resolve_keys(user_id)
+    """Create a LiteLLMClient via Container with resolved API keys."""
+    resolved_user_id = user_id if get_ee_settings().enabled else None
+    keys = resolver.resolve_keys(resolved_user_id)
     available = detect_available_providers(LITELLM_REQUIRED_ENV_VARS, keys)
     if not available:
         raise _NO_LLM_PROVIDERS
-    return LiteLLMClient(
+    return litellm_client_factory(
         get_api_key=resolver.create_key_fn(keys),
         available_providers=available,
     )

--- a/backend/api/routes/v1/experimental_settings.py
+++ b/backend/api/routes/v1/experimental_settings.py
@@ -13,6 +13,7 @@ from airas.usecases.generators.generate_experimental_design_subgraph.generate_ex
 from airas.usecases.generators.refine_experimental_design_subgraph.refine_experimental_design_subgraph import (
     RefineExperimentalDesignSubgraph,
 )
+from api.ee.auth.dependencies import get_langchain_client
 from api.schemas.experimental_settings import (
     GenerateExperimentalDesignSubgraphRequestBody,
     GenerateExperimentalDesignSubgraphResponseBody,
@@ -30,9 +31,7 @@ router = APIRouter(prefix="/experimental_settings", tags=["experimental_settings
 @observe()
 async def generate_experimental_design(
     request: GenerateExperimentalDesignSubgraphRequestBody,
-    langchain_client: Annotated[
-        LangChainClient, Depends(Provide[Container.langchain_client])
-    ],
+    langchain_client: Annotated[LangChainClient, Depends(get_langchain_client)],
     langfuse_client: Annotated[
         LangfuseClient, Depends(Provide[Container.langfuse_client])
     ],
@@ -65,9 +64,7 @@ async def generate_experimental_design(
 @observe()
 async def refine_experimental_design(
     request: RefineExperimentalDesignSubgraphRequestBody,
-    langchain_client: Annotated[
-        LangChainClient, Depends(Provide[Container.langchain_client])
-    ],
+    langchain_client: Annotated[LangChainClient, Depends(get_langchain_client)],
     langfuse_client: Annotated[
         LangfuseClient, Depends(Provide[Container.langfuse_client])
     ],

--- a/backend/api/routes/v1/experiments.py
+++ b/backend/api/routes/v1/experiments.py
@@ -33,7 +33,7 @@ from airas.usecases.executors.fetch_run_ids_subgraph.fetch_run_ids_subgraph impo
 from airas.usecases.generators.dispatch_diagram_generation_subgraph.dispatch_diagram_generation_subgraph import (
     DispatchDiagramGenerationSubgraph,
 )
-from api.ee.auth.dependencies import get_github_client
+from api.ee.auth.dependencies import get_github_client, get_langchain_client
 from api.schemas.experiments import (
     AnalyzeExperimentRequestBody,
     AnalyzeExperimentResponseBody,
@@ -280,9 +280,7 @@ async def dispatch_diagram_generation(
 @observe()
 async def analyze_experiment(
     request: AnalyzeExperimentRequestBody,
-    langchain_client: Annotated[
-        LangChainClient, Depends(Provide[Container.langchain_client])
-    ],
+    langchain_client: Annotated[LangChainClient, Depends(get_langchain_client)],
     langfuse_client: Annotated[
         LangfuseClient, Depends(Provide[Container.langfuse_client])
     ],

--- a/backend/api/routes/v1/hypotheses.py
+++ b/backend/api/routes/v1/hypotheses.py
@@ -10,6 +10,7 @@ from airas.infra.langfuse_client import LangfuseClient
 from airas.usecases.generators.generate_hypothesis_subgraph.generate_hypothesis_subgraph_v0 import (
     GenerateHypothesisSubgraphV0,
 )
+from api.ee.auth.dependencies import get_langchain_client
 from api.schemas.hypotheses import (
     GenerateHypothesisSubgraphV0RequestBody,
     GenerateHypothesisSubgraphV0ResponseBody,
@@ -23,9 +24,7 @@ router = APIRouter(prefix="/hypotheses", tags=["hypotheses"])
 @observe()
 async def generate_hypotheses(
     request: GenerateHypothesisSubgraphV0RequestBody,
-    langchain_client: Annotated[
-        LangChainClient, Depends(Provide[Container.langchain_client])
-    ],
+    langchain_client: Annotated[LangChainClient, Depends(get_langchain_client)],
     langfuse_client: Annotated[
         LangfuseClient, Depends(Provide[Container.langfuse_client])
     ],

--- a/backend/api/routes/v1/hypothesis_driven_research.py
+++ b/backend/api/routes/v1/hypothesis_driven_research.py
@@ -23,6 +23,7 @@ from api.ee.auth.dependencies import (
     get_current_user_id,
     get_github_client,
     get_github_owner,
+    get_langchain_client,
 )
 from api.schemas.hypothesis_driven_research import (
     HypothesisDrivenResearchListItemResponse,
@@ -123,9 +124,7 @@ async def execute_hypothesis_driven_research(
     current_user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     github_owner: Annotated[str, Depends(get_github_owner)],
     github_client: Annotated[GithubClient, Depends(get_github_client)],
-    langchain_client: Annotated[
-        LangChainClient, Depends(Provide[Container.langchain_client])
-    ],
+    langchain_client: Annotated[LangChainClient, Depends(get_langchain_client)],
     langfuse_client: Annotated[
         LangfuseClient, Depends(Provide[Container.langfuse_client])
     ],

--- a/backend/api/routes/v1/latex.py
+++ b/backend/api/routes/v1/latex.py
@@ -17,7 +17,7 @@ from airas.usecases.publication.generate_latex_subgraph.generate_latex_subgraph 
 from airas.usecases.publication.push_latex_subgraph.push_latex_subgraph import (
     PushLatexSubgraph,
 )
-from api.ee.auth.dependencies import get_github_client
+from api.ee.auth.dependencies import get_github_client, get_langchain_client
 from api.schemas.latex import (
     CompileLatexSubgraphRequestBody,
     CompileLatexSubgraphResponseBody,
@@ -35,9 +35,7 @@ router = APIRouter(prefix="/latex", tags=["latex"])
 @observe()
 async def generate_latex(
     request: GenerateLatexSubgraphRequestBody,
-    langchain_client: Annotated[
-        LangChainClient, Depends(Provide[Container.langchain_client])
-    ],
+    langchain_client: Annotated[LangChainClient, Depends(get_langchain_client)],
     github_client: Annotated[GithubClient, Depends(get_github_client)],
     langfuse_client: Annotated[
         LangfuseClient, Depends(Provide[Container.langfuse_client])

--- a/backend/api/routes/v1/papers.py
+++ b/backend/api/routes/v1/papers.py
@@ -9,6 +9,7 @@ from airas.infra.arxiv_client import ArxivClient
 from airas.infra.github_client import GithubClient
 from airas.infra.langchain_client import LangChainClient
 from airas.infra.langfuse_client import LangfuseClient
+from airas.infra.litellm_client import LiteLLMClient
 from airas.usecases.retrieve.retrieve_paper_subgraph.retrieve_paper_subgraph import (
     RetrievePaperSubgraph,
 )
@@ -19,7 +20,7 @@ from airas.usecases.retrieve.search_paper_titles_subgraph.search_paper_titles_fr
     SearchPaperTitlesFromQdrantSubgraph,
 )
 from airas.usecases.writers.write_subgraph.write_subgraph import WriteSubgraph
-from api.ee.auth.dependencies import get_github_client
+from api.ee.auth.dependencies import get_github_client, get_langchain_client
 from api.schemas.papers import (
     RetrievePaperSubgraphRequestBody,
     RetrievePaperSubgraphResponseBody,
@@ -41,9 +42,9 @@ async def search_paper_titles(
     container: Container = fastapi_request.app.state.container
 
     if request.search_method == "qdrant":
-        litellm_client = container.litellm_client()
-        if hasattr(litellm_client, "__await__"):
-            litellm_client = await litellm_client
+        # NOTE: Qdrant embedding uses platform keys (env vars), not per-user keys.
+        # LiteLLMClient() with no args falls back to os.environ.
+        litellm_client = LiteLLMClient()
 
         qdrant_client = container.qdrant_client()
         if hasattr(qdrant_client, "__await__"):
@@ -87,9 +88,7 @@ async def search_paper_titles(
 @observe()
 async def get_paper_title(
     request: RetrievePaperSubgraphRequestBody,
-    langchain_client: Annotated[
-        LangChainClient, Depends(Provide[Container.langchain_client])
-    ],
+    langchain_client: Annotated[LangChainClient, Depends(get_langchain_client)],
     arxiv_client: Annotated[ArxivClient, Depends(Provide[Container.arxiv_client])],
     github_client: Annotated[GithubClient, Depends(get_github_client)],
     langfuse_client: Annotated[
@@ -122,9 +121,7 @@ async def get_paper_title(
 @observe()
 async def generate_paper(
     request: WriteSubgraphRequestBody,
-    langchain_client: Annotated[
-        LangChainClient, Depends(Provide[Container.langchain_client])
-    ],
+    langchain_client: Annotated[LangChainClient, Depends(get_langchain_client)],
     langfuse_client: Annotated[
         LangfuseClient, Depends(Provide[Container.langfuse_client])
     ],

--- a/backend/api/routes/v1/topic_open_ended_research.py
+++ b/backend/api/routes/v1/topic_open_ended_research.py
@@ -28,6 +28,8 @@ from api.ee.auth.dependencies import (
     get_current_user_id,
     get_github_client,
     get_github_owner,
+    get_langchain_client,
+    get_litellm_client,
 )
 from api.schemas.topic_open_ended_research import (
     TopicOpenEndedResearchListItemResponse,
@@ -155,12 +157,8 @@ async def execute_topic_open_ended_research(
     github_owner: Annotated[str, Depends(get_github_owner)],
     github_client: Annotated[GithubClient, Depends(get_github_client)],
     arxiv_client: Annotated[ArxivClient, Depends(Provide[Container.arxiv_client])],
-    langchain_client: Annotated[
-        LangChainClient, Depends(Provide[Container.langchain_client])
-    ],
-    litellm_client: Annotated[
-        LiteLLMClient, Depends(Provide[Container.litellm_client])
-    ],
+    langchain_client: Annotated[LangChainClient, Depends(get_langchain_client)],
+    litellm_client: Annotated[LiteLLMClient, Depends(get_litellm_client)],
     langfuse_client: Annotated[
         LangfuseClient, Depends(Provide[Container.langfuse_client])
     ],

--- a/backend/api/routes/v1/verification.py
+++ b/backend/api/routes/v1/verification.py
@@ -21,7 +21,11 @@ from airas.usecases.assisted_research.propose_verification_policy_subgraph.propo
     ProposeVerificationPolicySubgraph,
 )
 from airas.usecases.verification.verification_service import VerificationService
-from api.ee.auth.dependencies import get_current_user_id, get_github_client
+from api.ee.auth.dependencies import (
+    get_current_user_id,
+    get_github_client,
+    get_litellm_client,
+)
 from api.schemas.verification import (
     ExperimentCodeStatusResponseBody,
     GenerateExperimentCodeRequestBody,
@@ -160,9 +164,7 @@ def delete_session(
 @observe(capture_input=False)
 async def propose_policies(
     request: ProposePoliciesRequestBody,
-    litellm_client: Annotated[
-        LiteLLMClient, Depends(Provide[Container.litellm_client])
-    ],
+    litellm_client: Annotated[LiteLLMClient, Depends(get_litellm_client)],
     langfuse_client: Annotated[
         LangfuseClient, Depends(Provide[Container.langfuse_client])
     ],
@@ -223,9 +225,7 @@ async def propose_policies(
 @observe(capture_input=False)
 async def generate_method(
     request: GenerateMethodRequestBody,
-    litellm_client: Annotated[
-        LiteLLMClient, Depends(Provide[Container.litellm_client])
-    ],
+    litellm_client: Annotated[LiteLLMClient, Depends(get_litellm_client)],
     langfuse_client: Annotated[
         LangfuseClient, Depends(Provide[Container.langfuse_client])
     ],

--- a/backend/src/airas/container.py
+++ b/backend/src/airas/container.py
@@ -110,10 +110,12 @@ class Container(containers.DeclarativeContainer):
     github_async_session = providers.Resource(init_github_async_session)
 
     # --- LangChain Client ---
-    langchain_client: providers.Factory = providers.Factory(LangChainClient)
+    langchain_client: providers.Factory[LangChainClient] = providers.Factory(
+        LangChainClient
+    )
 
     # --- LiteLLM Client ---
-    litellm_client: providers.Factory = providers.Factory(LiteLLMClient)
+    litellm_client: providers.Factory[LiteLLMClient] = providers.Factory(LiteLLMClient)
 
     # --- Observability ---
     langfuse_client: providers.Factory[LangfuseClient] = providers.Factory(
@@ -197,7 +199,7 @@ class Container(containers.DeclarativeContainer):
 
     api_key_resolver = providers.Factory(
         ApiKeyResolver,
-        plan_repo=user_plan_repository,
+        plan_service=plan_service,
         api_key_repo=user_api_key_repository,
     )
 

--- a/backend/src/airas/core/types/llm_provider.py
+++ b/backend/src/airas/core/types/llm_provider.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class LLMProvider(str, Enum):
+    GOOGLE = "google"
+    VERTEX_AI = "vertex_ai"
+    OPENAI = "openai"
+    ANTHROPIC = "anthropic"
+    OPENROUTER = "openrouter"
+    BEDROCK = "bedrock"
+    AZURE = "azure"
+    VERCEL_AI_GATEWAY = "vercel_ai_gateway"

--- a/backend/src/airas/infra/langchain_client.py
+++ b/backend/src/airas/infra/langchain_client.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from collections.abc import Callable
 from typing import Any, get_args
 
 from botocore.config import Config
@@ -10,6 +11,8 @@ from langchain_core.messages.utils import trim_messages
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
 
+from airas.core.types.llm_provider import LLMProvider
+from airas.infra.llm_provider_resolver import detect_available_providers
 from airas.infra.llm_specs import (
     ANTHROPIC_MODELS,
     ANTHROPIC_MODELS_FOR_OPENROUTER,
@@ -23,7 +26,6 @@ from airas.infra.llm_specs import (
     AnthropicParams,
     GoogleGenAIParams,
     LLMParams,
-    LLMProvider,
     OpenAIParams,
     get_model_context_info,
 )
@@ -46,20 +48,20 @@ class MissingEnvironmentVariablesError(RuntimeError):
 
 
 class LangChainClient:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        get_api_key: Callable[[str], str | None] | None = None,
+        available_providers: set[LLMProvider] | None = None,
+    ) -> None:
+        self._get_api_key = get_api_key or (lambda _: None)
         self._model_cache: dict[
             tuple[LLM_MODELS, bool, tuple[tuple[str, Any], ...] | None], object
         ] = {}
-        self._available_providers: set[LLMProvider] = self._detect_available_providers()
-
-    def _detect_available_providers(self) -> set[LLMProvider]:
-        available: set[LLMProvider] = set()
-        for provider, vars_ in PROVIDER_REQUIRED_ENV_VARS.items():
-            missing = [name for name in vars_ if not os.getenv(name)]
-            if missing:
-                continue
-            available.add(provider)
-        return available
+        self._available_providers = (
+            available_providers
+            if available_providers is not None
+            else detect_available_providers(PROVIDER_REQUIRED_ENV_VARS)
+        )
 
     def _select_provider_for_model(self, llm_name: LLM_MODELS) -> LLMProvider:
         """
@@ -156,29 +158,40 @@ class LangChainClient:
             f"web_search={web_search}, params={params}, langchain_kwargs={langchain_kwargs}"
         )
 
+        api_key = self._get_api_key(llm_name)
+
         if provider is LLMProvider.OPENROUTER:
             base_url = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
-            api_key = os.getenv("OPENROUTER_API_KEY")
+            resolved_key = api_key or os.getenv("OPENROUTER_API_KEY")
 
             model_name = f"{llm_name}:online" if web_search else llm_name
 
             model = ChatOpenAI(
-                api_key=api_key,
+                api_key=resolved_key,
                 base_url=base_url,
                 model=model_name,
                 **langchain_kwargs,
             )
 
         elif provider is LLMProvider.OPENAI:
-            model = ChatOpenAI(model=llm_name, **langchain_kwargs)
+            openai_kwargs: dict[str, Any] = {"model": llm_name, **langchain_kwargs}
+            if api_key is not None:
+                openai_kwargs["api_key"] = api_key
+            model = ChatOpenAI(**openai_kwargs)
             if web_search:
                 model = model.bind_tools([{"type": "web_search"}])
 
         elif provider is LLMProvider.GOOGLE:
-            model = ChatGoogleGenerativeAI(model=llm_name, **langchain_kwargs)
+            google_kwargs: dict[str, Any] = {"model": llm_name, **langchain_kwargs}
+            if api_key is not None:
+                google_kwargs["google_api_key"] = api_key
+            model = ChatGoogleGenerativeAI(**google_kwargs)
 
         elif provider is LLMProvider.ANTHROPIC:
-            model = ChatAnthropic(model=llm_name, **langchain_kwargs)
+            anthropic_kwargs: dict[str, Any] = {"model": llm_name, **langchain_kwargs}
+            if api_key is not None:
+                anthropic_kwargs["anthropic_api_key"] = api_key
+            model = ChatAnthropic(**anthropic_kwargs)
 
         elif provider is LLMProvider.BEDROCK:
             # https://reference.langchain.com/python/integrations/langchain_aws/
@@ -320,3 +333,7 @@ class LangChainClient:
         )
         response = await model_with_structure.ainvoke(trimmed_messages)
         return response
+
+    @property
+    def available_providers(self) -> set[LLMProvider]:
+        return self._available_providers

--- a/backend/src/airas/infra/litellm_client.py
+++ b/backend/src/airas/infra/litellm_client.py
@@ -12,33 +12,23 @@ To view available models in your environment, run:
 import json
 import logging
 import os
-from enum import Enum
+from collections.abc import Callable
 from functools import lru_cache
 from typing import Any
 
 import litellm
 from litellm import get_valid_models
 
+from airas.core.types.llm_provider import LLMProvider
+from airas.infra.llm_provider_resolver import detect_available_providers
 from airas.infra.retry_policy import make_llm_retry_policy
 
 logger = logging.getLogger(__name__)
 
 _LLM_RETRY = make_llm_retry_policy()
 
-
-class LLMProvider(str, Enum):
-    GEMINI = "gemini"
-    VERTEX_AI = "vertex_ai"
-    OPENAI = "openai"
-    ANTHROPIC = "anthropic"
-    OPENROUTER = "openrouter"
-    BEDROCK = "bedrock"
-    AZURE = "azure"
-    VERCEL_AI_GATEWAY = "vercel_ai_gateway"
-
-
 PROVIDER_REQUIRED_ENV_VARS: dict[LLMProvider, list[str]] = {
-    LLMProvider.GEMINI: ["GEMINI_API_KEY"],
+    LLMProvider.GOOGLE: ["GEMINI_API_KEY"],
     LLMProvider.VERTEX_AI: ["VERTEX_PROJECT", "VERTEX_LOCATION"],
     LLMProvider.OPENAI: ["OPENAI_API_KEY"],
     LLMProvider.ANTHROPIC: ["ANTHROPIC_API_KEY"],
@@ -52,20 +42,20 @@ PROVIDER_REQUIRED_ENV_VARS: dict[LLMProvider, list[str]] = {
 
 
 class LiteLLMClient:
-    def __init__(self) -> None:
-        self._available_providers: set[LLMProvider] = self._detect_available_providers()
+    def __init__(
+        self,
+        get_api_key: Callable[[str], str | None] | None = None,
+        available_providers: set[LLMProvider] | None = None,
+    ) -> None:
+        self._get_api_key = get_api_key or (lambda _: None)
+        self._available_providers = (
+            available_providers
+            if available_providers is not None
+            else detect_available_providers(PROVIDER_REQUIRED_ENV_VARS)
+        )
         litellm.drop_params = True
         if logger.isEnabledFor(logging.DEBUG):
             os.environ["LITELLM_LOG"] = "DEBUG"
-
-    def _detect_available_providers(self) -> set[LLMProvider]:
-        available: set[LLMProvider] = set()
-        for provider, vars_ in PROVIDER_REQUIRED_ENV_VARS.items():
-            missing = [name for name in vars_ if not os.getenv(name)]
-            if missing:
-                continue
-            available.add(provider)
-        return available
 
     @_LLM_RETRY
     async def generate(
@@ -96,10 +86,13 @@ class LiteLLMClient:
                 "Proceeding without max_tokens limit."
             )
 
+        api_key = self._get_api_key(llm_name)
+
         try:
             response = await litellm.acompletion(
                 model=llm_name,
                 messages=messages,
+                api_key=api_key,
                 **litellm_kwargs,
             )  # TODO: timeoutを延長する
             content = response.choices[0].message.content
@@ -147,11 +140,14 @@ class LiteLLMClient:
                 "Proceeding without max_tokens limit."
             )
 
+        api_key = self._get_api_key(llm_name)
+
         try:
             response = await litellm.acompletion(
                 model=llm_name,
                 messages=messages,
                 response_format=data_model,
+                api_key=api_key,
                 **litellm_kwargs,
             )  # TODO: timeoutを延長する
 
@@ -193,9 +189,12 @@ class LiteLLMClient:
                 f"Failed to get model info for {model}: {e}. Proceeding without model metadata."
             )
 
+        api_key = self._get_api_key(model)
+
         try:
-            response = await litellm.aembedding(model=model, input=texts)
-            # Ensure we got a non-empty response
+            response = await litellm.aembedding(
+                model=model, input=texts, api_key=api_key
+            )
             data = getattr(response, "data", None)
             if not data:
                 raise ValueError(f"Empty embedding response from model {model}")

--- a/backend/src/airas/infra/llm_provider_resolver.py
+++ b/backend/src/airas/infra/llm_provider_resolver.py
@@ -1,0 +1,97 @@
+# TODO: Expose a guard/eligibility check (e.g. check_model_available(provider, available_providers))
+#       so that the backend can reject unsupported model requests early and the frontend
+#       can filter the model selector based on the user's available providers.
+
+from __future__ import annotations
+
+import os
+
+from airas.core.types.llm_provider import LLMProvider
+
+# ---------------------------------------------------------------------------
+# Provider -> primary API-key env-var name
+# ---------------------------------------------------------------------------
+PROVIDER_PRIMARY_KEY: dict[LLMProvider, str] = {
+    LLMProvider.GOOGLE: "GEMINI_API_KEY",
+    LLMProvider.OPENAI: "OPENAI_API_KEY",
+    LLMProvider.ANTHROPIC: "ANTHROPIC_API_KEY",
+    LLMProvider.OPENROUTER: "OPENROUTER_API_KEY",
+    LLMProvider.AZURE: "AZURE_API_KEY",
+    LLMProvider.VERCEL_AI_GATEWAY: "VERCEL_AI_GATEWAY_API_KEY",
+}
+
+
+# ---------------------------------------------------------------------------
+# Model-name prefix -> provider (order matters: first match wins)
+# ---------------------------------------------------------------------------
+_MODEL_PREFIX_TO_PROVIDER: list[tuple[str, LLMProvider]] = [
+    # Explicit litellm-style prefixes
+    ("gemini/", LLMProvider.GOOGLE),
+    ("vertex_ai/", LLMProvider.VERTEX_AI),
+    ("bedrock/", LLMProvider.BEDROCK),
+    ("azure/", LLMProvider.AZURE),
+    ("openrouter/", LLMProvider.OPENROUTER),
+    # Bare model names (no prefix)
+    ("gemini-", LLMProvider.GOOGLE),
+    ("gemini-embedding-", LLMProvider.GOOGLE),
+    ("gpt-", LLMProvider.OPENAI),
+    ("o1-", LLMProvider.OPENAI),
+    ("o3-", LLMProvider.OPENAI),
+    ("o4-", LLMProvider.OPENAI),
+    ("text-embedding-", LLMProvider.OPENAI),
+    ("claude-", LLMProvider.ANTHROPIC),
+    # Bedrock cross-region inference profile IDs
+    ("jp.", LLMProvider.BEDROCK),
+    ("us.", LLMProvider.BEDROCK),
+    ("eu.", LLMProvider.BEDROCK),
+    ("global.", LLMProvider.BEDROCK),
+    # OpenRouter vendor-prefixed models
+    ("google/", LLMProvider.OPENROUTER),
+    ("anthropic/", LLMProvider.OPENROUTER),
+    ("openai/", LLMProvider.OPENROUTER),
+]
+
+
+def infer_provider(model_name: str) -> LLMProvider | None:
+    """Infer the LLM provider from a model name.
+
+    Resolution strategy:
+    1. Prefix-table lookup (covers most cases).
+    2. Slash-prefix fallback — treats the segment before the first ``/``
+       as a potential provider value (e.g. ``"openai/gpt-4"``).
+
+    Returns ``None`` when the provider cannot be determined.
+    """
+    for prefix, provider in _MODEL_PREFIX_TO_PROVIDER:
+        if model_name.startswith(prefix):
+            return provider
+
+    # Fallback: "provider/model" convention
+    if "/" in model_name:
+        candidate = model_name.split("/", 1)[0].lower()
+        try:
+            return LLMProvider(candidate)
+        except ValueError:
+            pass
+
+    return None
+
+
+def detect_available_providers(
+    required_env_vars: dict[LLMProvider, list[str]],
+    api_keys: dict[str, str] | None = None,
+) -> set[LLMProvider]:
+    """Return providers whose required credentials are present.
+
+    When *api_keys* is given the dict is checked first; otherwise
+    ``os.environ`` is consulted (backward-compatible self-host path).
+    """
+    available: set[LLMProvider] = set()
+    for provider, vars_ in required_env_vars.items():
+        if api_keys is not None:
+            missing = [name for name in vars_ if name not in api_keys]
+        else:
+            missing = [name for name in vars_ if not os.getenv(name)]
+        if not missing:
+            available.add(provider)
+    return available

--- a/backend/src/airas/infra/llm_specs.py
+++ b/backend/src/airas/infra/llm_specs.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from functools import lru_cache
 from typing import Annotated, TypeAlias, get_args
 
@@ -6,14 +5,7 @@ import litellm
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
-
-class LLMProvider(str, Enum):
-    GOOGLE = "google"
-    OPENAI = "openai"
-    ANTHROPIC = "anthropic"
-    OPENROUTER = "openrouter"
-    BEDROCK = "bedrock"
-
+from airas.core.types.llm_provider import LLMProvider
 
 PROVIDER_REQUIRED_ENV_VARS: dict[LLMProvider, list[str]] = {
     LLMProvider.GOOGLE: [

--- a/backend/src/airas/usecases/ee/api_key_resolver.py
+++ b/backend/src/airas/usecases/ee/api_key_resolver.py
@@ -1,15 +1,16 @@
 """Resolve LLM API keys based on user plan.
 
-Free users: use their own API keys stored in DB (encrypted).
-Pro users: use platform-provided API keys from environment variables.
+Non-EE: use API keys from environment variables directly.
+EE Free users: use their own API keys stored in DB (encrypted).
+EE Pro users: use platform-provided API keys from environment variables,
+              with optional fallback to user-stored keys.
 
 This module owns the full ``user_id + model -> api_key`` resolution chain.
 """
 
 import logging
 import os
-from collections.abc import Callable, Generator
-from contextlib import contextmanager
+from collections.abc import Callable
 from uuid import UUID
 
 from airas.infra.db.models.user_api_key import ApiProvider
@@ -17,7 +18,7 @@ from airas.infra.db.models.user_plan import PlanType
 from airas.infra.encryption import decrypt
 from airas.infra.llm_provider_resolver import PROVIDER_PRIMARY_KEY, infer_provider
 from airas.repository.user_api_key_repository import UserApiKeyRepository
-from airas.repository.user_plan_repository import UserPlanRepository
+from airas.usecases.ee.plan_service import PlanService
 
 logger = logging.getLogger(__name__)
 
@@ -28,8 +29,8 @@ _PROVIDER_ENV_MAP: dict[ApiProvider, str] = {
     ApiProvider.GEMINI: "GEMINI_API_KEY",
 }
 
-# Platform keys are stored with this prefix in environment variables
-_PLATFORM_KEY_PREFIX = "PLATFORM_"
+# TODO: Provisional name. Rename once the paid plan is finalised.
+_PLATFORM_API_KEY_ENV = "AIRAS_API_KEY"
 
 
 class ApiKeyResolver:
@@ -37,36 +38,31 @@ class ApiKeyResolver:
 
     def __init__(
         self,
-        plan_repo: UserPlanRepository,
+        plan_service: PlanService,
         api_key_repo: UserApiKeyRepository,
     ):
-        self._plan_repo = plan_repo
+        self._plan_service = plan_service
         self._api_key_repo = api_key_repo
 
-    def resolve_keys(self, user_id: UUID) -> dict[str, str]:
-        """Return a dict of env_var_name -> api_key for the given user.
+    def resolve_keys(self, user_id: UUID | None = None) -> dict[str, str]:
+        """Return a dict of env_var_name -> api_key.
 
-        Pro users get platform-provided keys (PLATFORM_OPENAI_API_KEY etc.).
-        Free users get their own DB-stored keys.
+        - user_id is None (non-EE): read keys from environment variables directly.
+        - EE paid plan: use platform-provided AIRAS_API_KEY,
+          with fallback to user-stored keys for providers not covered.
+        - EE Free: use user-stored DB keys only.
         """
-        plan = self._plan_repo.get_by_user(user_id)
-        is_pro = plan is not None and plan.plan_type == PlanType.PRO
+        if user_id is None:
+            return self._resolve_from_env()
 
-        keys: dict[str, str] = {}
-
-        if is_pro:
-            for _provider, env_name in _PROVIDER_ENV_MAP.items():
-                platform_key = os.getenv(f"{_PLATFORM_KEY_PREFIX}{env_name}", "")
-                if platform_key:
-                    keys[env_name] = platform_key
-        else:
-            db_keys = self._api_key_repo.list_by_user(user_id)
-            for db_key in db_keys:
-                env_name = _PROVIDER_ENV_MAP.get(ApiProvider(db_key.provider))
-                if env_name:
-                    keys[env_name] = decrypt(db_key.encrypted_key)
-
-        return keys
+        plan = self._plan_service.get_plan(user_id)
+        match plan.plan_type:
+            case PlanType.PRO:
+                return self._resolve_platform_keys(user_id)
+            case PlanType.FREE:
+                return self._resolve_user_keys(user_id)
+            case _ as unknown:
+                raise ValueError(f"Unknown plan type: {unknown}")
 
     def create_key_fn(self, keys: dict[str, str]) -> Callable[[str], str | None]:
         def _resolve(model_name: str) -> str | None:
@@ -83,27 +79,43 @@ class ApiKeyResolver:
 
         return _resolve
 
-    @contextmanager
-    def inject_keys(self, user_id: UUID) -> Generator[None, None, None]:
-        """Context manager that temporarily sets resolved API keys as env vars.
+    def _resolve_from_env(self) -> dict[str, str]:
+        """Non-EE path: read API keys from plain environment variables."""
+        keys: dict[str, str] = {}
+        for _provider, env_name in _PROVIDER_ENV_MAP.items():
+            val = os.getenv(env_name, "")
+            if val:
+                keys[env_name] = val
+        return keys
 
-        Restores original values on exit.
+    def _resolve_platform_keys(self, user_id: UUID) -> dict[str, str]:
+        """EE paid plan: use platform-provided AIRAS_API_KEY, fallback to user keys.
+
+        TODO: How AIRAS_API_KEY maps to individual providers is TBD.
+        For now it is stored under every provider env-var name so that
+        existing client code can pick it up regardless of provider.
         """
-        resolved = self.resolve_keys(user_id)
-        originals: dict[str, str | None] = {}
+        keys: dict[str, str] = {}
+        platform_key = os.getenv(_PLATFORM_API_KEY_ENV, "")
+        if platform_key:
+            for _provider, env_name in _PROVIDER_ENV_MAP.items():
+                keys[env_name] = platform_key
 
-        for env_name, key_value in resolved.items():
-            originals[env_name] = os.environ.get(env_name)
-            os.environ[env_name] = key_value
+        # Fallback: fill in providers not covered by platform key
+        db_keys = self._api_key_repo.list_by_user(user_id)
+        for db_key in db_keys:
+            env_name = _PROVIDER_ENV_MAP.get(ApiProvider(db_key.provider))
+            if env_name and env_name not in keys:
+                keys[env_name] = decrypt(db_key.encrypted_key)
 
-        try:
-            yield
-        finally:
-            for env_name, original in originals.items():
-                if original is None:
-                    os.environ.pop(env_name, None)
-                else:
-                    os.environ[env_name] = original
+        return keys
 
-    def close(self) -> None:
-        self._plan_repo.db.close()
+    def _resolve_user_keys(self, user_id: UUID) -> dict[str, str]:
+        """EE Free: user-stored DB keys only."""
+        keys: dict[str, str] = {}
+        db_keys = self._api_key_repo.list_by_user(user_id)
+        for db_key in db_keys:
+            env_name = _PROVIDER_ENV_MAP.get(ApiProvider(db_key.provider))
+            if env_name:
+                keys[env_name] = decrypt(db_key.encrypted_key)
+        return keys

--- a/backend/src/airas/usecases/ee/api_key_resolver.py
+++ b/backend/src/airas/usecases/ee/api_key_resolver.py
@@ -2,17 +2,20 @@
 
 Free users: use their own API keys stored in DB (encrypted).
 Pro users: use platform-provided API keys from environment variables.
+
+This module owns the full ``user_id + model -> api_key`` resolution chain.
 """
 
 import logging
 import os
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from uuid import UUID
 
 from airas.infra.db.models.user_api_key import ApiProvider
 from airas.infra.db.models.user_plan import PlanType
 from airas.infra.encryption import decrypt
+from airas.infra.llm_provider_resolver import PROVIDER_PRIMARY_KEY, infer_provider
 from airas.repository.user_api_key_repository import UserApiKeyRepository
 from airas.repository.user_plan_repository import UserPlanRepository
 
@@ -64,6 +67,21 @@ class ApiKeyResolver:
                     keys[env_name] = decrypt(db_key.encrypted_key)
 
         return keys
+
+    def create_key_fn(self, keys: dict[str, str]) -> Callable[[str], str | None]:
+        def _resolve(model_name: str) -> str | None:
+            provider = infer_provider(model_name)
+            if provider is None:
+                logger.warning(
+                    f"Cannot infer provider for model '{model_name}'; no api_key will be injected."
+                )
+                return None
+            env_var = PROVIDER_PRIMARY_KEY.get(provider)
+            if env_var is None:
+                return None
+            return keys.get(env_var)
+
+        return _resolve
 
     @contextmanager
     def inject_keys(self, user_id: UUID) -> Generator[None, None, None]:

--- a/frontend/src/lib/api/models/ExperimentHistory_Input.ts
+++ b/frontend/src/lib/api/models/ExperimentHistory_Input.ts
@@ -5,7 +5,7 @@
 import type { ExperimentCycle_Input } from './ExperimentCycle_Input';
 export type ExperimentHistory_Input = {
     /**
-     * Append-only list of experiment cycles (pilot and main only; sanity is not recorded)
+     * Append-only list of experiment cycles (pilot and full only; sanity is not recorded)
      */
     cycles?: Array<ExperimentCycle_Input>;
 };

--- a/frontend/src/lib/api/models/ExperimentHistory_Output.ts
+++ b/frontend/src/lib/api/models/ExperimentHistory_Output.ts
@@ -5,7 +5,7 @@
 import type { ExperimentCycle_Output } from './ExperimentCycle_Output';
 export type ExperimentHistory_Output = {
     /**
-     * Append-only list of experiment cycles (pilot and main only; sanity is not recorded)
+     * Append-only list of experiment cycles (pilot and full only; sanity is not recorded)
      */
     cycles?: Array<ExperimentCycle_Output>;
 };


### PR DESCRIPTION
## 背景と目的

`LangChainClient` と `LiteLLMClient` では、APIキーの取得が各SDKの内部 `os.getenv` に暗黙的に依存しており、非EE/EE（Free/Pro）のパターンごとにキー解決の経路が異なっていた。また、クライアントのインスタンス生成がContainerを経由せず直接行われていたため、リソース管理が一元化されていなかった。

このPRでは、APIキー解決ロジックを `ApiKeyResolver` に一元化し、全パターンで `resolve_keys` → `create_key_fn` による明示的なキー注入に統一する。あわせて、クライアント生成をContainer経由に変更し、不要なコード（`inject_keys`、`close()`）を削除する。

- https://github.com/airas-org/airas/issues/855

## 変更内容

以下の変更が行われました：

1. **APIキー解決ロジックの一元化**: 非EE/EE Free/EE Proすべてのパターンで `ApiKeyResolver.resolve_keys()` → `create_key_fn()` 経由のキー注入に統一
2. **`LangChainClient` / `LiteLLMClient` への明示的キー注入対応**: コンストラクタに `get_api_key` / `available_providers` を追加し、SDKの暗黙的 `os.getenv` 依存を排除
3. **LLMプロバイダ関連の型・ロジックの整理**: `LLMProvider` を共通型として分離し、プロバイダ推定ロジック (`infer_provider`) と利用可能プロバイダ検出 (`detect_available_providers`) を `llm_provider_resolver` に集約
4. **Container経由のクライアント生成**: `Provider[Container.langchain_client]` / `Provider[Container.litellm_client]` によるファクトリ注入に変更
5. **不要コードの削除と設計改善**: `inject_keys`（デッドコード）、`close()`（責務違反）を削除。`ApiKeyResolver` が `PlanService` を使うように変更し、planレコード未作成時の自動FREEプラン作成を保証
6. **EE Proのキー仕様の暫定対応**: プラットフォーム提供キーを仮称 `AIRAS_API_KEY`（単一キー）とし、ユーザーキーへのフォールバックも実装
   - プラン判定を `match-case` で記述し、将来のプラン追加に対応しやすい構造に変更

実装の詳細は以下の通りです：

<details>
<summary><code>1. ApiKeyResolver の再設計</code></summary>

**実装概要**

- **`resolve_keys(user_id: UUID | None)`**: `user_id=None`（非EE）ではenvから直接取得、EEでは `PlanService.get_plan()` を使いプラン判定
  - `PlanType.PRO`: `AIRAS_API_KEY` から取得 → ユーザーDBキーでフォールバック（`_resolve_platform_keys`）
  - `PlanType.FREE`: ユーザーDBキーのみ（`_resolve_user_keys`）
  - 未知のプランタイプ: `ValueError` で即座にエラー
- **`create_key_fn(keys)`**: モデル名からプロバイダを推定し、対応するAPIキーを返すクロージャを生成
- **削除**: `inject_keys`（env一時書き換え方式）、`close()`（DBセッション直接クローズ）
- **依存関係の変更**: `UserPlanRepository` → `PlanService` に変更し、planレコード自動作成を保証

</details>

<details>
<summary><code>2. LangChainClient / LiteLLMClient のキー注入対応</code></summary>

**実装概要**

- **コンストラクタ拡張**: `get_api_key: Callable[[str], str | None]` と `available_providers: set[LLMProvider]` を追加
  - 引数なしの場合は従来通り `os.getenv` フォールバック（後方互換）
- **LangChainClient**: 各SDKへのキー渡し方をプロバイダごとに分岐（`api_key`, `google_api_key`, `anthropic_api_key` 等）
- **LiteLLMClient**: `litellm.acompletion` / `litellm.aembedding` に `api_key` パラメータを明示渡し
- **`_detect_available_providers` の削除**: 共通化された `detect_available_providers` に置き換え

</details>

<details>
<summary><code>3. LLMProvider の共通型化と llm_provider_resolver の新設</code></summary>

**実装概要**

- **`airas.core.types.llm_provider.LLMProvider`**: `llm_specs.py` と `litellm_client.py` で重複していた `LLMProvider` enumを共通モジュールに分離
  - `AZURE`, `VERCEL_AI_GATEWAY` を追加
- **`airas.infra.llm_provider_resolver`** (新規):
  - `PROVIDER_PRIMARY_KEY`: プロバイダ → 主要APIキー環境変数名のマッピング
  - `infer_provider(model_name)`: モデル名からプロバイダを推定（prefix テーブル + スラッシュフォールバック）
  - `detect_available_providers(required_env_vars, api_keys)`: 指定されたキーdict または `os.environ` から利用可能プロバイダを検出

</details>

<details>
<summary><code>4. dependencies.py / routes の統一</code></summary>

**実装概要**

- **`get_langchain_client` / `get_litellm_client`**: 新規 FastAPI dependency として追加。非EE/EE分岐を吸収し、`Provider[Container.langchain_client]` でファクトリ注入
- **全ルートハンドラの更新**: `Depends(Provide[Container.langchain_client])` → `Depends(get_langchain_client)` に一括変更
  - 対象: `experimental_settings`, `experiments`, `hypotheses`, `hypothesis_driven_research`, `latex`, `papers`, `topic_open_ended_research`, `verification`
- **Container**: `langchain_client` / `litellm_client` に型注釈 `providers.Factory[T]` を追加。`api_key_resolver` の配線を `plan_service` に変更

</details>
