### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airas"
-version = "0.3.0"
+version = "0.3.1"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "airas"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Bumps the version to 0.3.1 so the next release publishes the MCP Registry entry with the AIRAS logo (#897) — registry entries are immutable per version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)