### PR TITLE
feat: add auxiliary research tools to MCP server (28 tools)

### DIFF
--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -19,7 +19,12 @@ from pydantic import BaseModel
 
 from airas.core.types.experiment_code import ExperimentCode
 from airas.core.types.experiment_history import ExperimentHistory
-from airas.core.types.experimental_design import ComputeEnvironment, ExperimentalDesign
+from airas.core.types.experimental_design import (
+    ComputeEnvironment,
+    DatasetSubfield,
+    ExperimentalDesign,
+    ModelSubfield,
+)
 from airas.core.types.experimental_results import ExperimentalResults
 from airas.core.types.github import GitHubConfig
 from airas.core.types.latex import LATEX_TEMPLATE_NAME
@@ -37,14 +42,23 @@ from airas.usecases.analyzers.analyze_experiment_subgraph.analyze_experiment_sub
 from airas.usecases.executors.dispatch_experiment_on_static_runner_subgraph.dispatch_experiment_on_static_runner_subgraph import (
     DispatchExperimentOnStaticRunnerSubgraph,
 )
+from airas.usecases.executors.dispatch_visualization_subgraph.dispatch_visualization_subgraph import (
+    DispatchVisualizationSubgraph,
+)
 from airas.usecases.executors.fetch_experiment_code_subgraph.fetch_experiment_code_subgraph import (
     FetchExperimentCodeSubgraph,
 )
 from airas.usecases.executors.fetch_experiment_results_subgraph.fetch_experiment_results_subgraph import (
     FetchExperimentResultsSubgraph,
 )
