### PR TITLE
Release 2026-07-16 (2)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airas"
-version = "0.2.2"
+version = "0.3.0"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "airas"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Something else!

#### Description

Version bump to 0.3.0 (PR #895) ahead of tagging `v0.3.0` — the first release with the bundled dashboard, dashboard API-key settings, and MCP Registry registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)