### PR TITLE
chore: remove stale TODO about latex_template_name in request bodies

### DIFF
--- a/backend/src/airas/dashboard/api/schemas/latex.py
+++ b/backend/src/airas/dashboard/api/schemas/latex.py
@@ -11,7 +11,6 @@ from airas.usecases.publication.generate_latex_subgraph.generate_latex_subgraph 
 )
 
 
-# TODO: Latex関連の各APIのrequest bodyにlatex_template_nameがあるのを取り除き、GenerateLatexSubgraphRequestBodyだけがもつ様に変更する
 class GenerateLatexSubgraphRequestBody(BaseModel):
     references_bib: str
     paper_content: PaperContent


### PR DESCRIPTION
## 概要
`schemas/latex.py` に残っていた「latex_template_name を GenerateLatexSubgraphRequestBody だけが持つように変更する」という TODO コメントを削除します。

## 背景
マルチテンプレート（同一研究から mdpi / iclr2024 など複数テンプレートで論文を生成する）を前提とする方針のため、`latex_template_name` は Generate / Push / Compile の各 API がそれぞれ受け取る現在の設計が正しく、この TODO は方針と矛盾する古い記述になっていました。

- Generate: テンプレートリポジトリから `.research/latex/{template}/template.tex` を取得
- Push: `.research/latex/{template}/main.tex` への保存先と画像配置の subdir 指定
- Compile: コンパイル対象 subdir と PDF URL の組み立て

コメント1行の削除のみで、動作変更はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)