### PR TITLE
feat: open the paper in Overleaf from MCP and the dashboard API

### DIFF
--- a/backend/src/airas/dashboard/api/routes/v1/latex.py
+++ b/backend/src/airas/dashboard/api/routes/v1/latex.py
@@ -1,10 +1,13 @@
 from typing import Annotated
 
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import HTMLResponse
 from langfuse import observe
 
 from airas.container import Container
+from airas.core.types.github import GitHubConfig
+from airas.core.types.latex import LATEX_TEMPLATE_NAME
 from airas.dashboard.api.dependencies import get_github_client, get_langchain_client
 from airas.dashboard.api.schemas.latex import (
     CompileLatexSubgraphRequestBody,
@@ -22,6 +25,9 @@ from airas.usecases.publication.compile_latex_subgraph.compile_latex_subgraph im
 )
 from airas.usecases.publication.generate_latex_subgraph.generate_latex_subgraph import (
     GenerateLatexSubgraph,
+)
+from airas.usecases.publication.open_in_overleaf_subgraph.open_in_overleaf_subgraph import (
+    OpenInOverleafSubgraph,
 )
 from airas.usecases.publication.push_latex_subgraph.push_latex_subgraph import (
     PushLatexSubgraph,
@@ -86,6 +92,44 @@ async def push_latex(
         is_images_prepared=result["is_images_prepared"],
         execution_time=result["execution_time"],
     )
+
+
+@router.get("/overleaf", response_class=HTMLResponse)
+@inject
+@observe()
+async def open_in_overleaf(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+    github_client: Annotated[GithubClient, Depends(get_github_client)],
+    latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
+) -> HTMLResponse:
+    """Serve a page that forwards the paper's LaTeX project to Overleaf.
+
+    Opened in a browser (not called as a JSON API): the page carries the
+    zipped LaTeX sources inline and immediately POSTs them to Overleaf,
+    which creates a new project in the user's Overleaf account.
+    """
+    try:
+        result = (
+            await OpenInOverleafSubgraph(
+                github_client=github_client,
+                latex_template_name=latex_template_name,
+            )
+            .build_graph()
+            .ainvoke(
+                {
+                    "github_config": GitHubConfig(
+                        github_owner=github_owner,
+                        repository_name=repository_name,
+                        branch_name=branch_name,
+                    )
+                }
+            )
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    return HTMLResponse(result["overleaf_html"])
 
 
 @router.post("/compile", response_model=CompileLatexSubgraphResponseBody)

--- a/backend/src/airas/dashboard/api/routes/v1/latex.py
+++ b/backend/src/airas/dashboard/api/routes/v1/latex.py
@@ -94,7 +94,16 @@ async def push_latex(
     )
 
 
-@router.get("/overleaf", response_class=HTMLResponse)
+@router.get(
+    "/overleaf",
+    response_class=HTMLResponse,
+    responses={
+        404: {
+            "description": "LaTeX project not found in the repository "
+            "(push_latex has not been run)",
+        }
+    },
+)
 @inject
 @observe()
 async def open_in_overleaf(

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -17,6 +17,7 @@ Run locally:
 import os
 import webbrowser
 from typing import Any, Literal
+from urllib.parse import urlencode
 
 import httpx
 from mcp.server.fastmcp import FastMCP
@@ -1159,6 +1160,51 @@ async def compile_latex(
     return {
         "compile_latex_dispatched": result["compile_latex_dispatched"],
         "paper_url": result["paper_url"],
+    }
+
+
+@mcp.tool()
+def open_in_overleaf(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+    latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
+) -> dict[str, Any]:
+    """Create a link that opens the paper in Overleaf for editing.
+
+    Returns `overleaf_url`, which must be shown to the user as a clickable
+    link. Opening it in a browser downloads the LaTeX project pushed by
+    `push_latex` (main.tex, bibliography, figures, template assets) from the
+    experiment repository and submits it to Overleaf, creating a new project
+    in the user's Overleaf account (login required; each click creates a new
+    project). Starts the local dashboard API in the background if needed.
+    Requires GH_PERSONAL_ACCESS_TOKEN; private repositories work too.
+    """
+    refresh_environment()
+
+    port = DEFAULT_DASHBOARD_PORT
+    dashboard_status = "already_running"
+    if not is_dashboard_running(port):
+        start_dashboard(port)
+        dashboard_status = "started"
+
+    params = urlencode(
+        {
+            "github_owner": github_owner,
+            "repository_name": repository_name,
+            "branch_name": branch_name,
+            "latex_template_name": latex_template_name,
+        }
+    )
+    overleaf_url = f"{dashboard_url(port)}/airas/v1/latex/overleaf?{params}"
+    return {
+        "overleaf_url": overleaf_url,
+        "dashboard_status": dashboard_status,
+        "note": (
+            "Show this URL to the user as a clickable link. Opening it in a "
+            "browser sends the paper's LaTeX sources to Overleaf and creates "
+            "a new editable project there."
+        ),
     }
 
 

--- a/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/build_overleaf_export.py
+++ b/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/build_overleaf_export.py
@@ -1,0 +1,47 @@
+import base64
+import html
+import io
+import zipfile
+
+OVERLEAF_DOCS_URL = "https://www.overleaf.com/docs"
+
+# Overleaf creates the project from a POST because the zip is passed inline as
+# a base64 data URL (no public URL needed, so private repositories work). The
+# POST must come from the user's browser so the project lands in their
+# Overleaf account; this page submits itself on load.
+_EXPORT_PAGE_TEMPLATE = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Opening in Overleaf…</title>
+  </head>
+  <body>
+    <p>Sending <strong>{project_name}</strong> to Overleaf…</p>
+    <p>If nothing happens, <button type="submit" form="overleaf">click here</button>.</p>
+    <form id="overleaf" method="POST" action="{overleaf_docs_url}">
+      <input type="hidden" name="snip_uri" value="{zip_data_url}" />
+      <input type="hidden" name="snip_name" value="{project_name}" />
+    </form>
+    <script>
+      document.getElementById("overleaf").submit();
+    </script>
+  </body>
+</html>
+"""
+
+
+def build_overleaf_export(
+    latex_files: dict[str, bytes],
+    project_name: str,
+) -> str:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        for path, content in sorted(latex_files.items()):
+            archive.writestr(path, content)
+    zip_base64 = base64.b64encode(buffer.getvalue()).decode("ascii")
+
+    return _EXPORT_PAGE_TEMPLATE.format(
+        overleaf_docs_url=OVERLEAF_DOCS_URL,
+        project_name=html.escape(project_name),
+        zip_data_url=f"data:application/zip;base64,{zip_base64}",
+    )

--- a/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
+++ b/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
@@ -1,0 +1,50 @@
+import io
+import logging
+import zipfile
+
+from airas.core.types.github import GitHubConfig
+from airas.core.types.latex import LATEX_TEMPLATE_NAME
+from airas.infra.github_client import GithubClient
+
+logger = logging.getLogger(__name__)
+
+# Not needed to compile the paper: main.tex already embeds the template, and
+# leaving template.tex in the project confuses Overleaf's main-file detection.
+_EXCLUDED_FILES = {"template.tex", "template.pdf"}
+
+
+def collect_latex_project_files(
+    github_config: GitHubConfig,
+    latex_template_name: LATEX_TEMPLATE_NAME,
+    github_client: GithubClient,
+) -> dict[str, bytes]:
+    repo_zip = github_client.download_repository_zip(
+        github_owner=github_config.github_owner,
+        repository_name=github_config.repository_name,
+        ref=github_config.branch_name,
+    )
+
+    # GitHub zipball entries are prefixed with a "{repo}-{sha}/" directory.
+    prefix = f".research/latex/{latex_template_name}/"
+    latex_files: dict[str, bytes] = {}
+    with zipfile.ZipFile(io.BytesIO(repo_zip)) as archive:
+        for info in archive.infolist():
+            if info.is_dir():
+                continue
+            _, _, repo_path = info.filename.partition("/")
+            if not repo_path.startswith(prefix):
+                continue
+            relative_path = repo_path[len(prefix) :]
+            if relative_path in _EXCLUDED_FILES:
+                continue
+            latex_files[relative_path] = archive.read(info)
+
+    if "main.tex" not in latex_files:
+        raise ValueError(
+            f"main.tex not found under {prefix} in "
+            f"{github_config.github_owner}/{github_config.repository_name}"
+            f"@{github_config.branch_name}. Run push_latex first."
+        )
+
+    logger.info(f"Collected {len(latex_files)} LaTeX project files from {prefix}")
+    return latex_files

--- a/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
+++ b/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
@@ -37,6 +37,18 @@ def collect_latex_project_files(
             relative_path = repo_path[len(prefix) :]
             if relative_path in _EXCLUDED_FILES:
                 continue
+            # Guard against zip-slip style entries: the paths end up inside the
+            # zip handed to Overleaf, so never pass through empty, absolute, or
+            # parent-escaping paths.
+            if (
+                not relative_path
+                or relative_path.startswith("/")
+                or ".." in relative_path.split("/")
+            ):
+                logger.warning(
+                    f"Skipping suspicious path in repository zip: {info.filename}"
+                )
+                continue
             latex_files[relative_path] = archive.read(info)
 
     if "main.tex" not in latex_files:

--- a/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/open_in_overleaf_subgraph.py
+++ b/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/open_in_overleaf_subgraph.py
@@ -1,0 +1,97 @@
+import logging
+from typing import cast
+
+from langgraph.graph import END, START, StateGraph
+from typing_extensions import TypedDict
+
+from airas.core.execution_timers import ExecutionTimeState, time_node
+from airas.core.logging_utils import setup_logging
+from airas.core.types.github import GitHubConfig
+from airas.core.types.latex import LATEX_TEMPLATE_NAME
+from airas.infra.github_client import GithubClient
+from airas.usecases.publication.open_in_overleaf_subgraph.nodes.build_overleaf_export import (
+    build_overleaf_export,
+)
+from airas.usecases.publication.open_in_overleaf_subgraph.nodes.collect_latex_project_files import (
+    collect_latex_project_files,
+)
+
+setup_logging()
+logger = logging.getLogger(__name__)
+record_execution_time = lambda f: time_node("open_in_overleaf_subgraph")(f)  # noqa: E731
+
+
+class OpenInOverleafSubgraphInputState(TypedDict):
+    github_config: GitHubConfig
+
+
+class OpenInOverleafSubgraphOutputState(ExecutionTimeState):
+    overleaf_html: str
+    file_names: list[str]
+
+
+class OpenInOverleafSubgraphState(
+    OpenInOverleafSubgraphInputState,
+    OpenInOverleafSubgraphOutputState,
+    total=False,
+):
+    latex_files: dict[str, bytes]
+
+
+# NOTE: Overleaf 自体は GitHub を要求しない（zip を base64 の data URL としてブラウザから
+# POST するだけ）が、このサブグラフは実験リポジトリの .research/latex/{template}/ に
+# push_latex 済みであることを前提にしている。main.tex・図版（GitHub Actions の実験成果物）・
+# テンプレート資材（.cls / .bst 等）がそこに揃っているため。
+# TODO: push_latex 前でも使えるように、latex_text を直接受け取る変種も検討する。
+# その場合テンプレート資材は airas-org/airas-template から取得できるが、図版は手元に
+# ないため含められない（\includegraphics が壊れた状態で Overleaf に渡る）。
+class OpenInOverleafSubgraph:
+    def __init__(
+        self,
+        github_client: GithubClient,
+        latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
+    ):
+        self.github_client = github_client
+        self.latex_template_name = latex_template_name
+
+    @record_execution_time
+    def _collect_latex_project_files(
+        self, state: OpenInOverleafSubgraphState
+    ) -> dict[str, dict[str, bytes] | list[str]]:
+        latex_files = collect_latex_project_files(
+            github_config=state["github_config"],
+            latex_template_name=cast(LATEX_TEMPLATE_NAME, self.latex_template_name),
+            github_client=self.github_client,
+        )
+        return {
+            "latex_files": latex_files,
+            "file_names": sorted(latex_files),
+        }
+
+    @record_execution_time
+    def _build_overleaf_export(
+        self, state: OpenInOverleafSubgraphState
+    ) -> dict[str, str]:
+        github_config = state["github_config"]
+        overleaf_html = build_overleaf_export(
+            latex_files=state["latex_files"],
+            project_name=f"{github_config.repository_name}-{github_config.branch_name}",
+        )
+        return {"overleaf_html": overleaf_html}
+
+    def build_graph(self):
+        graph_builder = StateGraph(
+            OpenInOverleafSubgraphState,
+            input_schema=OpenInOverleafSubgraphInputState,
+            output_schema=OpenInOverleafSubgraphOutputState,
+        )
+        graph_builder.add_node(
+            "collect_latex_project_files", self._collect_latex_project_files
+        )
+        graph_builder.add_node("build_overleaf_export", self._build_overleaf_export)
+
+        graph_builder.add_edge(START, "collect_latex_project_files")
+        graph_builder.add_edge("collect_latex_project_files", "build_overleaf_export")
+        graph_builder.add_edge("build_overleaf_export", END)
+
+        return graph_builder.compile()

--- a/frontend/src/lib/api/services/LatexService.ts
+++ b/frontend/src/lib/api/services/LatexService.ts
@@ -80,6 +80,7 @@ export class LatexService {
                 'latex_template_name': latexTemplateName,
             },
             errors: {
+                404: `LaTeX project not found in the repository (push_latex has not been run)`,
                 422: `Validation Error`,
             },
         });

--- a/frontend/src/lib/api/services/LatexService.ts
+++ b/frontend/src/lib/api/services/LatexService.ts
@@ -51,6 +51,40 @@ export class LatexService {
         });
     }
     /**
+     * Open In Overleaf
+     * Serve a page that forwards the paper's LaTeX project to Overleaf.
+     *
+     * Opened in a browser (not called as a JSON API): the page carries the
+     * zipped LaTeX sources inline and immediately POSTs them to Overleaf,
+     * which creates a new project in the user's Overleaf account.
+     * @param githubOwner
+     * @param repositoryName
+     * @param branchName
+     * @param latexTemplateName
+     * @returns string Successful Response
+     * @throws ApiError
+     */
+    public static openInOverleafAirasV1LatexOverleafGet(
+        githubOwner: string,
+        repositoryName: string,
+        branchName: string,
+        latexTemplateName: 'iclr2024' | 'agents4science_2025' | 'mdpi' = 'mdpi',
+    ): CancelablePromise<string> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/airas/v1/latex/overleaf',
+            query: {
+                'github_owner': githubOwner,
+                'repository_name': repositoryName,
+                'branch_name': branchName,
+                'latex_template_name': latexTemplateName,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
      * Compile Latex
      * @param requestBody
      * @returns CompileLatexSubgraphResponseBody Successful Response

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -613,6 +613,63 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /airas/v1/latex/overleaf:
+    get:
+      tags:
+      - latex
+      summary: Open In Overleaf
+      description: 'Serve a page that forwards the paper''s LaTeX project to Overleaf.
+
+
+        Opened in a browser (not called as a JSON API): the page carries the
+
+        zipped LaTeX sources inline and immediately POSTs them to Overleaf,
+
+        which creates a new project in the user''s Overleaf account.'
+      operationId: open_in_overleaf_airas_v1_latex_overleaf_get
+      parameters:
+      - name: github_owner
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Github Owner
+      - name: repository_name
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Repository Name
+      - name: branch_name
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Branch Name
+      - name: latex_template_name
+        in: query
+        required: false
+        schema:
+          enum:
+          - iclr2024
+          - agents4science_2025
+          - mdpi
+          type: string
+          default: mdpi
+          title: Latex Template Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/html:
+              schema:
+                type: string
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /airas/v1/latex/compile:
     post:
       tags:

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -664,6 +664,9 @@ paths:
             text/html:
               schema:
                 type: string
+        '404':
+          description: LaTeX project not found in the repository (push_latex has not
+            been run)
         '422':
           description: Validation Error
           content:


### PR DESCRIPTION
## Summary

Adds a way to hand the generated paper off to Overleaf for manual editing, per maintainer request.

- **`OpenInOverleafSubgraph`** (`usecases/publication/open_in_overleaf_subgraph/`): downloads the experiment repository zip, extracts `.research/latex/{template}/` (main.tex, references.bib, figures, template class files; `template.tex`/`template.pdf` are excluded so Overleaf's main-file detection isn't confused), zips it, and renders a self-submitting HTML page that POSTs the zip to `https://www.overleaf.com/docs` as a base64 `data:` URL. Because the POST comes from the user's browser, the project is created in **their** Overleaf account, and no public URL is needed — private repositories work too.
- **Dashboard API**: `GET /airas/v1/latex/overleaf?github_owner=..&repository_name=..&branch_name=..&latex_template_name=..` runs the export lazily on click, so the latest pushed sources are always sent. Returns 404 with a clear message when `main.tex` hasn't been pushed yet (`push_latex` not run).
- **MCP tool `open_in_overleaf`**: starts the local dashboard API if it isn't running and returns `overleaf_url` for the user to click.

An annotation comment on the subgraph records the design constraint: Overleaf itself doesn't require GitHub, but this implementation does (figures and template assets live in the experiment repo); a `latex_text`-direct variant is left as a TODO.

## Verification

- `pre-commit run --all-files` passes (ruff, mypy, biome, OpenAPI/client regeneration)
- Started the dashboard locally, pushed a minimal `main.tex` to a test repository, and called the endpoint: 200, and the embedded zip decodes to `main.tex`, `references.bib`, and `Definitions/*` (mdpi.cls etc.), without `template.tex`/`template.pdf`
- Opened the URL in a real (Playwright) browser: the page auto-POSTs and lands on Overleaf (login page in a logged-out browser; a logged-in session proceeds to project creation)
- Repo/branch without `main.tex` returns 404 with the "Run push_latex first" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)