### PR TITLE
feat: multi-source paper search and fulltext retrieval

### DIFF
--- a/backend/src/airas/core/credentials.py
+++ b/backend/src/airas/core/credentials.py
@@ -93,6 +93,9 @@ CREDENTIAL_SPECS: tuple[CredentialSpec, ...] = (
     CredentialSpec("GEMINI_API_KEY"),
     CredentialSpec("OPENROUTER_API_KEY"),
     CredentialSpec("AWS_BEARER_TOKEN_BEDROCK"),
+    # Optional: raise rate limits for the paper-search sources.
+    CredentialSpec("SEMANTIC_SCHOLAR_API_KEY"),
+    CredentialSpec("OPENALEX_API_KEY"),
     CredentialSpec("WANDB_API_KEY"),
     CredentialSpec("LANGFUSE_SECRET_KEY"),
     CredentialSpec("LANGFUSE_PUBLIC_KEY"),

--- a/backend/src/airas/core/types/paper_search.py
+++ b/backend/src/airas/core/types/paper_search.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+# Sources supported by the multi-source paper search.
+PAPER_SEARCH_SOURCES = ("openalex", "semantic_scholar", "arxiv", "airas_db")
+
+
+class PaperSearchResult(BaseModel):
+    """A paper found by any search source, normalized to a common shape."""
+
+    title: str
+    authors: list[str] = Field(default_factory=list)
+    abstract: Optional[str] = None
+    doi: Optional[str] = None
+    arxiv_id: Optional[str] = None
+    url: Optional[str] = None
+    pdf_url: Optional[str] = None
+    published_date: Optional[str] = None
+    venue: Optional[str] = None
+    citations: Optional[int] = None
+    # Which search source this result came from (see PAPER_SEARCH_SOURCES).
+    source: str
+    # Source-native identifiers, e.g. {"openalex": "W123", "semantic_scholar": "abc"}.
+    external_ids: dict[str, str] = Field(default_factory=dict)

--- a/backend/src/airas/dashboard/api/routes/v1/papers.py
+++ b/backend/src/airas/dashboard/api/routes/v1/papers.py
@@ -7,8 +7,12 @@ from langfuse import observe
 from airas.container import Container
 from airas.dashboard.api.dependencies import get_github_client, get_langchain_client
 from airas.dashboard.api.schemas.papers import (
+    FetchPaperFulltextRequestBody,
+    FetchPaperFulltextResponseBody,
     RetrievePaperSubgraphRequestBody,
     RetrievePaperSubgraphResponseBody,
+    SearchPapersRequestBody,
+    SearchPapersResponseBody,
     SearchPaperTitlesRequestBody,
     SearchPaperTitlesResponseBody,
     WriteSubgraphRequestBody,
@@ -19,6 +23,11 @@ from airas.infra.github_client import GithubClient
 from airas.infra.langchain_client import LangChainClient
 from airas.infra.langfuse_client import LangfuseClient
 from airas.infra.litellm_client import LiteLLMClient
+from airas.infra.openalex_client import OpenAlexClient
+from airas.infra.semantic_scholar_client import SemanticScholarClient
+from airas.usecases.retrieve.fetch_paper_fulltext_subgraph.fetch_paper_fulltext_subgraph import (
+    FetchPaperFulltextSubgraph,
+)
 from airas.usecases.retrieve.retrieve_paper_subgraph.retrieve_paper_subgraph import (
     RetrievePaperSubgraph,
 )
@@ -27,6 +36,9 @@ from airas.usecases.retrieve.search_paper_titles_subgraph.search_paper_titles_fr
 )
 from airas.usecases.retrieve.search_paper_titles_subgraph.search_paper_titles_from_qdrant_subgraph import (
     SearchPaperTitlesFromQdrantSubgraph,
+)
+from airas.usecases.retrieve.search_papers_subgraph.search_papers_subgraph import (
+    SearchPapersSubgraph,
 )
 from airas.usecases.writers.write_subgraph.write_subgraph import WriteSubgraph
 
@@ -79,6 +91,84 @@ async def search_paper_titles(
 
     return SearchPaperTitlesResponseBody(
         paper_titles=result["paper_titles"],
+        execution_time=result["execution_time"],
+    )
+
+
+@router.post("/source-search", response_model=SearchPapersResponseBody)
+@inject
+@observe()
+async def search_papers(
+    request: SearchPapersRequestBody,
+    fastapi_request: Request,
+    openalex_client: Annotated[
+        OpenAlexClient, Depends(Provide[Container.openalex_client])
+    ],
+    semantic_scholar_client: Annotated[
+        SemanticScholarClient, Depends(Provide[Container.semantic_scholar_client])
+    ],
+    arxiv_client: Annotated[ArxivClient, Depends(Provide[Container.arxiv_client])],
+) -> SearchPapersResponseBody:
+    container: Container = fastapi_request.app.state.container
+    search_index = container.airas_db_search_index()
+
+    result = (
+        await SearchPapersSubgraph(
+            openalex_client=openalex_client,
+            semantic_scholar_client=semantic_scholar_client,
+            arxiv_client=arxiv_client,
+            airas_db_search_index=search_index,
+        )
+        .build_graph()
+        .ainvoke(
+            {
+                "query": request.query,
+                "sources": request.sources,
+                "max_results_per_source": request.max_results_per_source,
+                "year": request.year,
+            }
+        )
+    )
+    return SearchPapersResponseBody(
+        papers=result["papers"],
+        source_results=result["source_results"],
+        search_errors=result["search_errors"],
+        execution_time=result["execution_time"],
+    )
+
+
+@router.post("/fulltext", response_model=FetchPaperFulltextResponseBody)
+@inject
+@observe()
+async def fetch_paper_fulltext(
+    request: FetchPaperFulltextRequestBody,
+    semantic_scholar_client: Annotated[
+        SemanticScholarClient, Depends(Provide[Container.semantic_scholar_client])
+    ],
+) -> FetchPaperFulltextResponseBody:
+    if not (request.arxiv_id or request.doi or request.pdf_url):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="One of arxiv_id, doi, or pdf_url must be provided.",
+        )
+
+    result = (
+        await FetchPaperFulltextSubgraph(
+            semantic_scholar_client=semantic_scholar_client,
+        )
+        .build_graph()
+        .ainvoke(
+            {
+                "arxiv_id": request.arxiv_id,
+                "doi": request.doi,
+                "pdf_url": request.pdf_url,
+            }
+        )
+    )
+    return FetchPaperFulltextResponseBody(
+        text=result["text"],
+        status=result["status"],
+        resolved_from=result["resolved_from"],
         execution_time=result["execution_time"],
     )
 

--- a/backend/src/airas/dashboard/api/routes/v1/papers.py
+++ b/backend/src/airas/dashboard/api/routes/v1/papers.py
@@ -126,6 +126,7 @@ async def search_papers(
                 "sources": request.sources,
                 "max_results_per_source": request.max_results_per_source,
                 "year": request.year,
+                "search_mode": request.search_mode,
             }
         )
     )

--- a/backend/src/airas/dashboard/api/schemas/papers.py
+++ b/backend/src/airas/dashboard/api/schemas/papers.py
@@ -1,8 +1,11 @@
-from pydantic import BaseModel, Field
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
 
 from airas.core.types.experiment_code import ExperimentCode
 from airas.core.types.experiment_history import ExperimentHistory
 from airas.core.types.paper import PaperContent, SearchMethod
+from airas.core.types.paper_search import PAPER_SEARCH_SOURCES, PaperSearchResult
 from airas.core.types.research_hypothesis import ResearchHypothesis
 from airas.core.types.research_study import ResearchStudy
 from airas.usecases.retrieve.retrieve_paper_subgraph.retrieve_paper_subgraph import (
@@ -20,6 +23,47 @@ class SearchPaperTitlesRequestBody(BaseModel):
 
 class SearchPaperTitlesResponseBody(BaseModel):
     paper_titles: list[str]
+    execution_time: dict[str, list[float]]
+
+
+class SearchPapersRequestBody(BaseModel):
+    query: str
+    sources: list[str] = Field(default_factory=lambda: list(PAPER_SEARCH_SOURCES))
+    max_results_per_source: int = Field(default=5, gt=0, le=50)
+    year: str | None = None
+
+    @field_validator("sources")
+    @classmethod
+    def _validate_sources(cls, sources: list[str]) -> list[str]:
+        unknown = sorted(set(sources) - set(PAPER_SEARCH_SOURCES))
+        if unknown:
+            raise ValueError(
+                f"Unknown sources: {', '.join(unknown)}. "
+                f"Available: {', '.join(PAPER_SEARCH_SOURCES)}"
+            )
+        if not sources:
+            raise ValueError("At least one source must be selected")
+        return sources
+
+
+class SearchPapersResponseBody(BaseModel):
+    papers: list[PaperSearchResult]
+    source_results: dict[str, int]
+    search_errors: dict[str, str]
+    execution_time: dict[str, list[float]]
+
+
+class FetchPaperFulltextRequestBody(BaseModel):
+    # Exactly one identifier is enough; they are tried in this order.
+    arxiv_id: str | None = None
+    doi: str | None = None
+    pdf_url: str | None = None
+
+
+class FetchPaperFulltextResponseBody(BaseModel):
+    text: str
+    status: Literal["fulltext", "abstract_only", "not_found"]
+    resolved_from: str | None
     execution_time: dict[str, list[float]]
 
 

--- a/backend/src/airas/dashboard/api/schemas/papers.py
+++ b/backend/src/airas/dashboard/api/schemas/papers.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from airas.core.types.experiment_code import ExperimentCode
 from airas.core.types.experiment_history import ExperimentHistory
@@ -26,11 +26,16 @@ class SearchPaperTitlesResponseBody(BaseModel):
     execution_time: dict[str, list[float]]
 
 
+# Sources that support semantic (AI-embedding) search natively.
+SEMANTIC_SEARCH_SOURCES = ("openalex",)
+
+
 class SearchPapersRequestBody(BaseModel):
     query: str
     sources: list[str] = Field(default_factory=lambda: list(PAPER_SEARCH_SOURCES))
     max_results_per_source: int = Field(default=5, gt=0, le=50)
     year: str | None = None
+    search_mode: Literal["keyword", "semantic"] = "keyword"
 
     @field_validator("sources")
     @classmethod
@@ -44,6 +49,17 @@ class SearchPapersRequestBody(BaseModel):
         if not sources:
             raise ValueError("At least one source must be selected")
         return sources
+
+    @model_validator(mode="after")
+    def _validate_semantic_sources(self) -> "SearchPapersRequestBody":
+        if self.search_mode == "semantic":
+            unsupported = sorted(set(self.sources) - set(SEMANTIC_SEARCH_SOURCES))
+            if unsupported:
+                raise ValueError(
+                    f"Semantic search is not supported by: {', '.join(unsupported)}. "
+                    f"Semantic-capable sources: {', '.join(SEMANTIC_SEARCH_SOURCES)}"
+                )
+        return self
 
 
 class SearchPapersResponseBody(BaseModel):

--- a/backend/src/airas/infra/openalex_client.py
+++ b/backend/src/airas/infra/openalex_client.py
@@ -62,6 +62,7 @@ class OpenAlexClient(BaseHTTPClient):
         per_page: int = 20,
         page: int = 1,
         sort: str | None = "relevance_score:desc",
+        semantic: bool = False,
         fields: tuple[str, ...] | None = None,
         timeout: float = 30.0,
     ) -> dict[str, Any]:
@@ -103,31 +104,43 @@ class OpenAlexClient(BaseHTTPClient):
         fields = fields or DEFAULT_FIELDS
         per_page = max(1, min(per_page, 200))
 
-        filters = []
-
-        if title or author:
-            if title and title.strip():
-                filters.append(f"display_name.search:{title.strip()}")
-            if author and author.strip():
-                filters.append(f"raw_author_name.search:{author.strip()}")
-        elif query and query.strip():
-            filters.append(f"default.search:{query.strip()}")
-        else:
-            raise ValueError("Either 'query' or 'title' must be provided")
-
-        filters.extend(self._build_year_filters(year))
-
         params: dict[str, Any] = {
             "page": page,
             "per-page": per_page,
             "select": ",".join(fields),
-            "filter": ",".join(filters),
         }
 
