### PR TITLE
chore: remove set_github_actions_secrets from the MCP server

### DIFF
--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -107,9 +107,6 @@ from airas.usecases.github.prepare_repository_subgraph.prepare_repository_subgra
 from airas.usecases.github.push_github_subgraph.push_github_subgraph import (
     PushGitHubSubgraph,
 )
-from airas.usecases.github.set_github_actions_secrets_subgraph.set_github_actions_secrets_subgraph import (
-    SetGithubActionsSecretsSubgraph,
-)
 from airas.usecases.publication.compile_latex_subgraph.compile_latex_subgraph import (
     CompileLatexSubgraph,
 )
@@ -533,30 +530,6 @@ async def prepare_repository(
         "is_repository_ready": result["is_repository_ready"],
         "is_branch_ready": result["is_branch_ready"],
     }
-
-
-@mcp.tool()
-async def set_github_actions_secrets(
-    github_owner: str,
-    repository_name: str,
-    branch_name: str = "main",
-) -> dict[str, Any]:
-    """Copy required secrets (LLM API keys etc.) from local environment variables to the experiment repository's GitHub Actions secrets.
-
-    Run this after `prepare_repository` so that code generation and
-    experiment workflows can call LLM providers. Requires GH_PERSONAL_ACCESS_TOKEN.
-    """
-    config = GitHubConfig(
-        github_owner=github_owner,
-        repository_name=repository_name,
-        branch_name=branch_name,
-    )
-    result = (
-        await SetGithubActionsSecretsSubgraph(github_client=_github_client())
-        .build_graph()
-        .ainvoke({"github_config": config})
-    )
-    return {"secrets_set": result["secrets_set"]}
 
 
 @mcp.tool()

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -74,7 +74,6 @@ Or add it to your project's `.mcp.json`:
 | Tool | Description |
 | --- | --- |
 | `prepare_repository` | Create and initialize an experiment repository |
-| `set_github_actions_secrets` | Copy LLM API keys from local env vars to the repository's Actions secrets |
 | `dispatch_code_generation` | Start experiment-code generation on GitHub Actions (async) |
 | `dispatch_experiment` | Start a sanity-check or main experiment run (async) |
 | `get_workflow_runs` | Check the status of recent workflow runs (non-blocking) |
@@ -104,7 +103,7 @@ Or add it to your project's `.mcp.json`:
 | `upload_research_history` | Save research state to the experiment repository |
 | `download_research_history` | Restore research state to continue in a later session |
 
-A typical flow: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `set_github_actions_secrets` → `dispatch_code_generation` → (poll `get_workflow_runs`) → `fetch_experiment_code` → `dispatch_experiment` → (poll) → `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`.
+A typical flow: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `dispatch_code_generation` → (poll `get_workflow_runs`) → `fetch_experiment_code` → `dispatch_experiment` → (poll) → `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`.
 
 Long-running steps (code generation, experiments) execute on GitHub Actions and return immediately; track them with `get_workflow_runs` instead of waiting.
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -74,7 +74,6 @@ claude mcp add airas -- uvx airas
 | ツール | 説明 |
 | --- | --- |
 | `prepare_repository` | 実験用リポジトリの作成・初期化 |
-| `set_github_actions_secrets` | ローカル環境変数のLLM APIキーをリポジトリのActionsシークレットに設定 |
 | `dispatch_code_generation` | 実験コード生成をGitHub Actionsで開始（非同期） |
 | `dispatch_experiment` | サニティチェック／本実験の実行を開始（非同期） |
 | `get_workflow_runs` | 直近のワークフロー実行のステータス確認（ノンブロッキング） |
@@ -104,7 +103,7 @@ claude mcp add airas -- uvx airas
 | `upload_research_history` | 研究状態を実験リポジトリに保存 |
 | `download_research_history` | 保存した研究状態を復元し、別セッションで継続 |
 
-典型的なフロー: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `set_github_actions_secrets` → `dispatch_code_generation` →（`get_workflow_runs` でポーリング）→ `fetch_experiment_code` → `dispatch_experiment` →（ポーリング）→ `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`
+典型的なフロー: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `dispatch_code_generation` →（`get_workflow_runs` でポーリング）→ `fetch_experiment_code` → `dispatch_experiment` →（ポーリング）→ `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`
 
 時間のかかるステップ（コード生成・実験）はGitHub Actions上で実行され、ツール自体は即座に返ります。完了待ちはせず `get_workflow_runs` で追跡してください。
 


### PR DESCRIPTION
## Summary

MCP セッション経由で GitHub Actions のシークレットを設定することは現実的にないため、MCP ツール `set_github_actions_secrets` を削除します。

## Changes

- `backend/src/airas/mcp/server.py` — MCP ツール定義と import を削除(ツール数 32 → 31)
- `docs/development/MCP.mdx` / `docs/ja/development/MCP.mdx` — ツール一覧の行と典型フローから削除

## Scope

サブグラフ本体(`usecases/github/set_github_actions_secrets_subgraph`)は**残しています**。ダッシュボード API(`POST /airas/v1/github/actions/secrets`)と autonomous research ワークフロー(hypothesis_driven / topic_open_ended)が引き続き使用しているためです。`schema/openapi.yaml` の参照もダッシュボード API 側のものなので変更なしです。

## Verification

- [x] MCP サーバーのロードとツール列挙を実行し、31ツール・`set_github_actions_secrets` 不在を確認
- [x] `pre-commit run ruff --all-files` / `pre-commit run mypy --all-files` Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)