### PR TITLE
feat: group paper-search API keys under a Papers category

### DIFF
--- a/frontend/src/components/pages/settings/api-keys.tsx
+++ b/frontend/src/components/pages/settings/api-keys.tsx
@@ -21,6 +21,10 @@ const CATEGORIES: { key: string; names: string[] }[] = [
     ],
   },
   {
+    key: "papers",
+    names: ["SEMANTIC_SCHOLAR_API_KEY", "OPENALEX_API_KEY"],
+  },
+  {
     key: "integrations",
     names: ["WANDB_API_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_PUBLIC_KEY", "LANGFUSE_BASE_URL"],
   },

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -848,6 +848,7 @@
     "categories": {
       "github": "GitHub",
       "llm": "LLM Providers",
+      "papers": "Papers",
       "integrations": "Optional Integrations",
       "other": "Other"
     }

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -847,6 +847,7 @@
     "categories": {
       "github": "GitHub",
       "llm": "LLMプロバイダー",
+      "papers": "論文",
       "integrations": "オプション連携",
       "other": "その他"
     }


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

- What does this PR change? Give us a brief description.

On the dashboard API Keys page, `SEMANTIC_SCHOLAR_API_KEY` and `OPENALEX_API_KEY` previously fell into the automatic "Other" section. This adds a dedicated **Papers（論文）** category for them, placed between LLM Providers and Optional Integrations. Section headings are localized (en: "Papers", ja: "論文").

Verified in a browser against the bundled UI (built with `VITE_API_BASE_URL=""`): the 論文 section renders with both keys and the Other section disappears; `biome check` and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)