+from airas.usecases.executors.fetch_run_ids_subgraph.fetch_run_ids_subgraph import (
+    FetchRunIdsSubgraph,
+)
 from airas.usecases.generators.dispatch_code_generation_subgraph.dispatch_code_generation_subgraph import (
     DispatchCodeGenerationSubgraph,
+)
+from airas.usecases.generators.dispatch_diagram_generation_subgraph.dispatch_diagram_generation_subgraph import (
+    DispatchDiagramGenerationSubgraph,
 )
 from airas.usecases.generators.generate_experimental_design_subgraph.generate_experimental_design_subgraph import (
     GenerateExperimentalDesignSubgraph,
@@ -55,6 +69,9 @@ from airas.usecases.generators.generate_hypothesis_subgraph.generate_hypothesis_
 from airas.usecases.generators.generate_queries_subgraph.generate_queries_subgraph import (
     GenerateQueriesSubgraph,
 )
+from airas.usecases.generators.refine_experimental_design_subgraph.refine_experimental_design_subgraph import (
+    RefineExperimentalDesignSubgraph,
+)
 from airas.usecases.github.download_github_actions_artifacts_subgraph.download_github_actions_artifacts_subgraph import (
     DownloadGithubActionsArtifactsSubgraph,
 )
@@ -62,6 +79,9 @@ from airas.usecases.github.github_download_subgraph import GithubDownloadSubgrap
 from airas.usecases.github.github_upload_subgraph import GithubUploadSubgraph
 from airas.usecases.github.prepare_repository_subgraph.prepare_repository_subgraph import (
     PrepareRepositorySubgraph,
+)
+from airas.usecases.github.push_github_subgraph.push_github_subgraph import (
+    PushGitHubSubgraph,
 )
 from airas.usecases.github.set_github_actions_secrets_subgraph.set_github_actions_secrets_subgraph import (
     SetGithubActionsSecretsSubgraph,
@@ -74,6 +94,12 @@ from airas.usecases.publication.generate_latex_subgraph.generate_latex_subgraph 
 )
 from airas.usecases.publication.push_latex_subgraph.push_latex_subgraph import (
     PushLatexSubgraph,
+)
+from airas.usecases.retrieve.retrieve_datasets_subgraph.retrieve_datasets_subgraph import (
+    RetrieveDatasetsSubgraph,
+)
+from airas.usecases.retrieve.retrieve_models_subgraph.retrieve_models_subgraph import (
+    RetrieveModelsSubgraph,
 )
 from airas.usecases.retrieve.retrieve_paper_subgraph.retrieve_paper_subgraph import (
     RetrievePaperSubgraph,
@@ -244,6 +270,80 @@ async def generate_experimental_design(
         )
     )
     return _dump(result["experimental_design"])
+
+
+@mcp.tool()
+async def refine_experimental_design(
+    research_hypothesis: dict[str, Any],
+    experiment_history: dict[str, Any],
+    design_instruction: str,
+    compute_environment: dict[str, Any] | None = None,
+    num_models_to_use: int = 1,
+    num_datasets_to_use: int = 1,
+    num_comparative_methods: int = 1,
+) -> dict[str, Any]:
+    """Refine an experimental design based on results so far and an instruction.
+
+    Use after experiments have run: `experiment_history` carries the designs
+    and results accumulated so far, and `design_instruction` states what to
+    change (e.g. "add an ablation for the attention variant"). Returns the
+    revised experimental design. Requires an LLM provider API key.
+    """
+    env = ComputeEnvironment.model_validate(compute_environment or {})
+    result = (
+        await RefineExperimentalDesignSubgraph(
+            langchain_client=LangChainClient(),
+            compute_environment=env,
+            num_models_to_use=num_models_to_use,
+            num_datasets_to_use=num_datasets_to_use,
+            num_comparative_methods=num_comparative_methods,
+        )
+        .build_graph()
+        .ainvoke(
+            {
+                "research_hypothesis": ResearchHypothesis.model_validate(
+                    research_hypothesis
+                ),
+                "experiment_history": ExperimentHistory.model_validate(
+                    experiment_history
+                ),
+                "design_instruction": design_instruction,
+            }
+        )
+    )
+    return _dump(result["experimental_design"])
+
+
+@mcp.tool()
+async def retrieve_models(model_subfield: ModelSubfield) -> dict[str, Any]:
+    """List curated candidate models for experiments in the given subfield.
+
+    Subfields: "transformer_decoder_based_models", "image_models",
+    "multi_modal_models", "llm_api_models". Returns model configurations
+    usable in an experimental design. No API keys required.
+    """
+    result = (
+        await RetrieveModelsSubgraph()
+        .build_graph()
+        .ainvoke({"model_subfield": model_subfield})
+    )
+    return result["models_dict"]
+
+
+@mcp.tool()
+async def retrieve_datasets(dataset_subfield: DatasetSubfield) -> dict[str, Any]:
+    """List curated candidate datasets for experiments in the given subfield.
+
+    Subfields: "language_model_fine_tuning_datasets", "image_datasets",
+    "prompt_engineering_datasets". Returns dataset configurations usable in
+    an experimental design. No API keys required.
+    """
+    result = (
+        await RetrieveDatasetsSubgraph()
+        .build_graph()
+        .ainvoke({"dataset_subfield": dataset_subfield})
+    )
+    return result["datasets_dict"]
 
 
 # --- Experiment repository & execution (GitHub Actions) ---
@@ -612,6 +712,136 @@ async def download_research_history(
         )
     )
     return _dump(result["research_history"])
