### PR TITLE
feat: publish AIRAS to the official MCP Registry on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,3 +85,28 @@ jobs:
       - name: Publish to PyPI (Trusted Publishing)
         working-directory: backend
         run: uv publish --trusted-publishing always
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Wait for the new version to appear on PyPI
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          for i in $(seq 1 30); do
+            if curl -sf "https://pypi.org/pypi/airas/${VERSION}/json" > /dev/null; then
+              echo "PyPI serves airas ${VERSION}"
+              exit 0
+            fi
+            echo "Waiting for airas ${VERSION} on PyPI... (attempt ${i}/30)"
+            sleep 10
+          done
+          echo "::error::airas ${VERSION} did not appear on PyPI in time"
+          exit 1
+
+      - name: Publish to MCP Registry
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp && mv server.tmp server.json
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,8 +87,15 @@ jobs:
         run: uv publish --trusted-publishing always
 
       - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.0
+          # From registry_1.8.0_checksums.txt on the GitHub release
+          MCP_PUBLISHER_SHA256: 1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -sSfL -o mcp-publisher.tar.gz "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+          rm mcp-publisher.tar.gz
 
       - name: Wait for the new version to appear on PyPI
         run: |

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,5 +1,9 @@
 # Backend
 
+<!-- mcp-name: io.github.airas-org/airas -->
+<!-- ^ MCP Registry ownership marker: must match server.json's name and stay
+     in the README published on PyPI (pyproject.toml's readme). -->
+
 ## Build API server
 
 ```bash

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.airas-org/airas",
+  "title": "AIRAS",
+  "description": "Automated AI research toolkit: hypothesis generation, experiments, and paper writing",
+  "repository": {
+    "url": "https://github.com/airas-org/airas",
+    "source": "github"
+  },
+  "version": "0.2.2",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "airas",
+      "version": "0.2.2",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Registers AIRAS in the [official MCP Registry](https://registry.modelcontextprotocol.io) automatically on every release, as `io.github.airas-org/airas`.

## Changes

- **`server.json`** (repo root) — registry manifest: PyPI package `airas`, stdio transport, schema-validated against `2025-12-11/server.schema.json`. No `environmentVariables` are declared since credentials come from `~/.airas/credentials.json`.
- **`backend/README.md`** — adds the `<!-- mcp-name: io.github.airas-org/airas -->` ownership marker. The registry validates PyPI package ownership by finding this string in the README published on PyPI, so it must ship with the next release.
- **`.github/workflows/publish.yml`** — after the PyPI publish:
  1. installs `mcp-publisher`
  2. waits until the new version is visible on PyPI (registry validation reads PyPI metadata, which can lag right after upload)
  3. rewrites `server.json` versions from the tag with `jq`
  4. `mcp-publisher login github-oidc && mcp-publisher publish` — authenticates via the existing `id-token: write` permission, granting the `io.github.airas-org/*` namespace; no new secrets required

## Notes

- The registry entry is created on the **next tag push** (the current PyPI release 0.2.2 predates the README marker, so a manual publish now would fail validation).
- Verify after release: `curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.airas-org/airas"`
- The MCP Registry is in preview; breaking changes/data resets are possible upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)