-        if sort:
-            params["sort"] = sort
-        if self._key_qs:
-            params["api_key"] = os.getenv("OPENALEX_API_KEY")
+        if semantic:
+            # AI-embedding search (https://api.openalex.org/works?search.semantic=).
+            # This is a paid operation and requires an API key.
+            api_key = os.getenv("OPENALEX_API_KEY")
+            if not api_key:
+                raise ValueError("OpenAlex semantic search requires OPENALEX_API_KEY.")
+            if not (query and query.strip()):
+                raise ValueError("'query' must be provided for semantic search")
+            params["search.semantic"] = query.strip()
+            params["api_key"] = api_key
+            year_filters = self._build_year_filters(year)
+            if year_filters:
+                params["filter"] = ",".join(year_filters)
+        else:
+            filters = []
+            if title or author:
+                if title and title.strip():
+                    filters.append(f"display_name.search:{title.strip()}")
+                if author and author.strip():
+                    filters.append(f"raw_author_name.search:{author.strip()}")
+            elif query and query.strip():
+                filters.append(f"default.search:{query.strip()}")
+            else:
+                raise ValueError("Either 'query' or 'title' must be provided")
+
+            filters.extend(self._build_year_filters(year))
+            params["filter"] = ",".join(filters)
+            if sort:
+                params["sort"] = sort
+            if self._key_qs:
+                params["api_key"] = os.getenv("OPENALEX_API_KEY")
 
         path = "works"
         resp = self.get(path=path, params=params, timeout=timeout)

--- a/backend/src/airas/infra/semantic_scholar_client.py
+++ b/backend/src/airas/infra/semantic_scholar_client.py
@@ -182,6 +182,50 @@ class SemanticScholarClient(BaseHTTPClient):
         raise_for_status(resp, path=path)
         return self._parser.parse(resp, as_="json")
 
+    @SEMANTIC_SCHOLAR_RETRY
+    def get_paper_by_doi(
+        self,
+        doi: str,
+        *,
+        fields: tuple[str, ...] | None = None,
+        timeout: float = 30.0,
+    ) -> dict[str, Any]:
+        """
+        Get paper details by DOI using Semantic Scholar API.
+
+        Args:
+            doi: DOI (e.g., "10.18653/v1/N18-3011")
+            fields: Fields to include in response
+            timeout: Request timeout in seconds
+
+        Returns:
+            Dictionary containing paper details
+        """
+        if not doi.strip():
+            raise ValueError("doi must be provided")
+
+        DEFAULT_FIELDS = (
+            "paperId",
+            "title",
+            "abstract",
+            "year",
+            "authors",
+            "venue",
+            "externalIds",
+            "openAccessPdf",
+        )
+
+        fields = fields or DEFAULT_FIELDS
+
+        path = f"paper/DOI:{doi.strip()}"
+        params: dict[str, Any] = {
+            "fields": ",".join(fields),
+        }
+
+        resp = self.get(path=path, params=params, timeout=timeout)
+        raise_for_status(resp, path=path)
+        return self._parser.parse(resp, as_="json")
+
 
 if __name__ == "__main__":
     client = SemanticScholarClient()

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -244,21 +244,41 @@ async def search_papers(
     sources: str = "all",
     max_results_per_source: int = 5,
     year: str | None = None,
+    search_mode: Literal["keyword", "semantic"] = "keyword",
 ) -> dict[str, Any]:
     """Search academic papers across multiple sources in parallel.
 
     Sources: openalex, semantic_scholar, arxiv, airas_db (curated major-ML-
     conference database). Pass a comma-separated subset or "all". `year`
-    filters by publication year ("2024" or "2020-2024"). Results are
-    normalized (title, authors, abstract, doi, arxiv_id, pdf_url, citations,
-    source) and de-duplicated across sources; failures of individual sources
-    are reported in `search_errors` without failing the search. No API keys
-    required (SEMANTIC_SCHOLAR_API_KEY / OPENALEX_API_KEY optionally raise
-    rate limits). Pass promising titles to `retrieve_papers`, or an
-    arxiv_id / doi / pdf_url to `fetch_paper_fulltext`.
+    filters by publication year ("2024" or "2020-2024").
+
+    `search_mode="keyword"` (default) does lexical/relevance search on every
+    source. `search_mode="semantic"` does AI-embedding search that matches by
+    meaning; it is only supported by `openalex` and requires OPENALEX_API_KEY
+    (so pass sources="openalex"). Selecting any other source in semantic mode
+    is an error.
+
+    Results are normalized (title, authors, abstract, doi, arxiv_id, pdf_url,
+    citations, source) and de-duplicated across sources; failures of
+    individual sources are reported in `search_errors` without failing the
+    search. Keyword search needs no API keys (SEMANTIC_SCHOLAR_API_KEY /
+    OPENALEX_API_KEY optionally raise rate limits). Pass promising titles to
+    `retrieve_papers`, or an arxiv_id / doi / pdf_url to
+    `fetch_paper_fulltext`.
     """
     refresh_environment()
     selected_sources = _parse_paper_sources(sources)
+    if search_mode == "semantic":
+        unsupported = sorted(set(selected_sources) - {"openalex"})
+        if unsupported:
+            raise ValueError(
+                f"Semantic search is not supported by: {', '.join(unsupported)}. "
+                "Only 'openalex' supports semantic search."
+            )
+        if not os.getenv("OPENALEX_API_KEY"):
+            raise RuntimeError(
+                f"Semantic search requires OPENALEX_API_KEY. {SETUP_INSTRUCTIONS}"
+            )
     result = (
         await SearchPapersSubgraph(
             openalex_client=_openalex_client(),
@@ -273,6 +293,7 @@ async def search_papers(
                 "sources": selected_sources,
                 "max_results_per_source": max_results_per_source,
                 "year": year,
+                "search_mode": search_mode,
             }
         )
     )

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -36,6 +36,7 @@ from airas.core.types.experimental_results import ExperimentalResults
 from airas.core.types.github import GitHubConfig
 from airas.core.types.latex import LATEX_TEMPLATE_NAME
 from airas.core.types.paper import PaperContent
+from airas.core.types.paper_search import PAPER_SEARCH_SOURCES
 from airas.core.types.research_history import ResearchHistory
 from airas.core.types.research_hypothesis import ResearchHypothesis
 from airas.core.types.research_study import ResearchStudy
@@ -56,6 +57,8 @@ from airas.infra.langchain_client import (
     LangChainClient,
 )
 from airas.infra.llm_provider_resolver import detect_available_providers
+from airas.infra.openalex_client import OpenAlexClient
+from airas.infra.semantic_scholar_client import SemanticScholarClient
 from airas.usecases.analyzers.analyze_experiment_subgraph.analyze_experiment_subgraph import (
     AnalyzeExperimentSubgraph,
 )
@@ -115,6 +118,9 @@ from airas.usecases.publication.generate_latex_subgraph.generate_latex_subgraph 
 from airas.usecases.publication.push_latex_subgraph.push_latex_subgraph import (
     PushLatexSubgraph,
 )
+from airas.usecases.retrieve.fetch_paper_fulltext_subgraph.fetch_paper_fulltext_subgraph import (
+    FetchPaperFulltextSubgraph,
+)
 from airas.usecases.retrieve.retrieve_datasets_subgraph.retrieve_datasets_subgraph import (
     RetrieveDatasetsSubgraph,
 )
@@ -127,8 +133,8 @@ from airas.usecases.retrieve.retrieve_paper_subgraph.retrieve_paper_subgraph imp
 from airas.usecases.retrieve.search_paper_titles_subgraph.nodes.search_paper_titles_from_airas_db import (
     AirasDbPaperSearchIndex,
 )
