### PR TITLE
ci: add automated PyPI publishing via Trusted Publishing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,6 +41,19 @@ Pull requests that do not meet these requirements may be requested for revision 
 
 ## For Core Team
 
+### Releasing to PyPI
+
+Publishing is automated via PyPI Trusted Publishing — no API tokens are involved. To release:
+
+1. Bump `version` in `backend/pyproject.toml` (must be newer than the latest release on [PyPI](https://pypi.org/project/airas/)) and merge it to `main` via the usual release flow.
+2. Tag the release commit and push the tag:
+
+    ```bash
+    git tag v0.2.0 && git push origin v0.2.0
+    ```
+
+3. The `publish.yml` workflow verifies the tag matches the package version, builds, smoke-tests the wheel, and publishes to PyPI.
+
 ### MCP servers and Plugins
 For core team development, we use the following. If you need access, please contact us and we will invite you to each service.
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # Required for PyPI Trusted Publishing (OIDC)
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify tag matches package version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          FILE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('backend/pyproject.toml','rb'))['project']['version'])")
+          if [ "$TAG_VERSION" != "$FILE_VERSION" ]; then
+            echo "::error::Tag v${TAG_VERSION} does not match backend/pyproject.toml version ${FILE_VERSION}"
+            exit 1
+          fi
+
+      - name: Verify version is newer than PyPI
+        run: |
+          FILE_VERSION="${GITHUB_REF_NAME#v}"
+          PYPI_VERSION=$(curl -s https://pypi.org/pypi/airas/json | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])")
+          NEWEST=$(printf '%s\n%s\n' "$PYPI_VERSION" "$FILE_VERSION" | sort -V | tail -1)
+          if [ "$NEWEST" != "$FILE_VERSION" ] || [ "$FILE_VERSION" = "$PYPI_VERSION" ]; then
+            echo "::error::Version ${FILE_VERSION} is not newer than the latest PyPI release ${PYPI_VERSION}"
+            exit 1
+          fi
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build
+        working-directory: backend
+        run: uv build
+
+      - name: Smoke-test the wheel (airas-mcp entry point)
+        working-directory: backend
+        run: |
+          uv venv /tmp/smoke
+          VIRTUAL_ENV=/tmp/smoke uv pip install "$(ls dist/*.whl)[mcp]"
+          /tmp/smoke/bin/python -c "from airas.mcp.server import mcp, main; print('wheel ok:', mcp.name)"
+
+      - name: Publish to PyPI (Trusted Publishing)
+        working-directory: backend
+        run: uv publish --trusted-publishing always

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airas"
-version = "0.0.11.dev58"
+version = "0.2.0"
 description = "Add your description here"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary

PyPIへの公開を手動 `uv publish` から**タグ駆動の自動publish（Trusted Publishing / OIDC、トークン不要）**に切り替えます。

### 追加: `.github/workflows/publish.yml`（`v*` タグのpushで起動）

1. **タグとバージョンの一致検証** — `vX.Y.Z` タグと `backend/pyproject.toml` の `version` が一致しなければ失敗
2. **PyPIとの新旧検証** — PyPI上の最新リリースより新しいバージョンでなければ失敗（今回発覚した「ローカル0.0.11.dev58 vs PyPI 0.1.0」のような乖離を機械的に防止）
3. `uv build` → **wheelスモークテスト**（`[mcp]` extra込みでインストールし `airas.mcp.server` のimportとエントリポイントを確認）
4. `uv publish --trusted-publishing always` で公開

### バージョンバンプ

`0.0.11.dev58` → **`0.2.0`**（PyPI最新の0.1.0より新しい必要があるため。MCPサーバー追加という大きな機能追加に相応のマイナーバンプ）

### ドキュメント

CONTRIBUTING.mdの「For Core Team」にリリース手順（バージョンバンプ → mainへ → タグpush → 自動公開）を追記。

## マージ後に必要な一度きりの設定（PyPIダッシュボード）

[PyPIのairasプロジェクト設定](https://pypi.org/manage/project/airas/settings/publishing/)で **Trusted Publisher** を追加してください：

| 項目 | 値 |
| --- | --- |
| Owner | `airas-org` |
| Repository | `airas` |
| Workflow | `publish.yml` |
| Environment | `pypi` |

設定後、リリースは `git tag v0.2.0 && git push origin v0.2.0` だけで完結します。

## Test plan

- [x] `uv build` と wheelスモークテスト（`[mcp]` extraインストール→import→エントリポイント確認）をローカルで同一コマンドで実行し成功
- [x] バージョン検証ロジックの動作をローカルで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)