+
+
+@mcp.tool()
+async def fetch_run_ids(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+) -> list[str]:
+    """List the experiment run IDs recorded in the experiment repository.
+
+    Run IDs identify individual experiment runs defined by the generated
+    code; pass them to `dispatch_experiment` or `dispatch_visualization`.
+    Requires GH_PERSONAL_ACCESS_TOKEN.
+    """
+    result = (
+        await FetchRunIdsSubgraph(github_client=_github_client())
+        .build_graph()
+        .ainvoke(
+            {
+                "github_config": GitHubConfig(
+                    github_owner=github_owner,
+                    repository_name=repository_name,
+                    branch_name=branch_name,
+                )
+            }
+        )
+    )
+    return result["run_ids"]
+
+
+@mcp.tool()
+async def dispatch_visualization(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+    run_ids: list[str],
+    runner_label: list[str] | None = None,
+) -> dict[str, Any]:
+    """Start result-visualization generation on GitHub Actions (asynchronous).
+
+    Generates figures for the given experiment `run_ids` (from
+    `fetch_run_ids`). The figures are used by the paper-writing stage.
+    Returns immediately; track with `get_workflow_runs`.
+    Requires GH_PERSONAL_ACCESS_TOKEN.
+    """
+    result = (
+        await DispatchVisualizationSubgraph(
+            github_client=_github_client(),
+            runner_label=runner_label,
+        )
+        .build_graph()
+        .ainvoke(
+            {
+                "github_config": GitHubConfig(
+                    github_owner=github_owner,
+                    repository_name=repository_name,
+                    branch_name=branch_name,
+                ),
+                "run_ids": run_ids,
+            }
+        )
+    )
+    return {"dispatched": result["dispatched"]}
+
+
+@mcp.tool()
+async def dispatch_diagram_generation(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+    github_actions_agent: Literal["claude_code", "open_code"] = "claude_code",
+    diagram_description: str | None = None,
+) -> dict[str, Any]:
+    """Start method-diagram generation on GitHub Actions (asynchronous).
+
+    Generates an explanatory diagram of the proposed method for the paper.
+    `diagram_description` optionally guides what the diagram should show.
+    Returns immediately; track with `get_workflow_runs`.
+    Requires GH_PERSONAL_ACCESS_TOKEN.
+    """
+    result = (
+        await DispatchDiagramGenerationSubgraph(
+            github_client=_github_client(),
+            diagram_description=diagram_description,
+            prompt_path=None,
+            llm_mapping=None,
+        )
+        .build_graph()
+        .ainvoke(
+            {
+                "github_config": GitHubConfig(
+                    github_owner=github_owner,
+                    repository_name=repository_name,
+                    branch_name=branch_name,
+                ),
+                "github_actions_agent": github_actions_agent,
+            }
+        )
+    )
+    return {"dispatched": result["dispatched"]}
+
+
+@mcp.tool()
+async def push_files(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+    files: dict[str, str],
+) -> dict[str, Any]:
+    """Push files to the experiment repository.
+
+    `files` maps repository paths to file contents (text). Useful for
+    manual fixes to experiment code or configuration between runs.
+    Requires GH_PERSONAL_ACCESS_TOKEN.
+    """
+    result = (
+        await PushGitHubSubgraph(github_client=_github_client())
+        .build_graph()
+        .ainvoke(
+            {
+                "github_config": GitHubConfig(
+                    github_owner=github_owner,
+                    repository_name=repository_name,
+                    branch_name=branch_name,
+                ),
+                "push_files": files,
+            }
+        )
+    )
+    return {"is_file_pushed": result["is_file_pushed"]}
 
 
 # --- Paper writing & publication ---

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -54,6 +54,9 @@ Or add it to your project's `.mcp.json`:
 | `retrieve_papers` | Fetch papers via arXiv and extract structured research study data |
 | `generate_hypothesis` | Generate a novel research hypothesis from a topic and related studies |
 | `generate_experimental_design` | Design experiments to test a hypothesis |
+| `refine_experimental_design` | Refine a design based on results so far and an instruction |
+| `retrieve_models` | List curated candidate models for a subfield; no API key required |
+| `retrieve_datasets` | List curated candidate datasets for a subfield; no API key required |
 
 ### Experiment execution (GitHub Actions)
 
@@ -65,9 +68,13 @@ Or add it to your project's `.mcp.json`:
 | `dispatch_experiment` | Start a sanity-check or main experiment run (async) |
 | `get_workflow_runs` | Check the status of recent workflow runs (non-blocking) |
 | `fetch_experiment_code` | Fetch the generated experiment code |
+| `fetch_run_ids` | List experiment run IDs recorded in the repository |
 | `fetch_experiment_results` | Fetch experiment results |
 | `download_workflow_artifacts` | Download artifacts of a specific workflow run |
 | `analyze_experiment` | Analyze results against the hypothesis and design |
