### PR TITLE
chore: remove cloud deployment configuration

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -25,23 +25,12 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Railway CLI
-RUN npm install -g @railway/cli
-
-# ttyd / cloudflared
+# ttyd
 RUN DPKG_ARCH=$(dpkg --print-architecture) && \
     if [ "$DPKG_ARCH" = "amd64" ]; then TTYD_ARCH="x86_64"; else TTYD_ARCH="aarch64"; fi && \
     curl -fsSL -o /usr/local/bin/ttyd \
       "https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.${TTYD_ARCH}" && \
     chmod +x /usr/local/bin/ttyd
-
-ARG CLOUDFLARED_VERSION=2026.3.0
-RUN ARCH=$(dpkg --print-architecture) && \
-    cd /tmp && \
-    curl -fsSL -o "cloudflared-linux-${ARCH}" \
-      "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-${ARCH}" && \
-    install -m 0755 "cloudflared-linux-${ARCH}" /usr/local/bin/cloudflared && \
-    rm "cloudflared-linux-${ARCH}"
 
 # uv・Claude Code
 USER $USERNAME

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -44,18 +44,6 @@ Pull requests that do not meet these requirements may be requested for revision 
 ### MCP servers and Plugins
 For core team development, we use the following. If you need access, please contact us and we will invite you to each service.
 
-- [Vercel](https://vercel.com/docs/agent-resources/vercel-mcp#claude-code)
-
-    ```bash
-    claude mcp add --transport http vercel https://mcp.vercel.com
-    ```
-
-- [Railway](https://docs.railway.com/ai/mcp-server#claude-code)
-
-    ```bash
-    claude mcp add Railway npx @railway/mcp-server
-    ```
-
 - [Subframe](https://docs.subframe.com/guides/mcp-server#installation)
 
     ```bash

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -43,9 +43,6 @@ from api.routes.v1 import (
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
     database_url = os.getenv("DATABASE_URL")
-    # Railway provides postgresql:// but SQLAlchemy needs the psycopg driver specified
-    if database_url and database_url.startswith("postgresql://"):
-        database_url = database_url.replace("postgresql://", "postgresql+psycopg://", 1)
     container = Container()
     container.config.from_dict({"database_url": database_url})
 
@@ -100,11 +97,7 @@ def create_app() -> FastAPI:
 
     application.add_middleware(
         CORSMiddleware,
-        allow_origins=[
-            "https://app.airas.io",
-            "https://app-dev.airas.io",
-        ],
-        allow_origin_regex=r"https://(airas.*\.vercel\.app|.*\.trycloudflare\.com)|http://(localhost|127\.0\.0\.1):\d+",
+        allow_origin_regex=r"http://(localhost|127\.0\.0\.1):\d+",
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,3 +1,0 @@
-{
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
-}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,9 +8,6 @@ import { defineConfig } from "vite";
 export default defineConfig({
   envDir: path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."),
   plugins: [react()],
-  server: {
-    allowedHosts: [".trycloudflare.com"],
-  },
   resolve: {
     alias: {
       "@": path.resolve(path.dirname(fileURLToPath(import.meta.url)), "./src"),


### PR DESCRIPTION
## 概要

クラウド環境へのデプロイを行わなくなったため、ホスティング/デプロイ関連の実装を削除しました。**ローカル開発（compose / devcontainer）や CI テストは維持**しています。また **GitHub Pages のドキュメント公開は意図的に残しています**（別途「維持」を選択済み）。

## 削除内容

### ① Vercel / Railway ホスティング設定
- `frontend/vercel.json`（Vercel の SPA ルーティング設定）を削除
- `backend/api/main.py`: Railway 用の `postgresql://` → `postgresql+psycopg://` 変換シムを削除（`.env.example` は既に `postgresql+psycopg://` を使用しているためローカル/compose に影響なし）
- `.devcontainer/dev.Dockerfile`: Railway CLI インストールを削除（`ttyd` は維持）
- `CONTRIBUTING.md`: Vercel / Railway の MCP サーバー登録手順を削除

### ② 本番ドメインの CORS 設定
- `main.py` の CORS を **localhost のみ**に制限（`app.airas.io` / `app-dev.airas.io` / `*.vercel.app` / `*.trycloudflare.com` を削除）

### ③ Cloudflare Tunnel 関連
- `.devcontainer/dev.Dockerfile`: `cloudflared` インストールを削除
- `frontend/vite.config.ts`: `.trycloudflare.com` の `allowedHosts` を削除

## 維持したもの（デプロイではないため）
- `VERCEL_AI_GATEWAY`（LLM プロバイダ設定。ホスティングの Vercel とは無関係）
- E2E 系ワークフロー（`e2e_scheduled.yml` / `hypothesis_driven_research.yml`。localhost 相手の CI テスト）
- GitHub Pages ドキュメント公開（`upload_github_pages.yml` と README/サイドバーのリンク）

## 検証
- ✅ backend: `ruff` / `mypy`（main.py）パス、`create_app()` import 成功
- ✅ frontend: `tsc`（vite.config）終了コード0、`biome` パス
- ✅ 削除対象シンボルへの dangling reference なし

## 補足
- `dispatch_interactive_repo_agent_subgraph.py` は Cloudflare Tunnel の URL を利用するアプリ機能を含みますが、今回の削除スコープ（devcontainer + vite の Tunnel 用インフラ設定）外のためアプリコードは未変更です。この機能をローカルで使う場合は別途トンネル手段の用意が必要になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)