### PR TITLE
feat: clean up navigation and categorize the API keys page

### DIFF
--- a/frontend/src/components/app-layout.tsx
+++ b/frontend/src/components/app-layout.tsx
@@ -1,7 +1,6 @@
 import { SiGithub, SiX } from "@icons-pack/react-simple-icons";
 import * as SubframeCore from "@subframe/core";
 import {
-  FeatherBell,
   FeatherCheck,
   FeatherGlobe,
   FeatherPanelLeftClose,
@@ -316,14 +315,6 @@ export function AppLayout() {
                   aria-label="Open X profile"
                 />
               </div>
-              <IconButton
-                variant={
-                  activeSection === "notifications" ? "neutral-secondary" : "neutral-tertiary"
-                }
-                icon={<FeatherBell className="h-4 w-4" />}
-                onClick={() => navigate("/notifications")}
-                aria-label="Open notifications"
-              />
             </>
           }
         />

--- a/frontend/src/components/pages/settings/api-keys.tsx
+++ b/frontend/src/components/pages/settings/api-keys.tsx
@@ -70,22 +70,27 @@ export function ApiKeysPage() {
   const renderCredential = (credential: CredentialStatus) => {
     const edited = credential.name in edits;
     const clearedForRemoval = edited && edits[credential.name] === "";
-    const statusText = clearedForRemoval
+    // Single-line rows: the configured/not-configured state lives in the
+    // input placeholder instead of a separate help-text line.
+    const placeholder = clearedForRemoval
       ? t("credentials.willBeRemoved")
       : credential.is_set
-        ? `${t("credentials.configured")}${credential.preview ? ` (${credential.preview})` : ""}`
-        : t("credentials.notConfigured");
+        ? `${t("credentials.configured")}${credential.preview ? ` (${credential.preview})` : ""} — ${t("credentials.replacePlaceholder")}`
+        : `${t("credentials.notConfigured")} — ${t("credentials.placeholder")}`;
     return (
-      <TextField key={credential.name} label={credential.name} helpText={statusText} error={false}>
-        <div className="flex items-center gap-2 w-full">
+      <div key={credential.name} className="flex items-center gap-3">
+        <span className="w-72 shrink-0 text-caption-bold font-caption-bold text-default-font break-all">
+          {credential.name}
+        </span>
+        <TextField className="flex-1" error={false}>
           <TextField.Input
             type={credential.is_secret ? "password" : "text"}
-            placeholder={
-              credential.is_set ? t("credentials.replacePlaceholder") : t("credentials.placeholder")
-            }
+            placeholder={placeholder}
             value={edits[credential.name] ?? ""}
             onChange={(e) => updateEdit(credential.name, e.target.value)}
           />
+        </TextField>
+        <div className="w-16 shrink-0">
           {credential.is_set && !clearedForRemoval && (
             <Button
               variant="neutral-tertiary"
@@ -96,7 +101,7 @@ export function ApiKeysPage() {
             </Button>
           )}
         </div>
-      </TextField>
+      </div>
     );
   };
 

--- a/frontend/src/components/pages/settings/api-keys.tsx
+++ b/frontend/src/components/pages/settings/api-keys.tsx
@@ -8,6 +8,24 @@ import { Alert } from "@/ui/components/Alert";
 import { Button } from "@/ui/components/Button";
 import { TextField } from "@/ui/components/TextField";
 
+const CATEGORIES: { key: string; names: string[] }[] = [
+  { key: "github", names: ["GH_PERSONAL_ACCESS_TOKEN", "GITHUB_OWNER"] },
+  {
+    key: "llm",
+    names: [
+      "OPENAI_API_KEY",
+      "ANTHROPIC_API_KEY",
+      "GEMINI_API_KEY",
+      "OPENROUTER_API_KEY",
+      "AWS_BEARER_TOKEN_BEDROCK",
+    ],
+  },
+  {
+    key: "integrations",
+    names: ["WANDB_API_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_PUBLIC_KEY", "LANGFUSE_BASE_URL"],
+  },
+];
+
 export function ApiKeysPage() {
   const { t } = useTranslation();
   const [credentials, setCredentials] = useState<CredentialStatus[] | null>(null);
@@ -49,6 +67,39 @@ export function ApiKeysPage() {
     }
   };
 
+  const renderCredential = (credential: CredentialStatus) => {
+    const edited = credential.name in edits;
+    const clearedForRemoval = edited && edits[credential.name] === "";
+    const statusText = clearedForRemoval
+      ? t("credentials.willBeRemoved")
+      : credential.is_set
+        ? `${t("credentials.configured")}${credential.preview ? ` (${credential.preview})` : ""}`
+        : t("credentials.notConfigured");
+    return (
+      <TextField key={credential.name} label={credential.name} helpText={statusText} error={false}>
+        <div className="flex items-center gap-2 w-full">
+          <TextField.Input
+            type={credential.is_secret ? "password" : "text"}
+            placeholder={
+              credential.is_set ? t("credentials.replacePlaceholder") : t("credentials.placeholder")
+            }
+            value={edits[credential.name] ?? ""}
+            onChange={(e) => updateEdit(credential.name, e.target.value)}
+          />
+          {credential.is_set && !clearedForRemoval && (
+            <Button
+              variant="neutral-tertiary"
+              size="small"
+              onClick={() => updateEdit(credential.name, "")}
+            >
+              {t("credentials.clear")}
+            </Button>
+          )}
+        </div>
+      </TextField>
+    );
+  };
+
   if (loading) {
     return (
       <div className="flex-1 flex items-center justify-center py-16">
@@ -56,6 +107,17 @@ export function ApiKeysPage() {
       </div>
     );
   }
+
+  const all = credentials ?? [];
+  const categorizedNames = new Set(CATEGORIES.flatMap((c) => c.names));
+  const sections = [
+    ...CATEGORIES.map((category) => ({
+      key: category.key,
+      items: all.filter((c) => category.names.includes(c.name)),
+    })),
+    // Credentials the backend knows but this page has not categorized yet.
+    { key: "other", items: all.filter((c) => !categorizedNames.has(c.name)) },
+  ].filter((section) => section.items.length > 0);
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -83,55 +145,24 @@ export function ApiKeysPage() {
           </div>
         )}
 
-        <div className="mt-6 rounded-lg border border-border bg-card p-6 flex flex-col gap-5">
-          {(credentials ?? []).map((credential) => {
-            const edited = credential.name in edits;
-            const clearedForRemoval = edited && edits[credential.name] === "";
-            const statusText = clearedForRemoval
-              ? t("credentials.willBeRemoved")
-              : credential.is_set
-                ? `${t("credentials.configured")}${credential.preview ? ` (${credential.preview})` : ""}`
-                : t("credentials.notConfigured");
-            return (
-              <TextField
-                key={credential.name}
-                label={credential.name}
-                helpText={statusText}
-                error={false}
-              >
-                <div className="flex items-center gap-2 w-full">
-                  <TextField.Input
-                    type={credential.is_secret ? "password" : "text"}
-                    placeholder={
-                      credential.is_set
-                        ? t("credentials.replacePlaceholder")
-                        : t("credentials.placeholder")
-                    }
-                    value={edits[credential.name] ?? ""}
-                    onChange={(e) => updateEdit(credential.name, e.target.value)}
-                  />
-                  {credential.is_set && !clearedForRemoval && (
-                    <Button
-                      variant="neutral-tertiary"
-                      size="small"
-                      onClick={() => updateEdit(credential.name, "")}
-                    >
-                      {t("credentials.clear")}
-                    </Button>
-                  )}
-                </div>
-              </TextField>
-            );
-          })}
-
-          <div className="flex items-center justify-between gap-4 pt-2">
-            <p className="text-caption font-caption text-subtext-color">
-              {t("credentials.storageNote")}
-            </p>
-            <Button onClick={handleSave} disabled={saving || Object.keys(edits).length === 0}>
-              {saving ? t("credentials.saving") : t("credentials.save")}
-            </Button>
+        {sections.map((section) => (
+          <div key={section.key} className="mt-6">
+            <h2 className="text-heading-3 font-heading-3 text-default-font">
+              {t(`credentials.categories.${section.key}`)}
+            </h2>
+            <div className="mt-2 rounded-lg border border-border bg-card p-6 flex flex-col gap-5">
+              {section.items.map(renderCredential)}
+            </div>
           </div>
+        ))}
+
+        <div className="mt-6 flex items-center justify-between gap-4">
+          <p className="text-caption font-caption text-subtext-color">
+            {t("credentials.storageNote")}
+          </p>
+          <Button onClick={handleSave} disabled={saving || Object.keys(edits).length === 0}>
+            {saving ? t("credentials.saving") : t("credentials.save")}
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/sidebar/main-sidebar.tsx
+++ b/frontend/src/components/sidebar/main-sidebar.tsx
@@ -4,7 +4,6 @@ import {
   FeatherBrainCircuit,
   FeatherExternalLink,
   FeatherKey,
-  FeatherMessageSquare,
   FeatherRefreshCw,
   FeatherTarget,
 } from "@subframe/core";
@@ -132,16 +131,6 @@ export function MainSidebar({
           }}
         >
           {t("nav.apiKeys")}
-        </SidebarWithSections.NavItem>
-        <SidebarWithSections.NavItem
-          icon={<FeatherMessageSquare />}
-          selected={getSettingsTab(location.pathname) === "feedback"}
-          onClick={() => {
-            navigate("/settings/feedback");
-            onMobileNavClose();
-          }}
-        >
-          {t("nav.feedback")}
         </SidebarWithSections.NavItem>
       </SidebarWithSections.NavSection>
     </>

--- a/frontend/src/components/sidebar/main-sidebar.tsx
+++ b/frontend/src/components/sidebar/main-sidebar.tsx
@@ -98,6 +98,22 @@ export function MainSidebar({
         </div>
       </SidebarWithSections.NavSection>
 
+      {/* --- Settings --- */}
+      <SidebarWithSections.NavSection
+        label={<span className="text-sm font-medium">{t("nav.settings")}</span>}
+      >
+        <SidebarWithSections.NavItem
+          icon={<FeatherKey />}
+          selected={getSettingsTab(location.pathname) === "api-keys"}
+          onClick={() => {
+            navigate("/settings/api-keys");
+            onMobileNavClose();
+          }}
+        >
+          {t("nav.apiKeys")}
+        </SidebarWithSections.NavItem>
+      </SidebarWithSections.NavSection>
+
       {/* --- Support --- */}
       <SidebarWithSections.NavSection
         label={<span className="text-sm font-medium">{t("nav.support")}</span>}
@@ -121,16 +137,6 @@ export function MainSidebar({
           }
         >
           Discord
-        </SidebarWithSections.NavItem>
-        <SidebarWithSections.NavItem
-          icon={<FeatherKey />}
-          selected={getSettingsTab(location.pathname) === "api-keys"}
-          onClick={() => {
-            navigate("/settings/api-keys");
-            onMobileNavClose();
-          }}
-        >
-          {t("nav.apiKeys")}
         </SidebarWithSections.NavItem>
       </SidebarWithSections.NavSection>
     </>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -843,6 +843,12 @@
     "savedTitle": "Credentials saved",
     "fetchError": "Failed to load credentials",
     "saveError": "Failed to save credentials",
-    "storageNote": "Changes take effect immediately; no restart is required."
+    "storageNote": "Changes take effect immediately; no restart is required.",
+    "categories": {
+      "github": "GitHub",
+      "llm": "LLM Providers",
+      "integrations": "Optional Integrations",
+      "other": "Other"
+    }
   }
 }

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -842,6 +842,12 @@
     "savedTitle": "認証情報を保存しました",
     "fetchError": "認証情報の読み込みに失敗しました",
     "saveError": "認証情報の保存に失敗しました",
-    "storageNote": "変更は即座に反映されます。再起動は不要です。"
+    "storageNote": "変更は即座に反映されます。再起動は不要です。",
+    "categories": {
+      "github": "GitHub",
+      "llm": "LLMプロバイダー",
+      "integrations": "オプション連携",
+      "other": "その他"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Three UI changes requested by the maintainer:

- **Sidebar**: removed the contact (お問い合わせ / feedback) item. The `/settings/feedback` route itself is untouched, only the navigation entry is gone.
- **Top-right navigation**: removed the notification bell. The `/notifications` route is likewise untouched.
- **API Keys page**: credentials are now grouped into sections — **GitHub** (`GH_PERSONAL_ACCESS_TOKEN`, `GITHUB_OWNER`), **LLM Providers** (OpenAI / Anthropic / Gemini / OpenRouter / Bedrock), and **Optional Integrations** (W&B, Langfuse). Any credential the backend adds later that isn't categorized falls into an automatic "Other" section, so nothing silently disappears. Section headings are localized (en/ja).

## Verification

- `biome check` and `npm run build` pass
- Built the wheel with the new frontend, launched the dashboard, and verified in a browser: sidebar shows ドキュメント / Discord / APIキー only, the bell is gone from the top bar, and the API keys page renders the three category sections with existing values intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)