### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airas"
-version = "0.2.2"
+version = "0.3.0"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "airas"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Bumps the package version to 0.3.0 for the first release with the bundled dashboard, dashboard API-key settings, and MCP Registry registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)