### PR TITLE
Release 2026-07-15 (3)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,11 +42,11 @@ jobs:
         working-directory: backend
         run: uv build
 
-      - name: Smoke-test the wheel (airas-mcp entry point)
+      - name: Smoke-test the wheel (airas entry point)
         working-directory: backend
         run: |
           uv venv /tmp/smoke
-          VIRTUAL_ENV=/tmp/smoke uv pip install "$(ls dist/*.whl)[mcp]"
+          VIRTUAL_ENV=/tmp/smoke uv pip install "$(ls dist/*.whl)"
           /tmp/smoke/bin/python -c "from airas.mcp.server import mcp, main; print('wheel ok:', mcp.name)"
 
       - name: Publish to PyPI (Trusted Publishing)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,11 +42,14 @@ jobs:
         working-directory: backend
         run: uv build
 
-      - name: Smoke-test the wheel (airas entry point)
+      - name: Smoke-test the wheel (console scripts and mcp extra)
         working-directory: backend
         run: |
           uv venv /tmp/smoke
-          VIRTUAL_ENV=/tmp/smoke uv pip install "$(ls dist/*.whl)"
+          # Install with the (empty) mcp extra to verify the backwards-compatible alias resolves
+          VIRTUAL_ENV=/tmp/smoke uv pip install "$(ls dist/*.whl)[mcp]"
+          test -x /tmp/smoke/bin/airas
+          test -x /tmp/smoke/bin/airas-mcp
           /tmp/smoke/bin/python -c "from airas.mcp.server import mcp, main; print('wheel ok:', mcp.name)"
 
       - name: Publish to PyPI (Trusted Publishing)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Use AIRAS research tools (paper search, retrieval, hypothesis generation, experi
 2. Register the MCP server:
 
     ```bash
-    claude mcp add airas -- uvx --from "airas[mcp]" airas-mcp
+    claude mcp add airas -- uvx airas
     ```
 
 See the [MCP documentation](docs/development/MCP.mdx) for the full tool list and configuration options.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airas"
-version = "0.2.1"
+version = "0.2.2"
 description = "Add your description here"
 readme = "README.md"
 authors = [
@@ -46,6 +46,7 @@ dependencies = [
     "nltk>=3.9.2",
     "litellm>=1.80.16",
     "boto3>=1.35.0",
+    "mcp[cli]>=1.6.0",
 ]
 
 [project.urls]
@@ -111,9 +112,10 @@ publish-url = "https://test.pypi.org/legacy/"
 explicit = true
 
 [project.optional-dependencies]
-mcp = [
-    "mcp[cli]>=1.6.0",
-]
+# Kept as a no-op alias so `airas[mcp]` (documented before 0.2.2) still installs.
+mcp = []
 
 [project.scripts]
+airas = "airas.mcp.server:main"
+# Backwards-compatible alias (documented command before 0.2.2)
 airas-mcp = "airas.mcp.server:main"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "airas"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -124,6 +124,7 @@ dependencies = [
     { name = "langfuse" },
     { name = "langgraph" },
     { name = "litellm" },
+    { name = "mcp", extra = ["cli"] },
     { name = "nltk" },
     { name = "openai" },
     { name = "pandas" },
@@ -142,11 +143,6 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uvicorn" },
     { name = "wandb" },
-]
-
-[package.optional-dependencies]
-mcp = [
-    { name = "mcp", extra = ["cli"] },
 ]
 
 [package.dev-dependencies]
@@ -183,7 +179,7 @@ requires-dist = [
     { name = "langfuse", specifier = ">=3.11.1" },
     { name = "langgraph", specifier = "==1.0.3" },
     { name = "litellm", specifier = ">=1.80.16" },
-    { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.6.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
     { name = "nltk", specifier = ">=3.9.2" },
     { name = "openai", specifier = ">=1.35.13" },
     { name = "pandas", specifier = ">=2.3.0" },

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -35,7 +35,7 @@ If a tool is called before its credential is configured, it returns an error poi
 ### 2. Register the server (Claude Code)
 
 ```bash
-claude mcp add airas -- uvx --from "airas[mcp]" airas-mcp
+claude mcp add airas -- uvx airas
 ```
 
 Or add it to your project's `.mcp.json`:
@@ -45,7 +45,7 @@ Or add it to your project's `.mcp.json`:
   "mcpServers": {
     "airas": {
       "command": "uvx",
-      "args": ["--from", "airas[mcp]", "airas-mcp"]
+      "args": ["airas"]
     }
   }
 }
@@ -111,8 +111,8 @@ Run the server from a checkout:
 
 ```bash
 cd backend
-uv sync --extra mcp
-uv run airas-mcp
+uv sync
+uv run airas
 ```
 
 The server uses stdio transport; it is started on demand by the MCP client and requires no database or web server.

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -35,7 +35,7 @@ chmod 600 ~/.airas/credentials.json
 ### 2. サーバーの登録（Claude Code）
 
 ```bash
-claude mcp add airas -- uvx --from "airas[mcp]" airas-mcp
+claude mcp add airas -- uvx airas
 ```
 
 またはプロジェクトの `.mcp.json` に追加します：
@@ -45,7 +45,7 @@ claude mcp add airas -- uvx --from "airas[mcp]" airas-mcp
   "mcpServers": {
     "airas": {
       "command": "uvx",
-      "args": ["--from", "airas[mcp]", "airas-mcp"]
+      "args": ["airas"]
     }
   }
 }
@@ -111,8 +111,8 @@ claude mcp add airas -- uvx --from "airas[mcp]" airas-mcp
 
 ```bash
 cd backend
-uv sync --extra mcp
-uv run airas-mcp
+uv sync
+uv run airas
 ```
 
 サーバーはstdioトランスポートを使用し、MCPクライアントがオンデマンドで起動します。データベースやWebサーバーは不要です。


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

v0.2.2 リリース。

**変更**
- **MCPサーバーの起動コマンドを `airas` に変更** — 登録が `claude mcp add airas -- uvx airas` の最短形に。`mcp[cli]` をbase依存に昇格し、`airas-mcp` コマンドと `[mcp]` extraは後方互換エイリアスとして残置（#888）
- publishワークフローのスモークテストを強化（console script実体と `[mcp]` extraの検証を追加）（#888）

🤖 Generated with [Claude Code](https://claude.com/claude-code)