### PR TITLE
feat: add the AIRAS logo to the MCP Registry manifest

### DIFF
--- a/server.json
+++ b/server.json
@@ -7,6 +7,13 @@
     "url": "https://github.com/airas-org/airas",
     "source": "github"
   },
+  "icons": [
+    {
+      "src": "https://raw.githubusercontent.com/airas-org/airas/main/images/airas_logo.png",
+      "mimeType": "image/png",
+      "sizes": ["1563x1563"]
+    }
+  ],
   "version": "0.2.2",
   "packages": [
     {


### PR DESCRIPTION
Adds the `icons` field to `server.json` so the AIRAS logo appears in the MCP Registry. The icon is served from the repository itself (`raw.githubusercontent.com`, same trusted domain as the server) as recommended by the schema, using the square `images/airas_logo.png` (1563×1563, PNG).

Note: registry entries are immutable per version, so the logo will show up with the next tagged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)