### PR TITLE
feat: add local MCP server exposing research subgraphs as tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ Currently, it focuses on the automation of machine learning research.
 Run the full research pipeline directly from any GitHub repository using the provided workflow.
 See **[QUICKSTART.md](./QUICKSTART.md)** for setup instructions and required API keys.
 
+### Option 3 — MCP Server (use from Claude Code / Claude Desktop)
+
+Use AIRAS research tools (paper search, retrieval, hypothesis generation) directly from an MCP client. No clone, no Docker — only [uv](https://docs.astral.sh/uv/) is required:
+
+```bash
+claude mcp add airas \
+  --env OPENAI_API_KEY=sk-... \
+  --env GH_PERSONAL_ACCESS_TOKEN=ghp_... \
+  -- uvx --from "airas[mcp]" airas-mcp
+```
+
+See the [MCP documentation](https://airas-org.github.io/airas/development/MCP) for the full tool list and configuration options.
+
 ## Roadmap
 
 - [x] Complete automation of machine learning research with code-based experimentation

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -112,7 +112,8 @@ explicit = true
 
 [project.optional-dependencies]
 mcp = [
-    "asyncio>=3.4.3",
     "mcp[cli]>=1.6.0",
-    "python-dotenv>=1.0.1",
 ]
+
+[project.scripts]
+airas-mcp = "airas.mcp.server:main"

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -5,26 +5,63 @@ such as Claude Code and Claude Desktop.
 
 Credentials are read from environment variables:
 - LLM providers: OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY (at least one)
-- GitHub (retrieve_papers only): GH_PERSONAL_ACCESS_TOKEN
+- GitHub (repository/experiment tools): GH_PERSONAL_ACCESS_TOKEN
 
 Run locally:
     uvx --from "airas[mcp]" airas-mcp
 """
 
 import os
-from typing import Any
+from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import BaseModel
 
+from airas.core.types.experiment_code import ExperimentCode
+from airas.core.types.experimental_design import ComputeEnvironment, ExperimentalDesign
+from airas.core.types.experimental_results import ExperimentalResults
+from airas.core.types.github import GitHubConfig
+from airas.core.types.research_history import ResearchHistory
+from airas.core.types.research_hypothesis import ResearchHypothesis
 from airas.core.types.research_study import ResearchStudy
+from airas.core.types.wandb import WandbConfig
 from airas.infra.arxiv_client import ArxivClient
 from airas.infra.github_client import GithubClient
 from airas.infra.langchain_client import LangChainClient
+from airas.usecases.analyzers.analyze_experiment_subgraph.analyze_experiment_subgraph import (
+    AnalyzeExperimentSubgraph,
+)
+from airas.usecases.executors.dispatch_experiment_on_static_runner_subgraph.dispatch_experiment_on_static_runner_subgraph import (
+    DispatchExperimentOnStaticRunnerSubgraph,
+)
+from airas.usecases.executors.fetch_experiment_code_subgraph.fetch_experiment_code_subgraph import (
+    FetchExperimentCodeSubgraph,
+)
+from airas.usecases.executors.fetch_experiment_results_subgraph.fetch_experiment_results_subgraph import (
+    FetchExperimentResultsSubgraph,
+)
+from airas.usecases.generators.dispatch_code_generation_subgraph.dispatch_code_generation_subgraph import (
+    DispatchCodeGenerationSubgraph,
+)
+from airas.usecases.generators.generate_experimental_design_subgraph.generate_experimental_design_subgraph import (
+    GenerateExperimentalDesignSubgraph,
+)
 from airas.usecases.generators.generate_hypothesis_subgraph.generate_hypothesis_subgraph_v0 import (
     GenerateHypothesisSubgraphV0,
 )
 from airas.usecases.generators.generate_queries_subgraph.generate_queries_subgraph import (
     GenerateQueriesSubgraph,
+)
+from airas.usecases.github.download_github_actions_artifacts_subgraph.download_github_actions_artifacts_subgraph import (
+    DownloadGithubActionsArtifactsSubgraph,
+)
+from airas.usecases.github.github_download_subgraph import GithubDownloadSubgraph
+from airas.usecases.github.github_upload_subgraph import GithubUploadSubgraph
+from airas.usecases.github.prepare_repository_subgraph.prepare_repository_subgraph import (
+    PrepareRepositorySubgraph,
+)
+from airas.usecases.github.set_github_actions_secrets_subgraph.set_github_actions_secrets_subgraph import (
+    SetGithubActionsSecretsSubgraph,
 )
 from airas.usecases.retrieve.retrieve_paper_subgraph.retrieve_paper_subgraph import (
     RetrievePaperSubgraph,
@@ -51,6 +88,13 @@ def _github_client() -> GithubClient:
             "Set it in the `env` block of your MCP client configuration."
         )
     return GithubClient(github_token=token)
+
+
+def _dump(value: Any) -> Any:
+    return value.model_dump() if isinstance(value, BaseModel) else value
+
+
+# --- Paper discovery & hypothesis ---
 
 
 @mcp.tool()
@@ -145,6 +189,413 @@ async def generate_hypothesis(
         )
     )
     return result["research_hypothesis"].model_dump()
+
+
+# --- Experimental design ---
+
+
+@mcp.tool()
+async def generate_experimental_design(
+    research_hypothesis: dict[str, Any],
+    compute_environment: dict[str, Any] | None = None,
+    num_models_to_use: int = 1,
+    num_datasets_to_use: int = 1,
+    num_comparative_methods: int = 1,
+) -> dict[str, Any]:
+    """Design experiments to test a research hypothesis.
+
+    `research_hypothesis` should be the output of `generate_hypothesis`.
+    `compute_environment` optionally describes the hardware the experiments
+    will run on (e.g. {"gpu_type": "A100", "gpu_count": 1}); it constrains
+    the design to what is actually runnable. Requires an LLM provider API key.
+    """
+    env = ComputeEnvironment.model_validate(compute_environment or {})
+    result = (
+        await GenerateExperimentalDesignSubgraph(
+            langchain_client=LangChainClient(),
+            compute_environment=env,
+            num_models_to_use=num_models_to_use,
+            num_datasets_to_use=num_datasets_to_use,
+            num_comparative_methods=num_comparative_methods,
+        )
+        .build_graph()
+        .ainvoke(
+            {
+                "research_hypothesis": ResearchHypothesis.model_validate(
+                    research_hypothesis
+                ),
+            }
+        )
+    )
+    return _dump(result["experimental_design"])
+
+
+# --- Experiment repository & execution (GitHub Actions) ---
+
+
+@mcp.tool()
+async def prepare_repository(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str = "main",
+    is_private: bool = True,
+) -> dict[str, Any]:
+    """Create and initialize a GitHub repository for running experiments.
+
+    Sets up the repository (from the AIRAS experiment template) and the
+    working branch. Run this once before `dispatch_code_generation`.
+    Requires GH_PERSONAL_ACCESS_TOKEN.
+    """
+    config = GitHubConfig(
+        github_owner=github_owner,
+        repository_name=repository_name,
+        branch_name=branch_name,
+    )
+    result = (
+        await PrepareRepositorySubgraph(
+            github_client=_github_client(),
+            is_github_repo_private=is_private,
+        )
+        .build_graph()
+        .ainvoke({"github_config": config})
+    )
+    return {
+        "is_repository_ready": result["is_repository_ready"],
+        "is_branch_ready": result["is_branch_ready"],
+    }
+
+
+@mcp.tool()
+async def set_github_actions_secrets(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str = "main",
+) -> dict[str, Any]:
+    """Copy required secrets (LLM API keys etc.) from local environment variables to the experiment repository's GitHub Actions secrets.
+
+    Run this after `prepare_repository` so that code generation and
+    experiment workflows can call LLM providers. Requires GH_PERSONAL_ACCESS_TOKEN.
+    """
+    config = GitHubConfig(
+        github_owner=github_owner,
+        repository_name=repository_name,
+        branch_name=branch_name,
+    )
+    result = (
+        await SetGithubActionsSecretsSubgraph(github_client=_github_client())
+        .build_graph()
+        .ainvoke({"github_config": config})
+    )
+    return {"secrets_set": result["secrets_set"]}
+
+
+@mcp.tool()
+async def dispatch_code_generation(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+    research_topic: str,
+    research_hypothesis: dict[str, Any],
+    experimental_design: dict[str, Any],
+    wandb_entity: str,
+    wandb_project: str,
+    github_actions_agent: Literal["claude_code", "open_code"] = "open_code",
+) -> dict[str, Any]:
+    """Start experiment-code generation on GitHub Actions (asynchronous).
+
+    Dispatches a workflow in the experiment repository that generates the
+    experiment code with a coding agent. Returns immediately with
+    `dispatched`; track progress with `get_workflow_runs` and fetch the
+    generated code with `fetch_experiment_code` once the run succeeds.
+    Requires GH_PERSONAL_ACCESS_TOKEN and an LLM provider API key.
+    """
+    result = (
+        await DispatchCodeGenerationSubgraph(
+            github_client=_github_client(),
+            llm_mapping=None,
+        )
+        .build_graph()
+        .ainvoke(
+            {
+                "github_config": GitHubConfig(
+                    github_owner=github_owner,
+                    repository_name=repository_name,
+                    branch_name=branch_name,
+                ),
+                "research_topic": research_topic,
+                "research_hypothesis": ResearchHypothesis.model_validate(
+                    research_hypothesis
+                ),
+                "experimental_design": ExperimentalDesign.model_validate(
+                    experimental_design
+                ),
+                "wandb_config": WandbConfig(entity=wandb_entity, project=wandb_project),
+                "github_actions_agent": github_actions_agent,
+            }
+        )
+    )
+    return {"dispatched": result["dispatched"]}
+
+
+@mcp.tool()
+async def dispatch_experiment(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+    run_id: str,
+    workflow: Literal["sanity_check", "main"] = "sanity_check",
+    runner_label: list[str] | None = None,
+) -> dict[str, Any]:
+    """Start an experiment run on GitHub Actions (asynchronous).
+
+    `workflow` selects the stage: "sanity_check" for a quick correctness run,
+    "main" for the full experiment. `run_id` identifies the experiment run
+    defined by the generated code. Returns immediately with `dispatched`;
+    track progress with `get_workflow_runs` and collect outputs with
+    `fetch_experiment_results`. Requires GH_PERSONAL_ACCESS_TOKEN.
+    """
+    workflow_file = (
+        "run_sanity_check.yml"
+        if workflow == "sanity_check"
+        else "run_main_experiment.yml"
+    )
+    result = (
+        await DispatchExperimentOnStaticRunnerSubgraph(
+            github_client=_github_client(),
+            workflow_file=workflow_file,
+            runner_label=runner_label or ["ubuntu-latest"],
+        )
+        .build_graph()
+        .ainvoke(
+            {
+                "github_config": GitHubConfig(
+                    github_owner=github_owner,
+                    repository_name=repository_name,
+                    branch_name=branch_name,
+                ),
+                "run_id": run_id,
+            }
+        )
+    )
+    return {"dispatched": result["dispatched"]}
+
+
+@mcp.tool()
+async def get_workflow_runs(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str | None = None,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Check the status of recent GitHub Actions runs in the experiment repository (non-blocking).
+
+    Returns the most recent dispatched workflow runs with their status and
+    conclusion. Use this to track runs started by `dispatch_code_generation`
+    or `dispatch_experiment` — poll it between other work instead of waiting.
+    Requires GH_PERSONAL_ACCESS_TOKEN.
+    """
+    response = await _github_client().alist_workflow_runs(
+        github_owner=github_owner,
+        repository_name=repository_name,
+        branch_name=branch_name,
+    )
+    runs = (response or {}).get("workflow_runs", [])[:limit]
+    return [
+        {
+            "workflow_run_id": run.get("id"),
+            "name": run.get("name"),
+            "status": run.get("status"),
+            "conclusion": run.get("conclusion"),
+            "created_at": run.get("created_at"),
+            "html_url": run.get("html_url"),
+        }
+        for run in runs
+    ]
+
+
+@mcp.tool()
+async def fetch_experiment_code(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+) -> dict[str, Any]:
+    """Fetch the generated experiment code from the experiment repository.
+
+    Use after a `dispatch_code_generation` run has succeeded. The returned
+    object can be passed to `analyze_experiment` as `experiment_code`.
+    Requires GH_PERSONAL_ACCESS_TOKEN.
+    """
+    result = (
+        await FetchExperimentCodeSubgraph(github_client=_github_client())
+        .build_graph()
+        .ainvoke(
+            {
+                "github_config": GitHubConfig(
+                    github_owner=github_owner,
+                    repository_name=repository_name,
+                    branch_name=branch_name,
+                )
+            }
+        )
+    )
+    return _dump(result["experiment_code"])
+
+
+@mcp.tool()
+async def fetch_experiment_results(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+) -> dict[str, Any]:
+    """Fetch experiment results from the experiment repository.
+
+    Use after a `dispatch_experiment` run has succeeded. The returned object
+    can be passed to `analyze_experiment` as `experimental_results`.
+    Requires GH_PERSONAL_ACCESS_TOKEN.
+    """
+    result = (
+        await FetchExperimentResultsSubgraph(github_client=_github_client())
+        .build_graph()
+        .ainvoke(
+            {
+                "github_config": GitHubConfig(
+                    github_owner=github_owner,
+                    repository_name=repository_name,
+                    branch_name=branch_name,
+                )
+            }
+        )
+    )
+    return _dump(result["experimental_results"])
+
+
+@mcp.tool()
+async def download_workflow_artifacts(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+    workflow_run_id: int,
+) -> dict[str, Any]:
+    """Download the artifacts produced by a GitHub Actions workflow run.
+
+    `workflow_run_id` comes from `get_workflow_runs`. Useful for inspecting
+    logs and outputs of a specific run. Requires GH_PERSONAL_ACCESS_TOKEN.
+    """
+    result = (
+        await DownloadGithubActionsArtifactsSubgraph(github_client=_github_client())
+        .build_graph()
+        .ainvoke(
+            {
+                "github_config": GitHubConfig(
+                    github_owner=github_owner,
+                    repository_name=repository_name,
+                    branch_name=branch_name,
+                ),
+                "workflow_run_id": workflow_run_id,
+            }
+        )
+    )
+    return _dump(result["artifact_data"])
+
+
+@mcp.tool()
+async def analyze_experiment(
+    research_hypothesis: dict[str, Any],
+    experimental_design: dict[str, Any],
+    experiment_code: dict[str, Any],
+    experimental_results: dict[str, Any],
+) -> dict[str, Any]:
+    """Analyze experiment results against the hypothesis and design.
+
+    Takes the outputs of `generate_hypothesis`, `generate_experimental_design`,
+    `fetch_experiment_code`, and `fetch_experiment_results`, and returns a
+    structured analysis (findings, whether the hypothesis is supported, and
+    suggested next steps). Requires an LLM provider API key.
+    """
+    result = (
+        await AnalyzeExperimentSubgraph(
+            langchain_client=LangChainClient(),
+            llm_mapping=None,
+        )
+        .build_graph()
+        .ainvoke(
+            {
+                "research_hypothesis": ResearchHypothesis.model_validate(
+                    research_hypothesis
+                ),
+                "experimental_design": ExperimentalDesign.model_validate(
+                    experimental_design
+                ),
+                "experiment_code": ExperimentCode.model_validate(experiment_code),
+                "experimental_results": ExperimentalResults.model_validate(
+                    experimental_results
+                ),
+            }
+        )
+    )
+    return _dump(result["experimental_analysis"])
+
+
+# --- Research history persistence (GitHub) ---
+
+
+@mcp.tool()
+async def upload_research_history(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+    research_history: dict[str, Any],
+    commit_message: str | None = None,
+) -> dict[str, Any]:
+    """Save research history (hypothesis, design, results, ...) to the experiment repository.
+
+    AIRAS persists research state in the GitHub repository, so uploading the
+    accumulated history lets you resume work in a later session with
+    `download_research_history`. Requires GH_PERSONAL_ACCESS_TOKEN.
+    """
+    result = (
+        await GithubUploadSubgraph(_github_client())
+        .build_graph()
+        .ainvoke(
+            {
+                "github_config": GitHubConfig(
+                    github_owner=github_owner,
+                    repository_name=repository_name,
+                    branch_name=branch_name,
+                ),
+                "research_history": ResearchHistory.model_validate(research_history),
+                "commit_message": commit_message,
+            }
+        )
+    )
+    return {"is_github_upload": result["is_github_upload"]}
+
+
+@mcp.tool()
+async def download_research_history(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+) -> dict[str, Any]:
+    """Load previously saved research history from the experiment repository.
+
+    Restores the state saved by `upload_research_history` so a research
+    session can continue where it left off. Requires GH_PERSONAL_ACCESS_TOKEN.
+    """
+    result = (
+        await GithubDownloadSubgraph(_github_client())
+        .build_graph()
+        .ainvoke(
+            {
+                "github_config": GitHubConfig(
+                    github_owner=github_owner,
+                    repository_name=repository_name,
+                    branch_name=branch_name,
+                )
+            }
+        )
+    )
+    return _dump(result["research_history"])
 
 
 def main() -> None:

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -1,0 +1,155 @@
+"""AIRAS MCP server (stdio).
+
+Exposes AIRAS research subgraphs as MCP tools for use from MCP clients
+such as Claude Code and Claude Desktop.
+
+Credentials are read from environment variables:
+- LLM providers: OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY (at least one)
+- GitHub (retrieve_papers only): GH_PERSONAL_ACCESS_TOKEN
+
+Run locally:
+    uvx --from "airas[mcp]" airas-mcp
+"""
+
+import os
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from airas.core.types.research_study import ResearchStudy
+from airas.infra.arxiv_client import ArxivClient
+from airas.infra.github_client import GithubClient
+from airas.infra.langchain_client import LangChainClient
+from airas.usecases.generators.generate_hypothesis_subgraph.generate_hypothesis_subgraph_v0 import (
+    GenerateHypothesisSubgraphV0,
+)
+from airas.usecases.generators.generate_queries_subgraph.generate_queries_subgraph import (
+    GenerateQueriesSubgraph,
+)
+from airas.usecases.retrieve.retrieve_paper_subgraph.retrieve_paper_subgraph import (
+    RetrievePaperSubgraph,
+)
+from airas.usecases.retrieve.search_paper_titles_subgraph.nodes.search_paper_titles_from_airas_db import (
+    AirasDbPaperSearchIndex,
+)
+from airas.usecases.retrieve.search_paper_titles_subgraph.search_paper_titles_from_airas_db_subgraph import (
+    SearchPaperTitlesFromAirasDbSubgraph,
+)
+
+mcp = FastMCP("airas")
+
+# BM25 index over the AIRAS papers DB; built lazily on first search and
+# reused for the lifetime of the server process.
+_search_index = AirasDbPaperSearchIndex()
+
+
+def _github_client() -> GithubClient:
+    token = os.getenv("GH_PERSONAL_ACCESS_TOKEN", "")
+    if not token:
+        raise RuntimeError(
+            "GH_PERSONAL_ACCESS_TOKEN environment variable is not set. "
+            "Set it in the `env` block of your MCP client configuration."
+        )
+    return GithubClient(github_token=token)
+
+
+@mcp.tool()
+async def generate_research_queries(
+    research_topic: str,
+    num_queries: int = 2,
+) -> list[str]:
+    """Generate academic paper search queries from a research topic.
+
+    Use this first to turn a free-form research topic into effective
+    search queries, then pass them to `search_paper_titles`.
+    """
+    result = (
+        await GenerateQueriesSubgraph(
+            llm_client=LangChainClient(),
+            num_paper_search_queries=num_queries,
+        )
+        .build_graph()
+        .ainvoke({"research_topic": research_topic})
+    )
+    return result["queries"]
+
+
+@mcp.tool()
+async def search_paper_titles(
+    queries: list[str],
+    max_results_per_query: int = 3,
+) -> list[str]:
+    """Search the AIRAS papers database (major ML conferences) for paper titles.
+
+    Takes search queries (e.g. from `generate_research_queries`) and returns
+    matching paper titles. The first call builds the search index, which can
+    take a while; subsequent calls are fast. No API keys required.
+    """
+    result = (
+        await SearchPaperTitlesFromAirasDbSubgraph(
+            search_index=_search_index,
+            papers_per_query=max_results_per_query,
+        )
+        .build_graph()
+        .ainvoke({"queries": queries})
+    )
+    return result["paper_titles"]
+
+
+@mcp.tool()
+async def retrieve_papers(paper_titles: list[str]) -> list[dict[str, Any]]:
+    """Retrieve full paper information for the given titles.
+
+    Fetches each paper (via arXiv) and extracts structured research study
+    data: abstract, methods, experimental settings, and results. The returned
+    objects can be passed to `generate_hypothesis` as `research_study_list`.
+    Requires GH_PERSONAL_ACCESS_TOKEN and an LLM provider API key.
+    """
+    result = (
+        await RetrievePaperSubgraph(
+            langchain_client=LangChainClient(),
+            arxiv_client=ArxivClient(),
+            github_client=_github_client(),
+            llm_mapping=None,
+        )
+        .build_graph()
+        .ainvoke({"paper_titles": paper_titles})
+    )
+    return [study.model_dump() for study in result["research_study_list"]]
+
+
+@mcp.tool()
+async def generate_hypothesis(
+    research_topic: str,
+    research_study_list: list[dict[str, Any]],
+    refinement_rounds: int = 1,
+) -> dict[str, Any]:
+    """Generate a novel research hypothesis from a topic and related studies.
+
+    `research_study_list` should be the output of `retrieve_papers`. Higher
+    `refinement_rounds` improves quality at the cost of more LLM calls.
+    Requires an LLM provider API key.
+    """
+    studies = [ResearchStudy.model_validate(study) for study in research_study_list]
+    result = (
+        await GenerateHypothesisSubgraphV0(
+            langchain_client=LangChainClient(),
+            refinement_rounds=refinement_rounds,
+        )
+        .build_graph()
+        .ainvoke(
+            {
+                "research_topic": research_topic,
+                "research_study_list": studies,
+            }
+        )
+    )
+    return result["research_hypothesis"].model_dump()
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -18,9 +18,12 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel
 
 from airas.core.types.experiment_code import ExperimentCode
+from airas.core.types.experiment_history import ExperimentHistory
 from airas.core.types.experimental_design import ComputeEnvironment, ExperimentalDesign
 from airas.core.types.experimental_results import ExperimentalResults
 from airas.core.types.github import GitHubConfig
+from airas.core.types.latex import LATEX_TEMPLATE_NAME
+from airas.core.types.paper import PaperContent
 from airas.core.types.research_history import ResearchHistory
 from airas.core.types.research_hypothesis import ResearchHypothesis
 from airas.core.types.research_study import ResearchStudy
@@ -63,6 +66,15 @@ from airas.usecases.github.prepare_repository_subgraph.prepare_repository_subgra
 from airas.usecases.github.set_github_actions_secrets_subgraph.set_github_actions_secrets_subgraph import (
     SetGithubActionsSecretsSubgraph,
 )
+from airas.usecases.publication.compile_latex_subgraph.compile_latex_subgraph import (
+    CompileLatexSubgraph,
+)
+from airas.usecases.publication.generate_latex_subgraph.generate_latex_subgraph import (
+    GenerateLatexSubgraph,
+)
+from airas.usecases.publication.push_latex_subgraph.push_latex_subgraph import (
+    PushLatexSubgraph,
+)
 from airas.usecases.retrieve.retrieve_paper_subgraph.retrieve_paper_subgraph import (
     RetrievePaperSubgraph,
 )
@@ -72,6 +84,10 @@ from airas.usecases.retrieve.search_paper_titles_subgraph.nodes.search_paper_tit
 from airas.usecases.retrieve.search_paper_titles_subgraph.search_paper_titles_from_airas_db_subgraph import (
     SearchPaperTitlesFromAirasDbSubgraph,
 )
+from airas.usecases.writers.generate_bibfile_subgraph.generate_bibfile_subgraph import (
+    GenerateBibfileSubgraph,
+)
+from airas.usecases.writers.write_subgraph.write_subgraph import WriteSubgraph
 
 mcp = FastMCP("airas")
 
@@ -596,6 +612,171 @@ async def download_research_history(
         )
     )
     return _dump(result["research_history"])
+
+
+# --- Paper writing & publication ---
+
+
+@mcp.tool()
+async def generate_bibfile(research_study_list: list[dict[str, Any]]) -> str:
+    """Generate a BibTeX references file from research studies.
+
+    `research_study_list` should be the output of `retrieve_papers`. Returns
+    the .bib content used by `generate_paper` and `generate_latex`.
+    No API keys required.
+    """
+    studies = [ResearchStudy.model_validate(study) for study in research_study_list]
+    result = (
+        await GenerateBibfileSubgraph()
+        .build_graph()
+        .ainvoke({"research_study_list": studies})
+    )
+    return result["references_bib"]
+
+
+@mcp.tool()
+async def generate_paper(
+    research_hypothesis: dict[str, Any],
+    experiment_history: dict[str, Any],
+    experiment_code: dict[str, Any],
+    research_study_list: list[dict[str, Any]],
+    references_bib: str,
+    writing_refinement_rounds: int = 2,
+) -> dict[str, Any]:
+    """Write the paper content from the completed research.
+
+    Takes the hypothesis, experiment history, experiment code, related
+    studies, and the BibTeX file (from `generate_bibfile`), and produces
+    structured paper content (title, abstract, sections). Pass the result
+    to `generate_latex`. Requires an LLM provider API key.
+    """
+    result = (
+        await WriteSubgraph(
+            langchain_client=LangChainClient(),
+            paper_content_refinement_iterations=writing_refinement_rounds,
+        )
+        .build_graph()
+        .ainvoke(
+            {
+                "research_hypothesis": ResearchHypothesis.model_validate(
+                    research_hypothesis
+                ),
+                "experiment_history": ExperimentHistory.model_validate(
+                    experiment_history
+                ),
+                "experiment_code": ExperimentCode.model_validate(experiment_code),
+                "research_study_list": [
+                    ResearchStudy.model_validate(study) for study in research_study_list
+                ],
+                "references_bib": references_bib,
+            }
+        )
+    )
+    return _dump(result["paper_content"])
+
+
+@mcp.tool()
+async def generate_latex(
+    paper_content: dict[str, Any],
+    references_bib: str,
+    latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
+) -> str:
+    """Convert paper content into a full LaTeX document.
+
+    `paper_content` should be the output of `generate_paper`. Available
+    templates: "mdpi", "iclr2024", "agents4science_2025". Push the returned
+    LaTeX to the experiment repository with `push_latex`, then build the PDF
+    with `compile_latex`. Requires an LLM provider API key and
+    GH_PERSONAL_ACCESS_TOKEN.
+    """
+    result = (
+        await GenerateLatexSubgraph(
+            langchain_client=LangChainClient(),
+            github_client=_github_client(),
+            latex_template_name=latex_template_name,
+        )
+        .build_graph()
+        .ainvoke(
+            {
+                "paper_content": PaperContent.model_validate(paper_content),
+                "references_bib": references_bib,
+            }
+        )
+    )
+    return result["latex_text"]
+
+
+@mcp.tool()
+async def push_latex(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+    latex_text: str,
+    latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
+) -> dict[str, Any]:
+    """Push the LaTeX document and figures to the experiment repository.
+
+    Uploads the LaTeX source (from `generate_latex`) and prepares the images
+    so that `compile_latex` can build the PDF. Requires GH_PERSONAL_ACCESS_TOKEN.
+    """
+    result = (
+        await PushLatexSubgraph(
+            github_client=_github_client(),
+            latex_template_name=latex_template_name,
+        )
+        .build_graph()
+        .ainvoke(
+            {
+                "github_config": GitHubConfig(
+                    github_owner=github_owner,
+                    repository_name=repository_name,
+                    branch_name=branch_name,
+                ),
+                "latex_text": latex_text,
+            }
+        )
+    )
+    return {
+        "is_upload_successful": result["is_upload_successful"],
+        "is_images_prepared": result["is_images_prepared"],
+    }
+
+
+@mcp.tool()
+async def compile_latex(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+    latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
+    github_actions_agent: Literal["claude_code", "open_code"] = "claude_code",
+) -> dict[str, Any]:
+    """Build the paper PDF on GitHub Actions (asynchronous).
+
+    Dispatches the LaTeX compilation workflow for the sources pushed by
+    `push_latex`. Returns immediately with `paper_url` (when available);
+    track the run with `get_workflow_runs`. Requires GH_PERSONAL_ACCESS_TOKEN.
+    """
+    result = (
+        await CompileLatexSubgraph(
+            github_client=_github_client(),
+            latex_template_name=latex_template_name,
+            github_actions_agent=github_actions_agent,
+        )
+        .build_graph()
+        .ainvoke(
+            {
+                "github_config": GitHubConfig(
+                    github_owner=github_owner,
+                    repository_name=repository_name,
+                    branch_name=branch_name,
+                )
+            }
+        )
+    )
+    return {
+        "compile_latex_dispatched": result["compile_latex_dispatched"],
+        "paper_url": result["paper_url"],
+    }
 
 
 def main() -> None:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -146,9 +146,7 @@ dependencies = [
 
 [package.optional-dependencies]
 mcp = [
-    { name = "asyncio" },
     { name = "mcp", extra = ["cli"] },
-    { name = "python-dotenv" },
 ]
 
 [package.dev-dependencies]
@@ -168,7 +166,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.66.0" },
-    { name = "asyncio", marker = "extra == 'mcp'", specifier = ">=3.4.3" },
     { name = "bibtexparser", specifier = ">=1.4.3" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "dependency-injector", specifier = ">=4.48.2" },
@@ -194,7 +191,6 @@ requires-dist = [
     { name = "pynacl", specifier = ">=1.6.0" },
     { name = "pypdf", specifier = ">=4.3.1" },
     { name = "pytest-asyncio", specifier = ">=1.2.0" },
-    { name = "python-dotenv", marker = "extra == 'mcp'", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2025.2" },
     { name = "rank-bm25", specifier = ">=0.2.2" },
     { name = "semanticscholar", specifier = ">=0.8.4" },
@@ -384,15 +380,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/87/d6/21b30a550dafea84b1b8eee21b5e23fa16d010ae006011221f33dcd8d7f8/async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f", size = 8345, upload-time = "2023-08-10T16:35:56.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/fa/e01228c2938de91d47b307831c62ab9e4001e747789d0b05baf779a6488c/async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028", size = 5721, upload-time = "2023-08-10T16:35:55.203Z" },
-]
-
-[[package]]
-name = "asyncio"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/ea/26c489a11f7ca862d5705db67683a7361ce11c23a7b98fc6c2deaeccede2/asyncio-4.0.0.tar.gz", hash = "sha256:570cd9e50db83bc1629152d4d0b7558d6451bb1bfd5dfc2e935d96fc2f40329b", size = 5371, upload-time = "2025-08-05T02:51:46.605Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/64/eff2564783bd650ca25e15938d1c5b459cda997574a510f7de69688cb0b4/asyncio-4.0.0-py3-none-any.whl", hash = "sha256:c1eddb0659231837046809e68103969b2bef8b0400d59cfa6363f6b5ed8cc88b", size = 5555, upload-time = "2025-08-05T02:51:45.767Z" },
 ]
 
 [[package]]

--- a/docs/docs/development/MCP.md
+++ b/docs/docs/development/MCP.md
@@ -70,6 +70,16 @@ Or add it to your project's `.mcp.json`:
 | `download_workflow_artifacts` | Download artifacts of a specific workflow run |
 | `analyze_experiment` | Analyze results against the hypothesis and design |
 
+### Paper writing & publication
+
+| Tool | Description |
+| --- | --- |
+| `generate_bibfile` | Generate a BibTeX references file from research studies; no API key required |
+| `generate_paper` | Write structured paper content (title, abstract, sections) from the completed research |
+| `generate_latex` | Convert paper content into a full LaTeX document (templates: mdpi / iclr2024 / agents4science_2025) |
+| `push_latex` | Push the LaTeX source and figures to the experiment repository |
+| `compile_latex` | Build the paper PDF on GitHub Actions (async) |
+
 ### Research history persistence
 
 | Tool | Description |
@@ -77,7 +87,7 @@ Or add it to your project's `.mcp.json`:
 | `upload_research_history` | Save research state to the experiment repository |
 | `download_research_history` | Restore research state to continue in a later session |
 
-A typical flow: `generate_research_queries` → `search_paper_titles` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `set_github_actions_secrets` → `dispatch_code_generation` → (poll `get_workflow_runs`) → `fetch_experiment_code` → `dispatch_experiment` → (poll) → `fetch_experiment_results` → `analyze_experiment` → `upload_research_history`.
+A typical flow: `generate_research_queries` → `search_paper_titles` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `set_github_actions_secrets` → `dispatch_code_generation` → (poll `get_workflow_runs`) → `fetch_experiment_code` → `dispatch_experiment` → (poll) → `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`.
 
 Long-running steps (code generation, experiments) execute on GitHub Actions and return immediately; track them with `get_workflow_runs` instead of waiting.
 

--- a/docs/docs/development/MCP.md
+++ b/docs/docs/development/MCP.md
@@ -3,4 +3,66 @@ title: MCP
 slug: /development/MCP
 ---
 
-coming soon
+# MCP Server
+
+AIRAS provides a local MCP (Model Context Protocol) server that exposes research subgraphs as tools for MCP clients such as Claude Code and Claude Desktop.
+
+## Setup
+
+No installation is required — `uvx` fetches the package on first run. The only prerequisite is [uv](https://docs.astral.sh/uv/).
+
+### Claude Code
+
+```bash
+claude mcp add airas \
+  --env OPENAI_API_KEY=sk-... \
+  --env GH_PERSONAL_ACCESS_TOKEN=ghp_... \
+  -- uvx --from "airas[mcp]" airas-mcp
+```
+
+Or add it to your project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "airas": {
+      "command": "uvx",
+      "args": ["--from", "airas[mcp]", "airas-mcp"],
+      "env": {
+        "OPENAI_API_KEY": "sk-...",
+        "GH_PERSONAL_ACCESS_TOKEN": "ghp_..."
+      }
+    }
+  }
+}
+```
+
+### Environment variables
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` | At least one | LLM calls (query generation, paper extraction, hypothesis generation) |
+| `GH_PERSONAL_ACCESS_TOKEN` | For `retrieve_papers` | GitHub API access |
+
+## Tools
+
+| Tool | Description |
+| --- | --- |
+| `generate_research_queries` | Generate paper search queries from a research topic |
+| `search_paper_titles` | BM25 search over the AIRAS papers database (major ML conferences); no API key required |
+| `retrieve_papers` | Fetch papers via arXiv and extract structured research study data |
+| `generate_hypothesis` | Generate a novel research hypothesis from a topic and related studies |
+
+A typical flow: `generate_research_queries` → `search_paper_titles` → `retrieve_papers` → `generate_hypothesis`.
+
+## Development
+
+Run the server from a checkout:
+
+```bash
+cd backend
+uv sync --extra mcp
+uv run airas-mcp
+```
+
+The server uses stdio transport; it is started on demand by the MCP client and requires no database or web server.

--- a/docs/docs/development/MCP.md
+++ b/docs/docs/development/MCP.md
@@ -46,14 +46,40 @@ Or add it to your project's `.mcp.json`:
 
 ## Tools
 
+### Paper discovery & hypothesis
+
 | Tool | Description |
 | --- | --- |
 | `generate_research_queries` | Generate paper search queries from a research topic |
 | `search_paper_titles` | BM25 search over the AIRAS papers database (major ML conferences); no API key required |
 | `retrieve_papers` | Fetch papers via arXiv and extract structured research study data |
 | `generate_hypothesis` | Generate a novel research hypothesis from a topic and related studies |
+| `generate_experimental_design` | Design experiments to test a hypothesis |
 
-A typical flow: `generate_research_queries` → `search_paper_titles` → `retrieve_papers` → `generate_hypothesis`.
+### Experiment execution (GitHub Actions)
+
+| Tool | Description |
+| --- | --- |
+| `prepare_repository` | Create and initialize an experiment repository |
+| `set_github_actions_secrets` | Copy LLM API keys from local env vars to the repository's Actions secrets |
+| `dispatch_code_generation` | Start experiment-code generation on GitHub Actions (async) |
+| `dispatch_experiment` | Start a sanity-check or main experiment run (async) |
+| `get_workflow_runs` | Check the status of recent workflow runs (non-blocking) |
+| `fetch_experiment_code` | Fetch the generated experiment code |
+| `fetch_experiment_results` | Fetch experiment results |
+| `download_workflow_artifacts` | Download artifacts of a specific workflow run |
+| `analyze_experiment` | Analyze results against the hypothesis and design |
+
+### Research history persistence
+
+| Tool | Description |
+| --- | --- |
+| `upload_research_history` | Save research state to the experiment repository |
+| `download_research_history` | Restore research state to continue in a later session |
+
+A typical flow: `generate_research_queries` → `search_paper_titles` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `set_github_actions_secrets` → `dispatch_code_generation` → (poll `get_workflow_runs`) → `fetch_experiment_code` → `dispatch_experiment` → (poll) → `fetch_experiment_results` → `analyze_experiment` → `upload_research_history`.
+
+Long-running steps (code generation, experiments) execute on GitHub Actions and return immediately; track them with `get_workflow_runs` instead of waiting.
 
 ## Development
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/development/MCP.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/development/MCP.md
@@ -70,6 +70,16 @@ claude mcp add airas \
 | `download_workflow_artifacts` | 特定のワークフロー実行のアーティファクトを取得 |
 | `analyze_experiment` | 仮説・実験設計に照らして結果を解析 |
 
+### 論文執筆・出版
+
+| ツール | 説明 |
+| --- | --- |
+| `generate_bibfile` | 研究データからBibTeX参考文献ファイルを生成。APIキー不要 |
+| `generate_paper` | 完了した研究から論文本文（タイトル・アブストラクト・各セクション）を執筆 |
+| `generate_latex` | 論文本文をLaTeX文書に変換（テンプレート: mdpi / iclr2024 / agents4science_2025） |
+| `push_latex` | LaTeXソースと図を実験リポジトリにプッシュ |
+| `compile_latex` | GitHub Actionsで論文PDFをビルド（非同期） |
+
 ### 研究履歴の永続化
 
 | ツール | 説明 |
@@ -77,7 +87,7 @@ claude mcp add airas \
 | `upload_research_history` | 研究状態を実験リポジトリに保存 |
 | `download_research_history` | 保存した研究状態を復元し、別セッションで継続 |
 
-典型的なフロー: `generate_research_queries` → `search_paper_titles` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `set_github_actions_secrets` → `dispatch_code_generation` →（`get_workflow_runs` でポーリング）→ `fetch_experiment_code` → `dispatch_experiment` →（ポーリング）→ `fetch_experiment_results` → `analyze_experiment` → `upload_research_history`
+典型的なフロー: `generate_research_queries` → `search_paper_titles` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `set_github_actions_secrets` → `dispatch_code_generation` →（`get_workflow_runs` でポーリング）→ `fetch_experiment_code` → `dispatch_experiment` →（ポーリング）→ `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`
 
 時間のかかるステップ（コード生成・実験）はGitHub Actions上で実行され、ツール自体は即座に返ります。完了待ちはせず `get_workflow_runs` で追跡してください。
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/development/MCP.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/development/MCP.md
@@ -3,4 +3,66 @@ title: MCP
 slug: /development/MCP
 ---
 
-近日公開予定です。
+# MCPサーバー
+
+AIRASは、Claude CodeやClaude DesktopなどのMCPクライアントから研究サブグラフをツールとして利用できる、ローカルMCP（Model Context Protocol）サーバーを提供しています。
+
+## セットアップ
+
+インストール作業は不要です。初回実行時に `uvx` がパッケージを取得します。前提条件は [uv](https://docs.astral.sh/uv/) がインストールされていることだけです。
+
+### Claude Code
+
+```bash
+claude mcp add airas \
+  --env OPENAI_API_KEY=sk-... \
+  --env GH_PERSONAL_ACCESS_TOKEN=ghp_... \
+  -- uvx --from "airas[mcp]" airas-mcp
+```
+
+またはプロジェクトの `.mcp.json` に追加します：
+
+```json
+{
+  "mcpServers": {
+    "airas": {
+      "command": "uvx",
+      "args": ["--from", "airas[mcp]", "airas-mcp"],
+      "env": {
+        "OPENAI_API_KEY": "sk-...",
+        "GH_PERSONAL_ACCESS_TOKEN": "ghp_..."
+      }
+    }
+  }
+}
+```
+
+### 環境変数
+
+| 変数 | 必須 | 用途 |
+| --- | --- | --- |
+| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` | いずれか1つ | LLM呼び出し（クエリ生成・論文抽出・仮説生成） |
+| `GH_PERSONAL_ACCESS_TOKEN` | `retrieve_papers` 使用時 | GitHub APIアクセス |
+
+## ツール
+
+| ツール | 説明 |
+| --- | --- |
+| `generate_research_queries` | 研究トピックから論文検索クエリを生成 |
+| `search_paper_titles` | AIRAS論文データベース（主要ML国際会議）のBM25検索。APIキー不要 |
+| `retrieve_papers` | arXiv経由で論文を取得し、構造化された研究データを抽出 |
+| `generate_hypothesis` | トピックと関連研究から新規の研究仮説を生成 |
+
+典型的なフロー: `generate_research_queries` → `search_paper_titles` → `retrieve_papers` → `generate_hypothesis`
+
+## 開発
+
+チェックアウトからサーバーを起動する場合：
+
+```bash
+cd backend
+uv sync --extra mcp
+uv run airas-mcp
+```
+
+サーバーはstdioトランスポートを使用し、MCPクライアントがオンデマンドで起動します。データベースやWebサーバーは不要です。

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/development/MCP.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/development/MCP.md
@@ -46,14 +46,40 @@ claude mcp add airas \
 
 ## ツール
 
+### 論文探索・仮説生成
+
 | ツール | 説明 |
 | --- | --- |
 | `generate_research_queries` | 研究トピックから論文検索クエリを生成 |
 | `search_paper_titles` | AIRAS論文データベース（主要ML国際会議）のBM25検索。APIキー不要 |
 | `retrieve_papers` | arXiv経由で論文を取得し、構造化された研究データを抽出 |
 | `generate_hypothesis` | トピックと関連研究から新規の研究仮説を生成 |
+| `generate_experimental_design` | 仮説を検証する実験を設計 |
 
-典型的なフロー: `generate_research_queries` → `search_paper_titles` → `retrieve_papers` → `generate_hypothesis`
+### 実験実行（GitHub Actions）
+
+| ツール | 説明 |
+| --- | --- |
+| `prepare_repository` | 実験用リポジトリの作成・初期化 |
+| `set_github_actions_secrets` | ローカル環境変数のLLM APIキーをリポジトリのActionsシークレットに設定 |
+| `dispatch_code_generation` | 実験コード生成をGitHub Actionsで開始（非同期） |
+| `dispatch_experiment` | サニティチェック／本実験の実行を開始（非同期） |
+| `get_workflow_runs` | 直近のワークフロー実行のステータス確認（ノンブロッキング） |
+| `fetch_experiment_code` | 生成された実験コードを取得 |
+| `fetch_experiment_results` | 実験結果を取得 |
+| `download_workflow_artifacts` | 特定のワークフロー実行のアーティファクトを取得 |
+| `analyze_experiment` | 仮説・実験設計に照らして結果を解析 |
+
+### 研究履歴の永続化
+
+| ツール | 説明 |
+| --- | --- |
+| `upload_research_history` | 研究状態を実験リポジトリに保存 |
+| `download_research_history` | 保存した研究状態を復元し、別セッションで継続 |
+
+典型的なフロー: `generate_research_queries` → `search_paper_titles` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `set_github_actions_secrets` → `dispatch_code_generation` →（`get_workflow_runs` でポーリング）→ `fetch_experiment_code` → `dispatch_experiment` →（ポーリング）→ `fetch_experiment_results` → `analyze_experiment` → `upload_research_history`
+
+時間のかかるステップ（コード生成・実験）はGitHub Actions上で実行され、ツール自体は即座に返ります。完了待ちはせず `get_workflow_runs` で追跡してください。
 
 ## 開発
 


### PR DESCRIPTION
## Summary

ローカルで簡単に使えるstdio MCPサーバーを実装します。Claude Code / Claude Desktopから `uvx` 経由で、**git cloneなし・DBなし・認証なし**で利用できます。

### 実装内容

- **`airas/mcp/server.py`** — FastMCP（`mcp[cli]`）ベースのstdioサーバー。既存のユースケースサブグラフを直接呼び出す4ツールを公開：

  | ツール | 内容 | 必要なキー |
  | --- | --- | --- |
  | `generate_research_queries` | 研究トピック → 論文検索クエリ | LLMキー |
  | `search_paper_titles` | AIRAS論文DB（58,000本超）のBM25検索 | 不要 |
  | `retrieve_papers` | arXiv経由で論文取得・構造化抽出 | LLMキー + `GH_PERSONAL_ACCESS_TOKEN` |
  | `generate_hypothesis` | トピック＋関連研究 → 研究仮説 | LLMキー |

- **`[project.scripts] airas-mcp`** — PyPIリリース後は `uvx --from "airas[mcp]" airas-mcp` の1コマンドで起動可能（リリース前も `uvx --from "git+...#subdirectory=backend"` で利用可）
- **`mcp` extraの整理** — PyPI上の古いバックポートである `asyncio` パッケージと未使用の `python-dotenv` を削除し、`mcp[cli]` のみに
- **ドキュメント** — 「coming soon」だった `docs/development/MCP.md`（英・日）をセットアップ手順・ツール一覧に置き換え

### 設計メモ

- 認証情報はすべて環境変数から解決（`.mcp.json` の `env` ブロックで注入する想定）。PR #880 で確立した構成に沿っています
- BM25検索インデックスはプロセス存続期間中キャッシュされるモジュールレベルのシングルトン（初回検索時に構築）
- wheelに含まれるのは `src/airas` のみのため、`api/` パッケージには依存しない自己完結の実装です

## Test plan

- [x] MCPクライアント（`mcp` SDK）からstdioで実接続し、`list_tools` で4ツールが列挙されることを確認
- [x] `search_paper_titles` を実呼び出しし、58,307本のインデックス構築（約5秒）と検索結果の返却を確認
- [x] `make ruff` パス
- [x] `make mypy` — 既存の2件（`llm_specs.py`）以外エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)