-from airas.usecases.retrieve.search_paper_titles_subgraph.search_paper_titles_from_airas_db_subgraph import (
-    SearchPaperTitlesFromAirasDbSubgraph,
+from airas.usecases.retrieve.search_papers_subgraph.search_papers_subgraph import (
+    SearchPapersSubgraph,
 )
 from airas.usecases.writers.generate_bibfile_subgraph.generate_bibfile_subgraph import (
     GenerateBibfileSubgraph,
@@ -170,6 +176,18 @@ def _arxiv_client() -> ArxivClient:
     return ArxivClient(sync_session=_sync_session, async_session=_async_session)
 
 
+def _openalex_client() -> OpenAlexClient:
+    refresh_environment()  # OPENALEX_API_KEY is optional
+    return OpenAlexClient(sync_session=_sync_session, async_session=_async_session)
+
+
+def _semantic_scholar_client() -> SemanticScholarClient:
+    refresh_environment()  # SEMANTIC_SCHOLAR_API_KEY is optional
+    return SemanticScholarClient(
+        sync_session=_sync_session, async_session=_async_session
+    )
+
+
 def _langchain_client() -> LangChainClient:
     refresh_environment()
     if not detect_available_providers(PROVIDER_REQUIRED_ENV_VARS):
@@ -194,7 +212,7 @@ async def generate_research_queries(
     """Generate academic paper search queries from a research topic.
 
     Use this first to turn a free-form research topic into effective
-    search queries, then pass them to `search_paper_titles`.
+    search queries, then pass them to `search_papers`.
     """
     result = (
         await GenerateQueriesSubgraph(
@@ -207,26 +225,93 @@ async def generate_research_queries(
     return result["queries"]
 
 
-@mcp.tool()
-async def search_paper_titles(
-    queries: list[str],
-    max_results_per_query: int = 3,
-) -> list[str]:
-    """Search the AIRAS papers database (major ML conferences) for paper titles.
+def _parse_paper_sources(sources: str) -> list[str]:
+    if not sources.strip() or sources.strip().lower() == "all":
+        return list(PAPER_SEARCH_SOURCES)
+    selected = [part.strip().lower() for part in sources.split(",") if part.strip()]
+    unknown = sorted(set(selected) - set(PAPER_SEARCH_SOURCES))
+    if unknown:
+        raise ValueError(
+            f"Unknown sources: {', '.join(unknown)}. "
+            f"Available: {', '.join(PAPER_SEARCH_SOURCES)} (or 'all')."
+        )
+    return selected
 
-    Takes search queries (e.g. from `generate_research_queries`) and returns
-    matching paper titles. The first call builds the search index, which can
-    take a while; subsequent calls are fast. No API keys required.
+
+@mcp.tool()
+async def search_papers(
+    query: str,
+    sources: str = "all",
+    max_results_per_source: int = 5,
+    year: str | None = None,
+) -> dict[str, Any]:
+    """Search academic papers across multiple sources in parallel.
+
+    Sources: openalex, semantic_scholar, arxiv, airas_db (curated major-ML-
+    conference database). Pass a comma-separated subset or "all". `year`
+    filters by publication year ("2024" or "2020-2024"). Results are
+    normalized (title, authors, abstract, doi, arxiv_id, pdf_url, citations,
+    source) and de-duplicated across sources; failures of individual sources
+    are reported in `search_errors` without failing the search. No API keys
+    required (SEMANTIC_SCHOLAR_API_KEY / OPENALEX_API_KEY optionally raise
+    rate limits). Pass promising titles to `retrieve_papers`, or an
+    arxiv_id / doi / pdf_url to `fetch_paper_fulltext`.
     """
+    refresh_environment()
+    selected_sources = _parse_paper_sources(sources)
     result = (
-        await SearchPaperTitlesFromAirasDbSubgraph(
-            search_index=_search_index,
-            papers_per_query=max_results_per_query,
+        await SearchPapersSubgraph(
+            openalex_client=_openalex_client(),
+            semantic_scholar_client=_semantic_scholar_client(),
+            arxiv_client=_arxiv_client(),
+            airas_db_search_index=_search_index,
         )
         .build_graph()
-        .ainvoke({"queries": queries})
+        .ainvoke(
+            {
+                "query": query,
+                "sources": selected_sources,
+                "max_results_per_source": max_results_per_source,
+                "year": year,
+            }
+        )
     )
-    return result["paper_titles"]
+    return {
+        "papers": [paper.model_dump(exclude_none=True) for paper in result["papers"]],
+        "source_results": result["source_results"],
+        "search_errors": result["search_errors"],
+    }
+
+
+@mcp.tool()
+async def fetch_paper_fulltext(
+    arxiv_id: str | None = None,
+    doi: str | None = None,
+    pdf_url: str | None = None,
+) -> dict[str, Any]:
+    """Fetch the full text of a paper by arXiv ID, DOI, or direct PDF URL.
+
+    Provide one identifier (tried in that order). arXiv IDs are fetched from
+    arXiv; DOIs are resolved to an open-access PDF via Semantic Scholar.
+    Returns the extracted text with `status`: "fulltext", "abstract_only"
+    (no legal open-access PDF found, abstract returned instead), or
+    "not_found". No API keys required.
+    """
+    if not (arxiv_id or doi or pdf_url):
+        raise ValueError("One of arxiv_id, doi, or pdf_url must be provided.")
+    refresh_environment()
+    result = (
+        await FetchPaperFulltextSubgraph(
+            semantic_scholar_client=_semantic_scholar_client(),
+        )
+        .build_graph()
+        .ainvoke({"arxiv_id": arxiv_id, "doi": doi, "pdf_url": pdf_url})
+    )
+    return {
+        "text": result["text"],
+        "status": result["status"],
+        "resolved_from": result["resolved_from"],
+    }
 
 
 @mcp.tool()

--- a/backend/src/airas/usecases/retrieve/fetch_paper_fulltext_subgraph/fetch_paper_fulltext_subgraph.py
+++ b/backend/src/airas/usecases/retrieve/fetch_paper_fulltext_subgraph/fetch_paper_fulltext_subgraph.py
@@ -1,0 +1,133 @@
+import asyncio
+import logging
+from typing import Literal, Optional
+
+from langgraph.graph import END, START, StateGraph
+from typing_extensions import TypedDict
+
+from airas.core.execution_timers import ExecutionTimeState, time_node
+from airas.core.logging_utils import setup_logging
+from airas.infra.semantic_scholar_client import SemanticScholarClient
+from airas.usecases.retrieve.fetch_paper_fulltext_subgraph.nodes.download_pdf_text import (
+    download_pdf_text,
+)
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+subgraph_name = "fetch_paper_fulltext_subgraph"
+record_execution_time = lambda f: time_node(subgraph_name)(f)  # noqa: E731
+
+FulltextStatus = Literal["fulltext", "abstract_only", "not_found"]
+
+
+class FetchPaperFulltextSubgraphInputState(TypedDict):
+    arxiv_id: Optional[str]
+    doi: Optional[str]
+    pdf_url: Optional[str]
+
+
+class FetchPaperFulltextSubgraphOutputState(ExecutionTimeState):
+    text: str
+    status: FulltextStatus
+    resolved_from: Optional[str]
+
+
+class FetchPaperFulltextSubgraphState(
+    FetchPaperFulltextSubgraphInputState, FetchPaperFulltextSubgraphOutputState
+):
+    resolved_pdf_url: Optional[str]
+    fallback_abstract: Optional[str]
+
+
+class FetchPaperFulltextSubgraph:
+    """Resolve a paper identifier to a PDF, download it, and extract the text.
+
+    Resolution order: arXiv ID → explicit PDF URL → open-access PDF located
+    via Semantic Scholar by DOI. When no PDF can be fetched, the abstract
+    (when the DOI lookup provided one) is returned with status
+    `abstract_only`, or `not_found` when nothing is available.
+    """
+
+    def __init__(self, semantic_scholar_client: SemanticScholarClient):
+        self.semantic_scholar_client = semantic_scholar_client
+
+    @record_execution_time
+    async def _resolve_pdf_url(self, state: FetchPaperFulltextSubgraphState) -> dict:
+        arxiv_id = (state.get("arxiv_id") or "").strip()
+        pdf_url = (state.get("pdf_url") or "").strip()
+        doi = (state.get("doi") or "").strip()
+
+        if arxiv_id:
+            bare_id = arxiv_id.split("v")[0]
+            return {
+                "resolved_pdf_url": f"https://arxiv.org/pdf/{bare_id}",
+                "resolved_from": "arxiv",
+            }
+        if pdf_url:
+            return {"resolved_pdf_url": pdf_url, "resolved_from": "pdf_url"}
+        # arXiv-minted DOIs (10.48550/arxiv.<id>) map directly to arXiv and
+        # are not resolvable through Semantic Scholar.
+        if doi and doi.lower().startswith("10.48550/arxiv."):
+            bare_id = doi[len("10.48550/arxiv.") :].split("v")[0]
+            return {
+                "resolved_pdf_url": f"https://arxiv.org/pdf/{bare_id}",
+                "resolved_from": "arxiv",
+            }
+        if doi:
+            try:
+                paper = await asyncio.to_thread(
+                    self.semantic_scholar_client.get_paper_by_doi, doi
+                )
+            except Exception as e:
+                logger.warning(f"Semantic Scholar DOI lookup failed for {doi}: {e}")
+                return {"resolved_pdf_url": None, "resolved_from": None}
+
+            open_access_pdf = (paper.get("openAccessPdf") or {}).get("url")
+            external = paper.get("externalIds") or {}
+            resolved: dict = {"fallback_abstract": paper.get("abstract")}
+            if resolved_arxiv_id := external.get("ArXiv"):
+                resolved["resolved_pdf_url"] = (
+                    f"https://arxiv.org/pdf/{resolved_arxiv_id}"
+                )
+                resolved["resolved_from"] = "arxiv"
+            elif open_access_pdf:
+                resolved["resolved_pdf_url"] = open_access_pdf
+                resolved["resolved_from"] = "open_access_pdf"
+            else:
+                resolved["resolved_pdf_url"] = None
+                resolved["resolved_from"] = None
+            return resolved
+        return {"resolved_pdf_url": None, "resolved_from": None}
+
+    @record_execution_time
+    async def _download_and_extract(
+        self, state: FetchPaperFulltextSubgraphState
+    ) -> dict:
+        resolved_pdf_url = state.get("resolved_pdf_url")
+
+        if resolved_pdf_url:
+            text = await download_pdf_text(resolved_pdf_url)
+            if text:
+                return {"text": text, "status": "fulltext"}
+
+        if fallback_abstract := state.get("fallback_abstract"):
+            return {
+                "text": fallback_abstract,
+                "status": "abstract_only",
+                "resolved_from": "semantic_scholar_abstract",
+            }
+        return {"text": "", "status": "not_found", "resolved_from": None}
+
+    def build_graph(self):
+        graph_builder = StateGraph(
+            FetchPaperFulltextSubgraphState,
+            input_schema=FetchPaperFulltextSubgraphInputState,
+            output_schema=FetchPaperFulltextSubgraphOutputState,
+        )
+        graph_builder.add_node("resolve_pdf_url", self._resolve_pdf_url)
+        graph_builder.add_node("download_and_extract", self._download_and_extract)
+        graph_builder.add_edge(START, "resolve_pdf_url")
+        graph_builder.add_edge("resolve_pdf_url", "download_and_extract")
+        graph_builder.add_edge("download_and_extract", END)
+        return graph_builder.compile()

--- a/backend/src/airas/usecases/retrieve/fetch_paper_fulltext_subgraph/nodes/download_pdf_text.py
+++ b/backend/src/airas/usecases/retrieve/fetch_paper_fulltext_subgraph/nodes/download_pdf_text.py
@@ -1,0 +1,24 @@
+from io import BytesIO
+from logging import getLogger
+
+import httpx
+from pypdf import PdfReader
+
+logger = getLogger(__name__)
+
+REQUEST_TIMEOUT_SECONDS = 60.0
+
+
+async def download_pdf_text(pdf_url: str) -> str:
+    """Download a PDF and return its extracted text ("" on failure)."""
+    try:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
+            response = await client.get(pdf_url, timeout=REQUEST_TIMEOUT_SECONDS)
+            response.raise_for_status()
+
+        pdf_reader = PdfReader(BytesIO(response.content))
+        text = "".join((page.extract_text() or "") for page in pdf_reader.pages)
+        return text.replace("\n", " ").strip()
+    except Exception as e:  # pragma: no cover - network/IO errors
+        logger.warning(f"Failed to extract text from PDF {pdf_url}: {e}")
+        return ""

--- a/backend/src/airas/usecases/retrieve/search_paper_titles_subgraph/nodes/search_paper_titles_from_airas_db.py
+++ b/backend/src/airas/usecases/retrieve/search_paper_titles_subgraph/nodes/search_paper_titles_from_airas_db.py
@@ -106,22 +106,27 @@ class AirasDbPaperSearchIndex:
         logger.info(f"Search index built with {len(self._papers)} papers")
 
     async def search(self, query: str, max_results: int) -> list[str]:
+        return [
+            paper.get("title", "")
+            for paper in await self.search_papers(query, max_results)
+        ]
+
+    async def search_papers(self, query: str, max_results: int) -> list[dict[str, Any]]:
+        """Return the full paper records (not just titles) for the best matches."""
         await self._ensure_loaded()
 
-        if not self._bm25 or not self._titles:
+        if not self._bm25 or not self._papers:
             return []
 
         tokenized_query = self._tokenize_with_stem(query)
         scores = self._bm25.get_scores(tokenized_query)
 
-        scored_papers = [
-            (score, title)
-            for score, title in zip(scores, self._titles, strict=True)
-            if score > 0
+        scored_indices = [
+            (score, index) for index, score in enumerate(scores) if score > 0
         ]
-        scored_papers.sort(key=lambda x: x[0], reverse=True)
+        scored_indices.sort(key=lambda x: x[0], reverse=True)
 
-        return [title for _, title in scored_papers[:max_results]]
+        return [self._papers[index] for _, index in scored_indices[:max_results]]
 
 
 async def search_paper_titles_from_airas_db(

--- a/backend/src/airas/usecases/retrieve/search_papers_subgraph/nodes/search_airas_db.py
+++ b/backend/src/airas/usecases/retrieve/search_papers_subgraph/nodes/search_airas_db.py
@@ -1,0 +1,70 @@
+import ast
+from logging import getLogger
+from typing import Any
+
+from airas.core.types.paper_search import PaperSearchResult
+from airas.usecases.retrieve.search_paper_titles_subgraph.nodes.search_paper_titles_from_airas_db import (
+    AirasDbPaperSearchIndex,
+)
+
+logger = getLogger(__name__)
+
+
+def _parse_authors(raw_authors: Any) -> list[str]:
+    """DB records store authors either as a list or its string repr."""
+    if isinstance(raw_authors, list):
+        return [str(author) for author in raw_authors]
+    if isinstance(raw_authors, str) and raw_authors.startswith("["):
+        try:
+            parsed = ast.literal_eval(raw_authors)
+            if isinstance(parsed, list):
+                return [str(author) for author in parsed]
+        except (ValueError, SyntaxError):
+            pass
+    return [raw_authors] if raw_authors else []
+
+
+def _in_year_range(record_year: str, year: str | None) -> bool:
+    if not year or not record_year:
+        return True
+    if "-" in year:
+        year_from, year_to = year.split("-", 1)
+        return year_from.strip() <= record_year <= year_to.strip()
+    return record_year == year.strip()
+
+
+def _record_year(record: dict[str, Any]) -> str:
+    # Year is stored as a string in some records and an int in others.
+    year = record.get("year")
+    return str(year) if year else ""
+
+
+def _normalize_record(record: dict[str, Any]) -> PaperSearchResult:
+    paper_url = record.get("paper_url")
+    if not paper_url or paper_url == "None":
+        paper_url = None
+    record_id = record.get("id")
+    return PaperSearchResult(
+        title=record.get("title") or "",
+        authors=_parse_authors(record.get("authors")),
+        abstract=record.get("abstract") or None,
+        url=paper_url,
+        published_date=_record_year(record) or None,
+        venue=record.get("conference") or None,
+        source="airas_db",
+        external_ids={"airas_db": str(record_id)} if record_id else {},
+    )
+
+
+async def search_airas_db(
+    search_index: AirasDbPaperSearchIndex,
+    query: str,
+    max_results: int,
+    year: str | None = None,
+) -> list[PaperSearchResult]:
+    records = await search_index.search_papers(query, max_results)
+    return [
+        _normalize_record(record)
+        for record in records
+        if _in_year_range(_record_year(record), year)
+    ]

--- a/backend/src/airas/usecases/retrieve/search_papers_subgraph/nodes/search_arxiv.py
+++ b/backend/src/airas/usecases/retrieve/search_papers_subgraph/nodes/search_arxiv.py
@@ -1,0 +1,55 @@
+from logging import getLogger
+
+import feedparser
+
+from airas.core.types.paper_search import PaperSearchResult
+from airas.infra.arxiv_client import ArxivClient
+
+logger = getLogger(__name__)
+
+
+def _year_to_date_range(year: str | None) -> tuple[str | None, str | None]:
+    """Convert "2023" or "2020-2023" to arXiv submittedDate bounds."""
+    if not year:
+        return None, None
+    if "-" in year:
+        year_from, year_to = year.split("-", 1)
+    else:
+        year_from = year_to = year
+    return f"{year_from.strip()}01010000", f"{year_to.strip()}12312359"
+
+
+def _normalize_entry(entry: feedparser.FeedParserDict) -> PaperSearchResult:
+    versioned_id = entry.id.split("/")[-1]
+    arxiv_id = versioned_id.split("v")[0]
+    return PaperSearchResult(
+        title=(getattr(entry, "title", "") or "").replace("\n", " ").strip(),
+        authors=[author.name for author in getattr(entry, "authors", [])],
+        abstract=getattr(entry, "summary", None),
+        doi=getattr(entry, "arxiv_doi", None),
+        arxiv_id=arxiv_id,
+        url=f"https://arxiv.org/abs/{arxiv_id}",
+        pdf_url=f"https://arxiv.org/pdf/{arxiv_id}",
+        published_date=getattr(entry, "published", None),
+        venue=getattr(entry, "arxiv_journal_ref", None),
+        citations=None,
+        source="arxiv",
+        external_ids={"arxiv": arxiv_id},
+    )
+
+
+async def search_arxiv(
+    arxiv_client: ArxivClient,
+    query: str,
+    max_results: int,
+    year: str | None = None,
+) -> list[PaperSearchResult]:
+    from_date, to_date = _year_to_date_range(year)
+    xml_feed = await arxiv_client.asearch_papers(
+        query,
+        max_results=max_results,
+        from_date=from_date,
+        to_date=to_date,
+    )
+    feed = feedparser.parse(xml_feed)
+    return [_normalize_entry(entry) for entry in feed.entries if hasattr(entry, "id")]

--- a/backend/src/airas/usecases/retrieve/search_papers_subgraph/nodes/search_openalex.py
+++ b/backend/src/airas/usecases/retrieve/search_papers_subgraph/nodes/search_openalex.py
@@ -1,0 +1,86 @@
+import asyncio
+import re
+from logging import getLogger
+from typing import Any
+
+from airas.core.types.paper_search import PaperSearchResult
+from airas.infra.openalex_client import OpenAlexClient
+
+logger = getLogger(__name__)
+
+_FIELDS = (
+    "id",
+    "doi",
+    "display_name",
+    "publication_date",
+    "authorships",
+    "primary_location",
+    "cited_by_count",
+    "best_oa_location",
+    "abstract_inverted_index",
+)
+
+_ARXIV_URL_PATTERN = re.compile(r"arxiv\.org/(?:pdf|abs)/([0-9]{4}\.[0-9]{4,5})")
+
+
+def _reconstruct_abstract(inverted_index: dict[str, list[int]] | None) -> str | None:
+    """OpenAlex stores abstracts as an inverted index; rebuild the text."""
+    if not inverted_index:
+        return None
+    positioned_words = [
+        (position, word)
+        for word, positions in inverted_index.items()
+        for position in positions
+    ]
+    positioned_words.sort(key=lambda item: item[0])
+    return " ".join(word for _, word in positioned_words)
+
+
+def _extract_arxiv_id(doi: str | None, pdf_url: str | None) -> str | None:
+    if doi and doi.lower().startswith("10.48550/arxiv."):
+        return doi[len("10.48550/arxiv.") :]
+    if pdf_url and (match := _ARXIV_URL_PATTERN.search(pdf_url)):
+        return match.group(1)
+    return None
+
+
+def _normalize_work(work: dict[str, Any]) -> PaperSearchResult:
+    openalex_id = (work.get("id") or "").rsplit("/", 1)[-1]
+    doi = ((work.get("doi") or "").removeprefix("https://doi.org/")) or None
+    best_oa_location = work.get("best_oa_location") or {}
+    pdf_url = best_oa_location.get("pdf_url")
+    primary_source = (work.get("primary_location") or {}).get("source") or {}
+    return PaperSearchResult(
+        title=work.get("display_name") or "",
+        authors=[
+            author_name
+            for authorship in work.get("authorships") or []
+            if (author_name := (authorship.get("author") or {}).get("display_name"))
+        ],
+        abstract=_reconstruct_abstract(work.get("abstract_inverted_index")),
+        doi=doi,
+        arxiv_id=_extract_arxiv_id(doi, pdf_url),
+        url=work.get("id"),
+        pdf_url=pdf_url,
+        published_date=work.get("publication_date"),
+        venue=primary_source.get("display_name"),
+        citations=work.get("cited_by_count"),
+        source="openalex",
+        external_ids={"openalex": openalex_id} if openalex_id else {},
+    )
+
+
+async def search_openalex(
+    openalex_client: OpenAlexClient,
+    query: str,
+    max_results: int,
+    year: str | None = None,
+) -> list[PaperSearchResult]:
+    response = await asyncio.to_thread(
+        openalex_client.search_papers,
+        query,
+        year=year,
+        per_page=max_results,
+        fields=_FIELDS,
+    )
+    return [_normalize_work(work) for work in response.get("results", [])]

--- a/backend/src/airas/usecases/retrieve/search_papers_subgraph/nodes/search_openalex.py
+++ b/backend/src/airas/usecases/retrieve/search_papers_subgraph/nodes/search_openalex.py
@@ -75,12 +75,14 @@ async def search_openalex(
     query: str,
     max_results: int,
     year: str | None = None,
+    semantic: bool = False,
 ) -> list[PaperSearchResult]:
     response = await asyncio.to_thread(
         openalex_client.search_papers,
         query,
         year=year,
         per_page=max_results,
+        semantic=semantic,
         fields=_FIELDS,
     )
     return [_normalize_work(work) for work in response.get("results", [])]

--- a/backend/src/airas/usecases/retrieve/search_papers_subgraph/nodes/search_semantic_scholar.py
+++ b/backend/src/airas/usecases/retrieve/search_papers_subgraph/nodes/search_semantic_scholar.py
@@ -1,0 +1,60 @@
+import asyncio
+from logging import getLogger
+from typing import Any
+
+from airas.core.types.paper_search import PaperSearchResult
+from airas.infra.semantic_scholar_client import SemanticScholarClient
+
+logger = getLogger(__name__)
+
+_FIELDS = (
+    "paperId",
+    "title",
+    "abstract",
+    "year",
+    "publicationDate",
+    "authors",
+    "venue",
+    "citationCount",
+    "externalIds",
+    "openAccessPdf",
+)
+
+
+def _normalize_item(item: dict[str, Any]) -> PaperSearchResult:
+    paper_id = item.get("paperId")
+    external = item.get("externalIds") or {}
+    open_access_pdf = item.get("openAccessPdf") or {}
+    year = item.get("year")
+    return PaperSearchResult(
+        title=item.get("title") or "",
+        authors=[
+            name for author in item.get("authors") or [] if (name := author.get("name"))
+        ],
+        abstract=item.get("abstract"),
+        doi=external.get("DOI"),
+        arxiv_id=external.get("ArXiv"),
+        url=f"https://www.semanticscholar.org/paper/{paper_id}" if paper_id else None,
+        pdf_url=open_access_pdf.get("url"),
+        published_date=item.get("publicationDate") or (str(year) if year else None),
+        venue=item.get("venue") or None,
+        citations=item.get("citationCount"),
+        source="semantic_scholar",
+        external_ids={"semantic_scholar": paper_id} if paper_id else {},
+    )
+
+
+async def search_semantic_scholar(
+    semantic_scholar_client: SemanticScholarClient,
+    query: str,
+    max_results: int,
+    year: str | None = None,
+) -> list[PaperSearchResult]:
+    response = await asyncio.to_thread(
+        semantic_scholar_client.search_papers,
+        query,
+        year=year,
+        limit=max_results,
+        fields=_FIELDS,
+    )
+    return [_normalize_item(item) for item in response.get("data") or []]

--- a/backend/src/airas/usecases/retrieve/search_papers_subgraph/search_papers_subgraph.py
+++ b/backend/src/airas/usecases/retrieve/search_papers_subgraph/search_papers_subgraph.py
@@ -1,0 +1,233 @@
+import logging
+import re
+from operator import or_
+from typing import Annotated, Callable, Coroutine
+
+from langgraph.graph import END, START, StateGraph
+from typing_extensions import Any, TypedDict
+
+from airas.core.execution_timers import ExecutionTimeState, time_node
+from airas.core.logging_utils import setup_logging
+from airas.core.types.paper_search import PAPER_SEARCH_SOURCES, PaperSearchResult
+from airas.infra.arxiv_client import ArxivClient
+from airas.infra.openalex_client import OpenAlexClient
+from airas.infra.semantic_scholar_client import SemanticScholarClient
+from airas.usecases.retrieve.search_paper_titles_subgraph.nodes.search_paper_titles_from_airas_db import (
+    AirasDbPaperSearchIndex,
+)
+from airas.usecases.retrieve.search_papers_subgraph.nodes.search_airas_db import (
+    search_airas_db,
+)
+from airas.usecases.retrieve.search_papers_subgraph.nodes.search_arxiv import (
+    search_arxiv,
+)
+from airas.usecases.retrieve.search_papers_subgraph.nodes.search_openalex import (
+    search_openalex,
+)
+from airas.usecases.retrieve.search_papers_subgraph.nodes.search_semantic_scholar import (
+    search_semantic_scholar,
+)
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+subgraph_name = "search_papers_subgraph"
+record_execution_time = lambda f: time_node(subgraph_name)(f)  # noqa: E731
+
+
+class SourceSearchOutput(TypedDict):
+    papers: list[PaperSearchResult]
+    error: str | None
+
+
+class SearchPapersSubgraphInputState(TypedDict):
+    query: str
+    sources: list[str]
+    max_results_per_source: int
+    year: str | None
+
+
+class SearchPapersSubgraphOutputState(ExecutionTimeState):
+    papers: list[PaperSearchResult]
+    source_results: dict[str, int]
+    search_errors: dict[str, str]
+
+
+class SearchPapersSubgraphState(
+    SearchPapersSubgraphInputState, SearchPapersSubgraphOutputState
+):
+    # Source nodes run in parallel; each merges its own entry into this dict.
+    source_outputs: Annotated[dict[str, SourceSearchOutput], or_]
+
+
+def _dedupe_keys(paper: PaperSearchResult) -> list[str]:
+    keys = []
+    if paper.doi:
+        keys.append(f"doi:{paper.doi.lower()}")
+    if paper.arxiv_id:
+        keys.append(f"arxiv:{paper.arxiv_id.lower()}")
+    if paper.title:
+        keys.append(f"title:{re.sub(r'[^a-z0-9]', '', paper.title.lower())}")
+    return keys
+
+
+def _merge_missing_fields(
+    kept: PaperSearchResult, duplicate: PaperSearchResult
+) -> None:
+    """Fill fields the kept entry lacks from a duplicate found by another source."""
+    for field in (
+        "abstract",
+        "doi",
+        "arxiv_id",
+        "url",
+        "pdf_url",
+        "published_date",
+        "venue",
+        "citations",
+    ):
+        if getattr(kept, field) is None and getattr(duplicate, field) is not None:
+            setattr(kept, field, getattr(duplicate, field))
+    kept.external_ids = {**duplicate.external_ids, **kept.external_ids}
+
+
+class SearchPapersSubgraph:
+    """Search multiple paper sources in parallel and merge the results.
+
+    Sources that raise are reported in `search_errors` without failing the
+    whole search. Duplicates across sources are merged (DOI, then arXiv ID,
+    then normalized title).
+    """
+
+    def __init__(
+        self,
+        openalex_client: OpenAlexClient,
+        semantic_scholar_client: SemanticScholarClient,
+        arxiv_client: ArxivClient,
+        airas_db_search_index: AirasDbPaperSearchIndex,
+    ):
+        self.openalex_client = openalex_client
+        self.semantic_scholar_client = semantic_scholar_client
+        self.arxiv_client = arxiv_client
+        self.airas_db_search_index = airas_db_search_index
+
+    async def _run_source(
+        self,
+        source: str,
+        state: SearchPapersSubgraphState,
+        search: Callable[..., Coroutine[Any, Any, list[PaperSearchResult]]],
+    ) -> dict[str, dict[str, SourceSearchOutput]]:
+        if source not in state["sources"]:
+            return {}
+        try:
+            papers = await search(
+                query=state["query"],
+                max_results=state["max_results_per_source"],
+                year=state.get("year"),
+            )
+            output = SourceSearchOutput(papers=papers, error=None)
+        except Exception as e:
+            logger.warning(f"Paper search failed for source '{source}': {e}")
+            output = SourceSearchOutput(papers=[], error=str(e))
+        return {"source_outputs": {source: output}}
+
+    @record_execution_time
+    async def _search_openalex(self, state: SearchPapersSubgraphState) -> dict:
+        return await self._run_source(
+            "openalex",
+            state,
+            lambda **kwargs: search_openalex(self.openalex_client, **kwargs),
+        )
+
+    @record_execution_time
+    async def _search_semantic_scholar(self, state: SearchPapersSubgraphState) -> dict:
+        return await self._run_source(
+            "semantic_scholar",
+            state,
+            lambda **kwargs: search_semantic_scholar(
+                self.semantic_scholar_client, **kwargs
+            ),
+        )
+
+    @record_execution_time
+    async def _search_arxiv(self, state: SearchPapersSubgraphState) -> dict:
+        return await self._run_source(
+            "arxiv",
+            state,
+            lambda **kwargs: search_arxiv(self.arxiv_client, **kwargs),
+        )
+
+    @record_execution_time
+    async def _search_airas_db(self, state: SearchPapersSubgraphState) -> dict:
+        return await self._run_source(
+            "airas_db",
+            state,
+            lambda **kwargs: search_airas_db(self.airas_db_search_index, **kwargs),
+        )
+
+    @record_execution_time
+    def _merge_results(self, state: SearchPapersSubgraphState) -> dict:
+        source_outputs = state.get("source_outputs", {})
+
+        source_results: dict[str, int] = {}
+        search_errors: dict[str, str] = {}
+        merged: list[PaperSearchResult] = []
+        seen: dict[str, PaperSearchResult] = {}
+
+        for source in PAPER_SEARCH_SOURCES:
+            output = source_outputs.get(source)
+            if output is None:
+                continue
+            if output["error"] is not None:
+                search_errors[source] = output["error"]
+            source_results[source] = len(output["papers"])
+
+            for paper in output["papers"]:
+                keys = _dedupe_keys(paper)
+                kept = next(
+                    (seen[key] for key in keys if key in seen),
+                    None,
+                )
+                if kept is None:
+                    merged.append(paper)
+                    kept = paper
+                else:
+                    _merge_missing_fields(kept, paper)
+                for key in _dedupe_keys(kept):
+                    seen[key] = kept
+
+        return {
+            "papers": merged,
+            "source_results": source_results,
+            "search_errors": search_errors,
+        }
+
+    def build_graph(self):
+        graph_builder = StateGraph(
+            SearchPapersSubgraphState,
+            input_schema=SearchPapersSubgraphInputState,
+            output_schema=SearchPapersSubgraphOutputState,
+        )
+        graph_builder.add_node("search_openalex", self._search_openalex)
+        graph_builder.add_node("search_semantic_scholar", self._search_semantic_scholar)
+        graph_builder.add_node("search_arxiv", self._search_arxiv)
+        graph_builder.add_node("search_airas_db", self._search_airas_db)
+        graph_builder.add_node("merge_results", self._merge_results)
+
+        for node in (
+            "search_openalex",
+            "search_semantic_scholar",
+            "search_arxiv",
+            "search_airas_db",
+        ):
+            graph_builder.add_edge(START, node)
+        graph_builder.add_edge(
+            [
+                "search_openalex",
+                "search_semantic_scholar",
+                "search_arxiv",
+                "search_airas_db",
+            ],
+            "merge_results",
+        )
+        graph_builder.add_edge("merge_results", END)
+        return graph_builder.compile()

--- a/backend/src/airas/usecases/retrieve/search_papers_subgraph/search_papers_subgraph.py
+++ b/backend/src/airas/usecases/retrieve/search_papers_subgraph/search_papers_subgraph.py
@@ -45,6 +45,9 @@ class SearchPapersSubgraphInputState(TypedDict):
     sources: list[str]
     max_results_per_source: int
     year: str | None
+    # "keyword" (default) or "semantic". Semantic search is only supported by
+    # OpenAlex (native AI-embedding search, requires OPENALEX_API_KEY).
+    search_mode: str
 
 
 class SearchPapersSubgraphOutputState(ExecutionTimeState):
@@ -132,10 +135,13 @@ class SearchPapersSubgraph:
 
     @record_execution_time
     async def _search_openalex(self, state: SearchPapersSubgraphState) -> dict:
+        semantic = state.get("search_mode") == "semantic"
         return await self._run_source(
             "openalex",
             state,
-            lambda **kwargs: search_openalex(self.openalex_client, **kwargs),
+            lambda **kwargs: search_openalex(
+                self.openalex_client, semantic=semantic, **kwargs
+            ),
         )
 
     @record_execution_time

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -60,7 +60,8 @@ Or add it to your project's `.mcp.json`:
 | Tool | Description |
 | --- | --- |
 | `generate_research_queries` | Generate paper search queries from a research topic |
-| `search_paper_titles` | BM25 search over the AIRAS papers database (major ML conferences); no API key required |
+| `search_papers` | Multi-source paper search (OpenAlex / Semantic Scholar / arXiv / AIRAS DB) with normalized, de-duplicated results; no API keys required |
+| `fetch_paper_fulltext` | Fetch a paper's full text by arXiv ID, DOI, or PDF URL (legal open-access resolution only); no API keys required |
 | `retrieve_papers` | Fetch papers via arXiv and extract structured research study data |
 | `generate_hypothesis` | Generate a novel research hypothesis from a topic and related studies |
 | `generate_experimental_design` | Design experiments to test a hypothesis |
@@ -103,7 +104,7 @@ Or add it to your project's `.mcp.json`:
 | `upload_research_history` | Save research state to the experiment repository |
 | `download_research_history` | Restore research state to continue in a later session |
 
-A typical flow: `generate_research_queries` → `search_paper_titles` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `set_github_actions_secrets` → `dispatch_code_generation` → (poll `get_workflow_runs`) → `fetch_experiment_code` → `dispatch_experiment` → (poll) → `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`.
+A typical flow: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `set_github_actions_secrets` → `dispatch_code_generation` → (poll `get_workflow_runs`) → `fetch_experiment_code` → `dispatch_experiment` → (poll) → `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`.
 
 Long-running steps (code generation, experiments) execute on GitHub Actions and return immediately; track them with `get_workflow_runs` instead of waiting.
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -60,7 +60,8 @@ claude mcp add airas -- uvx airas
 | ツール | 説明 |
 | --- | --- |
 | `generate_research_queries` | 研究トピックから論文検索クエリを生成 |
-| `search_paper_titles` | AIRAS論文データベース（主要ML国際会議）のBM25検索。APIキー不要 |
+| `search_papers` | 複数ソース（OpenAlex / Semantic Scholar / arXiv / AIRAS DB）の並列論文検索。結果は正規化・重複排除済み。APIキー不要 |
+| `fetch_paper_fulltext` | arXiv ID / DOI / PDF URL から論文全文を取得（合法なオープンアクセス解決のみ）。APIキー不要 |
 | `retrieve_papers` | arXiv経由で論文を取得し、構造化された研究データを抽出 |
 | `generate_hypothesis` | トピックと関連研究から新規の研究仮説を生成 |
 | `generate_experimental_design` | 仮説を検証する実験を設計 |
@@ -103,7 +104,7 @@ claude mcp add airas -- uvx airas
 | `upload_research_history` | 研究状態を実験リポジトリに保存 |
 | `download_research_history` | 保存した研究状態を復元し、別セッションで継続 |
 
-典型的なフロー: `generate_research_queries` → `search_paper_titles` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `set_github_actions_secrets` → `dispatch_code_generation` →（`get_workflow_runs` でポーリング）→ `fetch_experiment_code` → `dispatch_experiment` →（ポーリング）→ `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`
+典型的なフロー: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `set_github_actions_secrets` → `dispatch_code_generation` →（`get_workflow_runs` でポーリング）→ `fetch_experiment_code` → `dispatch_experiment` →（ポーリング）→ `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`
 
 時間のかかるステップ（コード生成・実験）はGitHub Actions上で実行され、ツール自体は即座に返ります。完了待ちはせず `get_workflow_runs` で追跡してください。
 

--- a/frontend/src/components/app-layout.tsx
+++ b/frontend/src/components/app-layout.tsx
@@ -53,6 +53,7 @@ function getActiveSection(pathname: string): string {
   if (pathname.startsWith("/verification")) return "verification";
   if (pathname.startsWith("/notifications")) return "notifications";
   if (pathname.startsWith("/reproduction")) return "reproduction";
+  if (pathname.startsWith("/paper-search")) return "paper-search";
   if (pathname.startsWith("/papers")) return "papers";
   return "home";
 }

--- a/frontend/src/components/main-content.tsx
+++ b/frontend/src/components/main-content.tsx
@@ -5,6 +5,7 @@ import { Navigate, Route, Routes, useNavigate, useParams } from "react-router-do
 import { AutonomousResearchPage } from "@/components/pages/autonomous-research";
 import { HypothesisDrivenResearchPage } from "@/components/pages/hypothesis-driven-research";
 import { NotificationsPage } from "@/components/pages/notifications";
+import { PaperSearchPage } from "@/components/pages/paper-search";
 import { PapersPage } from "@/components/pages/papers";
 import { ReproductionPage } from "@/components/pages/reproduction";
 import { SETTINGS_TABS, SettingsPage, type SettingsTab } from "@/components/pages/settings";
@@ -170,6 +171,7 @@ export function MainContent({ assistedResearchProps }: MainContentProps) {
           }
         />
         <Route path="/verification/:id" element={<VerificationDetailRoute />} />
+        <Route path="/paper-search" element={<PaperSearchPage />} />
         <Route
           path="/papers"
           element={

--- a/frontend/src/components/pages/paper-search.tsx
+++ b/frontend/src/components/pages/paper-search.tsx
@@ -1,8 +1,10 @@
 import { FeatherAlertTriangle, FeatherExternalLink } from "@subframe/core";
 import { Loader2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { PaperSearchResult } from "@/lib/api/models/PaperSearchResult";
+import { SearchPapersRequestBody } from "@/lib/api/models/SearchPapersRequestBody";
+import { CredentialsService } from "@/lib/api/services/CredentialsService";
 import { PapersService } from "@/lib/api/services/PapersService";
 import { Alert } from "@/ui/components/Alert";
 import { Badge } from "@/ui/components/Badge";
@@ -11,6 +13,15 @@ import { Checkbox } from "@/ui/components/Checkbox";
 import { TextField } from "@/ui/components/TextField";
 
 const ALL_SOURCES = ["openalex", "semantic_scholar", "arxiv", "airas_db"] as const;
+// Sources that support semantic (AI-embedding) search, and the credential each needs.
+const SEMANTIC_SOURCES = ["openalex"] as const;
+const SEMANTIC_KEY = "OPENALEX_API_KEY";
+
+type SearchMode = SearchPapersRequestBody.search_mode;
+const SEARCH_MODES = [
+  SearchPapersRequestBody.search_mode.KEYWORD,
+  SearchPapersRequestBody.search_mode.SEMANTIC,
+] as const;
 
 type FulltextState =
   | { status: "loading" }
@@ -21,6 +32,9 @@ export function PaperSearchPage() {
   const { t } = useTranslation();
   const [query, setQuery] = useState("");
   const [sources, setSources] = useState<string[]>([...ALL_SOURCES]);
+  const [searchMode, setSearchMode] = useState<SearchMode>(
+    SearchPapersRequestBody.search_mode.KEYWORD,
+  );
   const [year, setYear] = useState("");
   const [maxResults, setMaxResults] = useState("5");
   const [searching, setSearching] = useState(false);
@@ -29,13 +43,39 @@ export function PaperSearchPage() {
   const [sourceResults, setSourceResults] = useState<Record<string, number>>({});
   const [searchErrors, setSearchErrors] = useState<Record<string, string>>({});
   const [fulltexts, setFulltexts] = useState<Record<string, FulltextState>>({});
+  // null = still loading credential status.
+  const [semanticKeySet, setSemanticKeySet] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    CredentialsService.listCredentialsAirasV1CredentialsGet()
+      .then((res) => {
+        const cred = res.credentials.find((c) => c.name === SEMANTIC_KEY);
+        setSemanticKeySet(Boolean(cred?.is_set));
+      })
+      .catch(() => setSemanticKeySet(false));
+  }, []);
+
+  // In semantic mode the key must be configured; surface the error immediately.
+  const isSemantic = searchMode === SearchPapersRequestBody.search_mode.SEMANTIC;
+  const semanticKeyMissing = isSemantic && semanticKeySet === false;
+
+  const switchMode = (mode: SearchMode) => {
+    setSearchMode(mode);
+    setError(null);
+    // Semantic search is OpenAlex-only; restrict the source selection.
+    setSources(
+      mode === SearchPapersRequestBody.search_mode.SEMANTIC
+        ? [...SEMANTIC_SOURCES]
+        : [...ALL_SOURCES],
+    );
+  };
 
   const toggleSource = (source: string, checked: boolean) => {
     setSources((prev) => (checked ? [...prev, source] : prev.filter((s) => s !== source)));
   };
 
   const handleSearch = async () => {
-    if (!query.trim() || sources.length === 0) return;
+    if (!query.trim() || sources.length === 0 || semanticKeyMissing) return;
     setSearching(true);
     setError(null);
     setFulltexts({});
@@ -45,6 +85,7 @@ export function PaperSearchPage() {
         sources,
         max_results_per_source: Number(maxResults) || 5,
         year: year.trim() || null,
+        search_mode: searchMode,
       });
       setPapers(res.papers);
       setSourceResults(res.source_results);
@@ -88,6 +129,28 @@ export function PaperSearchPage() {
 
         {/* Search form */}
         <div className="mt-6 rounded-lg border border-border bg-card p-6 flex flex-col gap-4">
+          {/* Mode toggle */}
+          <div className="flex items-center gap-2">
+            <span className="text-caption-bold font-caption-bold text-default-font">
+              {t("paperSearch.mode")}
+            </span>
+            {SEARCH_MODES.map((mode) => (
+              <Button
+                key={mode}
+                variant={searchMode === mode ? "brand-primary" : "neutral-tertiary"}
+                size="small"
+                onClick={() => switchMode(mode)}
+              >
+                {t(`paperSearch.modes.${mode}`)}
+              </Button>
+            ))}
+            {isSemantic && (
+              <span className="text-caption font-caption text-subtext-color">
+                {t("paperSearch.semanticHint")}
+              </span>
+            )}
+          </div>
+
           <div className="flex items-center gap-3">
             <TextField className="flex-1" error={false}>
               <TextField.Input
@@ -101,7 +164,7 @@ export function PaperSearchPage() {
             </TextField>
             <Button
               onClick={handleSearch}
-              disabled={searching || !query.trim() || sources.length === 0}
+              disabled={searching || !query.trim() || sources.length === 0 || semanticKeyMissing}
             >
               {searching ? t("paperSearch.searching") : t("paperSearch.search")}
             </Button>
@@ -110,14 +173,20 @@ export function PaperSearchPage() {
             <span className="text-caption-bold font-caption-bold text-default-font">
               {t("paperSearch.sources")}
             </span>
-            {ALL_SOURCES.map((source) => (
-              <Checkbox
-                key={source}
-                label={t(`paperSearch.sourceNames.${source}`)}
-                checked={sources.includes(source)}
-                onCheckedChange={(checked) => toggleSource(source, checked)}
-              />
-            ))}
+            {ALL_SOURCES.map((source) => {
+              const disabled =
+                isSemantic &&
+                !SEMANTIC_SOURCES.includes(source as (typeof SEMANTIC_SOURCES)[number]);
+              return (
+                <Checkbox
+                  key={source}
+                  label={t(`paperSearch.sourceNames.${source}`)}
+                  checked={sources.includes(source)}
+                  disabled={disabled}
+                  onCheckedChange={(checked) => toggleSource(source, checked)}
+                />
+              );
+            })}
             <div className="flex items-center gap-2 ml-auto">
               <span className="text-caption font-caption text-subtext-color">
                 {t("paperSearch.year")}
@@ -142,6 +211,17 @@ export function PaperSearchPage() {
             </div>
           </div>
         </div>
+
+        {semanticKeyMissing && (
+          <div className="mt-4">
+            <Alert
+              variant="error"
+              icon={<FeatherAlertTriangle />}
+              title={t("paperSearch.semanticKeyMissingTitle")}
+              description={t("paperSearch.semanticKeyMissingDescription")}
+            />
+          </div>
+        )}
 
         {error && (
           <div className="mt-4">

--- a/frontend/src/components/pages/paper-search.tsx
+++ b/frontend/src/components/pages/paper-search.tsx
@@ -1,0 +1,264 @@
+import { FeatherAlertTriangle, FeatherExternalLink } from "@subframe/core";
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { PaperSearchResult } from "@/lib/api/models/PaperSearchResult";
+import { PapersService } from "@/lib/api/services/PapersService";
+import { Alert } from "@/ui/components/Alert";
+import { Badge } from "@/ui/components/Badge";
+import { Button } from "@/ui/components/Button";
+import { Checkbox } from "@/ui/components/Checkbox";
+import { TextField } from "@/ui/components/TextField";
+
+const ALL_SOURCES = ["openalex", "semantic_scholar", "arxiv", "airas_db"] as const;
+
+type FulltextState =
+  | { status: "loading" }
+  | { status: "error" }
+  | { status: "done"; text: string; fulltextStatus: string };
+
+export function PaperSearchPage() {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+  const [sources, setSources] = useState<string[]>([...ALL_SOURCES]);
+  const [year, setYear] = useState("");
+  const [maxResults, setMaxResults] = useState("5");
+  const [searching, setSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [papers, setPapers] = useState<PaperSearchResult[] | null>(null);
+  const [sourceResults, setSourceResults] = useState<Record<string, number>>({});
+  const [searchErrors, setSearchErrors] = useState<Record<string, string>>({});
+  const [fulltexts, setFulltexts] = useState<Record<string, FulltextState>>({});
+
+  const toggleSource = (source: string, checked: boolean) => {
+    setSources((prev) => (checked ? [...prev, source] : prev.filter((s) => s !== source)));
+  };
+
+  const handleSearch = async () => {
+    if (!query.trim() || sources.length === 0) return;
+    setSearching(true);
+    setError(null);
+    setFulltexts({});
+    try {
+      const res = await PapersService.searchPapersAirasV1PapersSourceSearchPost({
+        query: query.trim(),
+        sources,
+        max_results_per_source: Number(maxResults) || 5,
+        year: year.trim() || null,
+      });
+      setPapers(res.papers);
+      setSourceResults(res.source_results);
+      setSearchErrors(res.search_errors);
+    } catch {
+      setError(t("paperSearch.searchError"));
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const paperKey = (paper: PaperSearchResult, index: number) =>
+    paper.doi ?? paper.arxiv_id ?? paper.url ?? `${paper.source}-${index}`;
+
+  const handleFetchFulltext = async (key: string, paper: PaperSearchResult) => {
+    setFulltexts((prev) => ({ ...prev, [key]: { status: "loading" } }));
+    try {
+      const res = await PapersService.fetchPaperFulltextAirasV1PapersFulltextPost({
+        arxiv_id: paper.arxiv_id ?? null,
+        doi: paper.doi ?? null,
+        pdf_url: paper.pdf_url ?? null,
+      });
+      setFulltexts((prev) => ({
+        ...prev,
+        [key]: { status: "done", text: res.text, fulltextStatus: res.status },
+      }));
+    } catch {
+      setFulltexts((prev) => ({ ...prev, [key]: { status: "error" } }));
+    }
+  };
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-4xl mx-auto px-8 py-8">
+        <h1 className="text-heading-2 font-heading-2 text-default-font">
+          {t("paperSearch.pageTitle")}
+        </h1>
+        <p className="text-caption font-caption text-subtext-color mt-1">
+          {t("paperSearch.pageSubtitle")}
+        </p>
+
+        {/* Search form */}
+        <div className="mt-6 rounded-lg border border-border bg-card p-6 flex flex-col gap-4">
+          <div className="flex items-center gap-3">
+            <TextField className="flex-1" error={false}>
+              <TextField.Input
+                placeholder={t("paperSearch.queryPlaceholder")}
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleSearch();
+                }}
+              />
+            </TextField>
+            <Button
+              onClick={handleSearch}
+              disabled={searching || !query.trim() || sources.length === 0}
+            >
+              {searching ? t("paperSearch.searching") : t("paperSearch.search")}
+            </Button>
+          </div>
+          <div className="flex flex-wrap items-center gap-5">
+            <span className="text-caption-bold font-caption-bold text-default-font">
+              {t("paperSearch.sources")}
+            </span>
+            {ALL_SOURCES.map((source) => (
+              <Checkbox
+                key={source}
+                label={t(`paperSearch.sourceNames.${source}`)}
+                checked={sources.includes(source)}
+                onCheckedChange={(checked) => toggleSource(source, checked)}
+              />
+            ))}
+            <div className="flex items-center gap-2 ml-auto">
+              <span className="text-caption font-caption text-subtext-color">
+                {t("paperSearch.year")}
+              </span>
+              <TextField className="w-28" error={false}>
+                <TextField.Input
+                  placeholder="2020-2025"
+                  value={year}
+                  onChange={(e) => setYear(e.target.value)}
+                />
+              </TextField>
+              <span className="text-caption font-caption text-subtext-color">
+                {t("paperSearch.maxResults")}
+              </span>
+              <TextField className="w-16" error={false}>
+                <TextField.Input
+                  type="number"
+                  value={maxResults}
+                  onChange={(e) => setMaxResults(e.target.value)}
+                />
+              </TextField>
+            </div>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mt-4">
+            <Alert variant="error" icon={<FeatherAlertTriangle />} title={error} />
+          </div>
+        )}
+
+        {/* Per-source stats */}
+        {papers !== null && (
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <span className="text-caption font-caption text-subtext-color">
+              {t("paperSearch.resultCount", { count: papers.length })}
+            </span>
+            {Object.entries(sourceResults).map(([source, count]) => (
+              <Badge key={source} variant="neutral">
+                {t(`paperSearch.sourceNames.${source}`)}: {count}
+              </Badge>
+            ))}
+            {Object.entries(searchErrors).map(([source, message]) => (
+              <Badge key={source} variant="error" title={message}>
+                {t(`paperSearch.sourceNames.${source}`)}: {t("paperSearch.sourceFailed")}
+              </Badge>
+            ))}
+          </div>
+        )}
+
+        {/* Results */}
+        <div className="mt-4 flex flex-col gap-4">
+          {(papers ?? []).map((paper, index) => {
+            const key = paperKey(paper, index);
+            const fulltext = fulltexts[key];
+            const canFetch = paper.arxiv_id || paper.doi || paper.pdf_url;
+            return (
+              <div key={key} className="rounded-lg border border-border bg-card p-5">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    {paper.url ? (
+                      <a
+                        href={paper.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-body-bold font-body-bold text-brand-700 hover:underline inline-flex items-center gap-1"
+                      >
+                        {paper.title}
+                        <FeatherExternalLink className="h-3.5 w-3.5 shrink-0" />
+                      </a>
+                    ) : (
+                      <span className="text-body-bold font-body-bold text-default-font">
+                        {paper.title}
+                      </span>
+                    )}
+                    <p className="text-caption font-caption text-subtext-color mt-1">
+                      {(paper.authors ?? []).slice(0, 5).join(", ")}
+                      {(paper.authors ?? []).length > 5 ? " et al." : ""}
+                      {paper.venue ? ` · ${paper.venue}` : ""}
+                      {paper.published_date ? ` · ${paper.published_date}` : ""}
+                      {paper.citations != null
+                        ? ` · ${t("paperSearch.citations", { count: paper.citations })}`
+                        : ""}
+                    </p>
+                  </div>
+                  <Badge variant="brand">{t(`paperSearch.sourceNames.${paper.source}`)}</Badge>
+                </div>
+
+                {paper.abstract && (
+                  <p className="text-caption font-caption text-default-font mt-3 line-clamp-3">
+                    {paper.abstract}
+                  </p>
+                )}
+
+                <div className="mt-3 flex items-center gap-3">
+                  {canFetch && !fulltext && (
+                    <Button
+                      variant="neutral-secondary"
+                      size="small"
+                      onClick={() => handleFetchFulltext(key, paper)}
+                    >
+                      {t("paperSearch.fetchFulltext")}
+                    </Button>
+                  )}
+                  {fulltext?.status === "loading" && (
+                    <span className="inline-flex items-center gap-2 text-caption font-caption text-subtext-color">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      {t("paperSearch.fetchingFulltext")}
+                    </span>
+                  )}
+                  {fulltext?.status === "error" && (
+                    <span className="text-caption font-caption text-error-600">
+                      {t("paperSearch.fulltextError")}
+                    </span>
+                  )}
+                </div>
+
+                {fulltext?.status === "done" && (
+                  <div className="mt-3">
+                    <Badge variant={fulltext.fulltextStatus === "fulltext" ? "success" : "warning"}>
+                      {t(`paperSearch.fulltextStatus.${fulltext.fulltextStatus}`)}
+                    </Badge>
+                    {fulltext.text && (
+                      <div className="mt-2 max-h-64 overflow-y-auto rounded-md border border-border bg-default-background p-3">
+                        <p className="text-caption font-caption text-default-font whitespace-pre-wrap">
+                          {fulltext.text}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+          {papers !== null && papers.length === 0 && (
+            <p className="text-body font-body text-subtext-color text-center py-8">
+              {t("paperSearch.noResults")}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/sidebar/main-sidebar.tsx
+++ b/frontend/src/components/sidebar/main-sidebar.tsx
@@ -3,6 +3,7 @@ import {
   FeatherBookOpen,
   FeatherBrainCircuit,
   FeatherExternalLink,
+  FeatherFileText,
   FeatherKey,
   FeatherMessageSquare,
   FeatherRefreshCw,
@@ -36,6 +37,16 @@ export function MainSidebar({
       <SidebarWithSections.NavSection
         label={<span className="text-sm font-medium">{t("nav.research")}</span>}
       >
+        <SidebarWithSections.NavItem
+          icon={<FeatherFileText />}
+          selected={activeSection === "paper-search"}
+          onClick={() => {
+            navigate("/paper-search");
+            onMobileNavClose();
+          }}
+        >
+          {t("nav.paperSearch")}
+        </SidebarWithSections.NavItem>
         <SidebarWithSections.NavItem
           icon={<FeatherTarget />}
           selected={activeSection === "home" || activeSection === "verification"}

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -62,6 +62,8 @@ export type { FetchExperimentalResultsRequestBody } from './models/FetchExperime
 export type { FetchExperimentalResultsResponseBody } from './models/FetchExperimentalResultsResponseBody';
 export type { FetchExperimentCodeRequestBody } from './models/FetchExperimentCodeRequestBody';
 export type { FetchExperimentCodeResponseBody } from './models/FetchExperimentCodeResponseBody';
+export type { FetchPaperFulltextRequestBody } from './models/FetchPaperFulltextRequestBody';
+export { FetchPaperFulltextResponseBody } from './models/FetchPaperFulltextResponseBody';
 export type { FetchRunIdsRequestBody } from './models/FetchRunIdsRequestBody';
 export type { FetchRunIdsResponseBody } from './models/FetchRunIdsResponseBody';
 export type { GenerateBibfileSubgraphRequestBody } from './models/GenerateBibfileSubgraphRequestBody';
@@ -110,6 +112,7 @@ export type { OpenAIParams } from './models/OpenAIParams';
 export type { OptunaConfig } from './models/OptunaConfig';
 export type { PaperContent } from './models/PaperContent';
 export type { PaperReviewScores } from './models/PaperReviewScores';
+export type { PaperSearchResult } from './models/PaperSearchResult';
 export type { PollGithubActionsRequestBody } from './models/PollGithubActionsRequestBody';
 export type { PollGithubActionsResponseBody } from './models/PollGithubActionsResponseBody';
 export type { PrepareRepositorySubgraphRequestBody } from './models/PrepareRepositorySubgraphRequestBody';
@@ -137,6 +140,8 @@ export type { RetrievePaperSubgraphLLMMapping } from './models/RetrievePaperSubg
 export type { RetrievePaperSubgraphRequestBody } from './models/RetrievePaperSubgraphRequestBody';
 export type { RetrievePaperSubgraphResponseBody } from './models/RetrievePaperSubgraphResponseBody';
 export { RunStage } from './models/RunStage';
+export type { SearchPapersRequestBody } from './models/SearchPapersRequestBody';
+export type { SearchPapersResponseBody } from './models/SearchPapersResponseBody';
 export type { SearchPaperTitlesFromQdrantLLMMapping } from './models/SearchPaperTitlesFromQdrantLLMMapping';
 export { SearchPaperTitlesRequestBody } from './models/SearchPaperTitlesRequestBody';
 export type { SearchPaperTitlesResponseBody } from './models/SearchPaperTitlesResponseBody';

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -140,7 +140,7 @@ export type { RetrievePaperSubgraphLLMMapping } from './models/RetrievePaperSubg
 export type { RetrievePaperSubgraphRequestBody } from './models/RetrievePaperSubgraphRequestBody';
 export type { RetrievePaperSubgraphResponseBody } from './models/RetrievePaperSubgraphResponseBody';
 export { RunStage } from './models/RunStage';
-export type { SearchPapersRequestBody } from './models/SearchPapersRequestBody';
+export { SearchPapersRequestBody } from './models/SearchPapersRequestBody';
 export type { SearchPapersResponseBody } from './models/SearchPapersResponseBody';
 export type { SearchPaperTitlesFromQdrantLLMMapping } from './models/SearchPaperTitlesFromQdrantLLMMapping';
 export { SearchPaperTitlesRequestBody } from './models/SearchPaperTitlesRequestBody';

--- a/frontend/src/lib/api/models/FetchPaperFulltextRequestBody.ts
+++ b/frontend/src/lib/api/models/FetchPaperFulltextRequestBody.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type FetchPaperFulltextRequestBody = {
+    arxiv_id?: (string | null);
+    doi?: (string | null);
+    pdf_url?: (string | null);
+};
+

--- a/frontend/src/lib/api/models/FetchPaperFulltextResponseBody.ts
+++ b/frontend/src/lib/api/models/FetchPaperFulltextResponseBody.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type FetchPaperFulltextResponseBody = {
+    text: string;
+    status: FetchPaperFulltextResponseBody.status;
+    resolved_from: (string | null);
+    execution_time: Record<string, Array<number>>;
+};
+export namespace FetchPaperFulltextResponseBody {
+    export enum status {
+        FULLTEXT = 'fulltext',
+        ABSTRACT_ONLY = 'abstract_only',
+        NOT_FOUND = 'not_found',
+    }
+}
+

--- a/frontend/src/lib/api/models/PaperSearchResult.ts
+++ b/frontend/src/lib/api/models/PaperSearchResult.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * A paper found by any search source, normalized to a common shape.
+ */
+export type PaperSearchResult = {
+    title: string;
+    authors?: Array<string>;
+    abstract?: (string | null);
+    doi?: (string | null);
+    arxiv_id?: (string | null);
+    url?: (string | null);
+    pdf_url?: (string | null);
+    published_date?: (string | null);
+    venue?: (string | null);
+    citations?: (number | null);
+    source: string;
+    external_ids?: Record<string, string>;
+};
+

--- a/frontend/src/lib/api/models/SearchPapersRequestBody.ts
+++ b/frontend/src/lib/api/models/SearchPapersRequestBody.ts
@@ -7,5 +7,12 @@ export type SearchPapersRequestBody = {
     sources?: Array<string>;
     max_results_per_source?: number;
     year?: (string | null);
+    search_mode?: SearchPapersRequestBody.search_mode;
 };
+export namespace SearchPapersRequestBody {
+    export enum search_mode {
+        KEYWORD = 'keyword',
+        SEMANTIC = 'semantic',
+    }
+}
 

--- a/frontend/src/lib/api/models/SearchPapersRequestBody.ts
+++ b/frontend/src/lib/api/models/SearchPapersRequestBody.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type SearchPapersRequestBody = {
+    query: string;
+    sources?: Array<string>;
+    max_results_per_source?: number;
+    year?: (string | null);
+};
+

--- a/frontend/src/lib/api/models/SearchPapersResponseBody.ts
+++ b/frontend/src/lib/api/models/SearchPapersResponseBody.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { PaperSearchResult } from './PaperSearchResult';
+export type SearchPapersResponseBody = {
+    papers: Array<PaperSearchResult>;
+    source_results: Record<string, number>;
+    search_errors: Record<string, string>;
+    execution_time: Record<string, Array<number>>;
+};
+

--- a/frontend/src/lib/api/services/PapersService.ts
+++ b/frontend/src/lib/api/services/PapersService.ts
@@ -2,8 +2,12 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { FetchPaperFulltextRequestBody } from '../models/FetchPaperFulltextRequestBody';
+import type { FetchPaperFulltextResponseBody } from '../models/FetchPaperFulltextResponseBody';
 import type { RetrievePaperSubgraphRequestBody } from '../models/RetrievePaperSubgraphRequestBody';
 import type { RetrievePaperSubgraphResponseBody } from '../models/RetrievePaperSubgraphResponseBody';
+import type { SearchPapersRequestBody } from '../models/SearchPapersRequestBody';
+import type { SearchPapersResponseBody } from '../models/SearchPapersResponseBody';
 import type { SearchPaperTitlesRequestBody } from '../models/SearchPaperTitlesRequestBody';
 import type { SearchPaperTitlesResponseBody } from '../models/SearchPaperTitlesResponseBody';
 import type { WriteSubgraphRequestBody } from '../models/WriteSubgraphRequestBody';
@@ -24,6 +28,44 @@ export class PapersService {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/airas/v1/papers/search',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Search Papers
+     * @param requestBody
+     * @returns SearchPapersResponseBody Successful Response
+     * @throws ApiError
+     */
+    public static searchPapersAirasV1PapersSourceSearchPost(
+        requestBody: SearchPapersRequestBody,
+    ): CancelablePromise<SearchPapersResponseBody> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/airas/v1/papers/source-search',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Fetch Paper Fulltext
+     * @param requestBody
+     * @returns FetchPaperFulltextResponseBody Successful Response
+     * @throws ApiError
+     */
+    public static fetchPaperFulltextAirasV1PapersFulltextPost(
+        requestBody: FetchPaperFulltextRequestBody,
+    ): CancelablePromise<FetchPaperFulltextResponseBody> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/airas/v1/papers/fulltext',
             body: requestBody,
             mediaType: 'application/json',
             errors: {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -873,6 +873,14 @@
       "not_found": "Not found"
     },
     "searchError": "Search failed",
-    "noResults": "No papers found"
+    "noResults": "No papers found",
+    "mode": "Mode",
+    "modes": {
+      "keyword": "Keyword",
+      "semantic": "Semantic"
+    },
+    "semanticHint": "OpenAlex only — AI embedding search (requires OPENALEX_API_KEY)",
+    "semanticKeyMissingTitle": "OPENALEX_API_KEY is not set",
+    "semanticKeyMissingDescription": "Semantic search requires an OpenAlex API key. Set OPENALEX_API_KEY on the API Keys page, then try again."
   }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -25,7 +25,8 @@
     "experimental": "Experimental",
     "reproduction": "Reproduction",
     "research": "Research",
-    "apiKeys": "API Keys"
+    "apiKeys": "API Keys",
+    "paperSearch": "Paper"
   },
   "userMenu": {
     "developer": "Developer",
@@ -844,5 +845,34 @@
     "fetchError": "Failed to load credentials",
     "saveError": "Failed to save credentials",
     "storageNote": "Changes take effect immediately; no restart is required."
+  },
+  "paperSearch": {
+    "pageTitle": "Paper Search",
+    "pageSubtitle": "Search papers across OpenAlex, Semantic Scholar, arXiv, and the AIRAS conference database, and fetch open-access full texts.",
+    "queryPlaceholder": "e.g. diffusion model distillation",
+    "search": "Search",
+    "searching": "Searching...",
+    "sources": "Sources",
+    "sourceNames": {
+      "openalex": "OpenAlex",
+      "semantic_scholar": "Semantic Scholar",
+      "arxiv": "arXiv",
+      "airas_db": "AIRAS DB"
+    },
+    "year": "Year",
+    "maxResults": "Per source",
+    "resultCount": "{{count}} papers",
+    "sourceFailed": "failed",
+    "citations": "{{count}} citations",
+    "fetchFulltext": "Fetch full text",
+    "fetchingFulltext": "Fetching full text...",
+    "fulltextError": "Failed to fetch full text",
+    "fulltextStatus": {
+      "fulltext": "Full text",
+      "abstract_only": "Abstract only",
+      "not_found": "Not found"
+    },
+    "searchError": "Search failed",
+    "noResults": "No papers found"
   }
 }

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -25,7 +25,8 @@
     "experimental": "実験的機能",
     "reproduction": "再現実装",
     "research": "研究",
-    "apiKeys": "APIキー"
+    "apiKeys": "APIキー",
+    "paperSearch": "Paper"
   },
   "userMenu": {
     "developer": "開発者",
@@ -843,5 +844,34 @@
     "fetchError": "認証情報の読み込みに失敗しました",
     "saveError": "認証情報の保存に失敗しました",
     "storageNote": "変更は即座に反映されます。再起動は不要です。"
+  },
+  "paperSearch": {
+    "pageTitle": "論文検索",
+    "pageSubtitle": "OpenAlex・Semantic Scholar・arXiv・AIRAS会議データベースを横断検索し、オープンアクセスの全文を取得できます。",
+    "queryPlaceholder": "例: diffusion model distillation",
+    "search": "検索",
+    "searching": "検索中...",
+    "sources": "検索元",
+    "sourceNames": {
+      "openalex": "OpenAlex",
+      "semantic_scholar": "Semantic Scholar",
+      "arxiv": "arXiv",
+      "airas_db": "AIRAS DB"
+    },
+    "year": "年",
+    "maxResults": "各ソース件数",
+    "resultCount": "{{count}} 件",
+    "sourceFailed": "失敗",
+    "citations": "被引用 {{count}}",
+    "fetchFulltext": "全文を取得",
+    "fetchingFulltext": "全文を取得中...",
+    "fulltextError": "全文の取得に失敗しました",
+    "fulltextStatus": {
+      "fulltext": "全文",
+      "abstract_only": "要旨のみ",
+      "not_found": "見つかりません"
+    },
+    "searchError": "検索に失敗しました",
+    "noResults": "論文が見つかりませんでした"
   }
 }

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -872,6 +872,14 @@
       "not_found": "見つかりません"
     },
     "searchError": "検索に失敗しました",
-    "noResults": "論文が見つかりませんでした"
+    "noResults": "論文が見つかりませんでした",
+    "mode": "モード",
+    "modes": {
+      "keyword": "キーワード",
+      "semantic": "意味検索"
+    },
+    "semanticHint": "OpenAlex のみ・AI埋め込み検索（OPENALEX_API_KEY が必要）",
+    "semanticKeyMissingTitle": "OPENALEX_API_KEY が設定されていません",
+    "semanticKeyMissingDescription": "意味検索には OpenAlex の API キーが必要です。APIキーページで OPENALEX_API_KEY を設定してから再度お試しください。"
   }
 }

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -4666,6 +4666,13 @@ components:
           - type: string
           - type: 'null'
           title: Year
+        search_mode:
+          type: string
+          enum:
+          - keyword
+          - semantic
+          title: Search Mode
+          default: keyword
       type: object
       required:
       - query

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -38,6 +38,56 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /airas/v1/papers/source-search:
+    post:
+      tags:
+      - papers
+      summary: Search Papers
+      operationId: search_papers_airas_v1_papers_source_search_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchPapersRequestBody'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchPapersResponseBody'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /airas/v1/papers/fulltext:
+    post:
+      tags:
+      - papers
+      summary: Fetch Paper Fulltext
+      operationId: fetch_paper_fulltext_airas_v1_papers_fulltext_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FetchPaperFulltextRequestBody'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FetchPaperFulltextResponseBody'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /airas/v1/papers/retrieval:
     post:
       tags:
@@ -2512,6 +2562,56 @@ components:
       - experimental_results
       - execution_time
       title: FetchExperimentalResultsResponseBody
+    FetchPaperFulltextRequestBody:
+      properties:
+        arxiv_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Arxiv Id
+        doi:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Doi
+        pdf_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pdf Url
+      type: object
+      title: FetchPaperFulltextRequestBody
+    FetchPaperFulltextResponseBody:
+      properties:
+        text:
+          type: string
+          title: Text
+        status:
+          type: string
+          enum:
+          - fulltext
+          - abstract_only
+          - not_found
+          title: Status
+        resolved_from:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Resolved From
+        execution_time:
+          additionalProperties:
+            items:
+              type: number
+            type: array
+          type: object
+          title: Execution Time
+      type: object
+      required:
+      - text
+      - status
+      - resolved_from
+      - execution_time
+      title: FetchPaperFulltextResponseBody
     FetchRunIdsRequestBody:
       properties:
         github_config:
@@ -3767,6 +3867,70 @@ components:
           description: Paper experimental quality score
       type: object
       title: PaperReviewScores
+    PaperSearchResult:
+      properties:
+        title:
+          type: string
+          title: Title
+        authors:
+          items:
+            type: string
+          type: array
+          title: Authors
+        abstract:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Abstract
+        doi:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Doi
+        arxiv_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Arxiv Id
+        url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Url
+        pdf_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Pdf Url
+        published_date:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Published Date
+        venue:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Venue
+        citations:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Citations
+        source:
+          type: string
+          title: Source
+        external_ids:
+          additionalProperties:
+            type: string
+          type: object
+          title: External Ids
+      type: object
+      required:
+      - title
+      - source
+      title: PaperSearchResult
+      description: A paper found by any search source, normalized to a common shape.
     PollGithubActionsRequestBody:
       properties:
         github_config:
@@ -4481,6 +4645,62 @@ components:
       - paper_titles
       - execution_time
       title: SearchPaperTitlesResponseBody
+    SearchPapersRequestBody:
+      properties:
+        query:
+          type: string
+          title: Query
+        sources:
+          items:
+            type: string
+          type: array
+          title: Sources
+        max_results_per_source:
+          type: integer
+          maximum: 50.0
+          exclusiveMinimum: 0.0
+          title: Max Results Per Source
+          default: 5
+        year:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Year
+      type: object
+      required:
+      - query
+      title: SearchPapersRequestBody
+    SearchPapersResponseBody:
+      properties:
+        papers:
+          items:
+            $ref: '#/components/schemas/PaperSearchResult'
+          type: array
+          title: Papers
+        source_results:
+          additionalProperties:
+            type: integer
+          type: object
+          title: Source Results
+        search_errors:
+          additionalProperties:
+            type: string
+          type: object
+          title: Search Errors
+        execution_time:
+          additionalProperties:
+            items:
+              type: number
+            type: array
+          type: object
+          title: Execution Time
+      type: object
+      required:
+      - papers
+      - source_results
+      - search_errors
+      - execution_time
+      title: SearchPapersResponseBody
     SearchSpace:
       properties:
         param_name:


### PR DESCRIPTION
## Summary

Implements multi-source paper retrieval by wrapping paper APIs behind LangGraph subgraphs, exposed through both the dashboard REST API and the MCP server. The MCP tool surface stays at two tools regardless of how many sources are added ("source is a parameter, not a tool name").

## Architecture

```
MCP tools ──────────────┐                ┌── OpenAlexClient        (existing)
  search_papers         │   LangGraph    ├── SemanticScholarClient (existing, + get_paper_by_doi)
  fetch_paper_fulltext  ├── subgraphs ───┼── ArxivClient           (existing)
Dashboard API ──────────┘                └── AirasDbPaperSearchIndex
  POST /papers/source-search
  POST /papers/fulltext
```

### `SearchPapersSubgraph`
- Four source nodes run in **parallel** (LangGraph fan-out, merged via an `Annotated[dict, or_]` reducer), then a merge node
- Results normalized to `PaperSearchResult` (title/authors/abstract/doi/arxiv_id/pdf_url/citations/`source`/`external_ids`)
- **Per-source error isolation**: a failing source lands in `search_errors`, the rest of the search succeeds
- **Cross-source dedupe** by DOI → arXiv ID → normalized title; duplicates *merge* missing fields (e.g. arXiv hit gains OpenAlex citation counts)

### `FetchPaperFulltextSubgraph`
- Resolution chain: arXiv ID → explicit PDF URL → DOI (arXiv-minted `10.48550/arxiv.*` DOIs short-circuit straight to arXiv; others resolve via Semantic Scholar `openAccessPdf`)
- Returns `status`: `fulltext` / `abstract_only` / `not_found` — **legal open-access resolution only**

### MCP changes
- **Removed `search_paper_titles`** (fully subsumed by `search_papers` with `sources="airas_db"`); the underlying title-search subgraph is kept for the existing dashboard endpoint and autonomous-research pipelines
- Added `search_papers(query, sources="all", max_results_per_source, year)` and `fetch_paper_fulltext(arxiv_id|doi|pdf_url)` — both work without any API keys
- `SEMANTIC_SCHOLAR_API_KEY` / `OPENALEX_API_KEY` added to the credentials allowlist (optional, higher rate limits), so they are manageable from the dashboard API-keys page
- Tool count: 30 → 31

## Verification (live APIs)

- `search_papers` across openalex+semantic_scholar+arxiv: 3×3 results, deduped, no errors; unknown source name rejected with a clear message
- `airas_db` source: index build + BM25 + normalization (handles int years and stringified author lists found in real DB records)
- `fetch_paper_fulltext`: arXiv ID (39k chars), arXiv-minted DOI (54k chars), publisher DOI resolved via S2 → arXiv (34k chars), bogus DOI → `not_found`
- Dashboard endpoints exercised over HTTP via uvicorn: search (4 papers, per-source stats), fulltext (156k chars), empty-body validation 422
- MCP: tool list shows `search_paper_titles` gone, both new tools present
- ruff / mypy green (300 files); OpenAPI schema + frontend client regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)