+| `dispatch_visualization` | Generate result figures for given run IDs (async) |
+| `dispatch_diagram_generation` | Generate a method diagram for the paper (async) |
+| `push_files` | Push arbitrary files to the experiment repository |
 
 ### Paper writing & publication
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -54,6 +54,9 @@ claude mcp add airas \
 | `retrieve_papers` | arXiv経由で論文を取得し、構造化された研究データを抽出 |
 | `generate_hypothesis` | トピックと関連研究から新規の研究仮説を生成 |
 | `generate_experimental_design` | 仮説を検証する実験を設計 |
+| `refine_experimental_design` | これまでの結果と指示に基づき実験設計を改良 |
+| `retrieve_models` | サブ分野ごとの候補モデル一覧を取得。APIキー不要 |
+| `retrieve_datasets` | サブ分野ごとの候補データセット一覧を取得。APIキー不要 |
 
 ### 実験実行（GitHub Actions）
 
@@ -65,9 +68,13 @@ claude mcp add airas \
 | `dispatch_experiment` | サニティチェック／本実験の実行を開始（非同期） |
 | `get_workflow_runs` | 直近のワークフロー実行のステータス確認（ノンブロッキング） |
 | `fetch_experiment_code` | 生成された実験コードを取得 |
+| `fetch_run_ids` | リポジトリに記録された実験run IDの一覧を取得 |
 | `fetch_experiment_results` | 実験結果を取得 |
 | `download_workflow_artifacts` | 特定のワークフロー実行のアーティファクトを取得 |
 | `analyze_experiment` | 仮説・実験設計に照らして結果を解析 |
+| `dispatch_visualization` | 指定run IDの結果グラフを生成（非同期） |
+| `dispatch_diagram_generation` | 論文用の手法ダイアグラムを生成（非同期） |
+| `push_files` | 任意のファイルを実験リポジトリにプッシュ |
 
 ### 論文執筆・出版
 


### PR DESCRIPTION
## Summary

研究サイクルAPIのMCPカバレッジを完成させる7ツールを追加します（21 → **28ツール**）。

### 追加ツール

| ツール | 内容 | 必要なキー |
| --- | --- | --- |
| `refine_experimental_design` | これまでの実験履歴と指示（例:「アブレーションを追加して」）に基づき実験設計を改良 | LLMキー |
| `retrieve_models` | サブ分野別の候補モデルカタログ（transformer_decoder / image / multi_modal / llm_api） | 不要 |
| `retrieve_datasets` | サブ分野別の候補データセットカタログ（LM fine-tuning / image / prompt engineering） | 不要 |
| `fetch_run_ids` | 実験リポジトリに記録されたrun ID一覧 | GHトークン |
| `dispatch_visualization` | 指定run IDの結果グラフ生成をActionsで開始（非同期） | GHトークン |
| `dispatch_diagram_generation` | 論文用の手法ダイアグラム生成をActionsで開始（非同期） | GHトークン |
| `push_files` | 任意ファイルを実験リポジトリへプッシュ（実験コードの手動修正用） | GHトークン |

これで意図的に除外したもの（E2E一括実行 = ClaudeがMCP経由でオーケストレーションするため不要、`poll_github_actions` = ブロッキングのため `get_workflow_runs` で代替、qdrant検索・ephemeral cloudランナー = 運用前提が別）以外、研究サイクルの全APIがMCPから利用可能になります。

## Test plan

- [x] 7サブグラフの入力ステート（TypedDict）とツール引数の一致をソースで照合
- [x] 実MCPクライアントからstdio接続し28ツールの列挙を確認
- [x] `retrieve_models` / `retrieve_datasets` を実呼び出しし、カタログが返ることを確認（キー不要ツール）
- [x] `make ruff` パス、`make mypy` は既存2件のみ
- [x] ドキュメント（英・日）のツール表を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)