### PR TITLE
feat: local-agent experiment flow with AIXS execution backend

### DIFF
--- a/backend/src/airas/core/credentials.py
+++ b/backend/src/airas/core/credentials.py
@@ -100,6 +100,9 @@ CREDENTIAL_SPECS: tuple[CredentialSpec, ...] = (
     CredentialSpec("LANGFUSE_SECRET_KEY"),
     CredentialSpec("LANGFUSE_PUBLIC_KEY"),
     CredentialSpec("LANGFUSE_BASE_URL", is_secret=False),
+    # Optional: run experiments on the AIXS compute platform.
+    CredentialSpec("AIXS_API_KEY"),
+    CredentialSpec("AIXS_BASE_URL", is_secret=False),
 )
 
 KNOWN_CREDENTIAL_NAMES = frozenset(spec.name for spec in CREDENTIAL_SPECS)

--- a/backend/src/airas/infra/aixs_client.py
+++ b/backend/src/airas/infra/aixs_client.py
@@ -1,0 +1,140 @@
+import os
+from logging import getLogger
+from typing import Any
+
+import httpx
+
+from airas.infra.base_http_client import BaseHTTPClient
+from airas.infra.response_parser import ResponseParser
+from airas.infra.retry_policy import make_retry_policy, raise_for_status
+
+logger = getLogger(__name__)
+
+AIXS_RETRY = make_retry_policy()
+
+DEFAULT_AIXS_BASE_URL = "https://api.aixs.dev"
+
+
+class AixsClient(BaseHTTPClient):
+    """Client for the AIXS agent compute platform.
+
+    AIXS executes code from a registered GitHub repository on managed or
+    BYO compute. The ownership chain is repository -> commit -> run: a repo
+    is registered once (cloned server-side), `pull` refreshes it and lists
+    branches with commit hashes, an analysis record ties a commit to runs,
+    and a run executes one entry command. Auth is a Bearer `aixs_pat_` key.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        parser: ResponseParser | None = None,
+        sync_session: httpx.Client | None = None,
+        async_session: httpx.AsyncClient | None = None,
+    ):
+        key = api_key or os.getenv("AIXS_API_KEY", "")
+        super().__init__(
+            base_url=(
+                base_url or os.getenv("AIXS_BASE_URL") or DEFAULT_AIXS_BASE_URL
+            ).rstrip("/"),
+            default_headers={"Authorization": f"Bearer {key}"} if key else {},
+            sync_session=sync_session,
+            async_session=async_session,
+        )
+        self._parser = parser or ResponseParser()
+
+    # --- repositories ---
+
+    async def aregister_repository(self, git_url: str) -> dict[str, Any]:
+        """Register a repository (idempotent: an existing one is returned).
+
+        Cloning happens server-side, so allow a generous timeout.
+        """
+        path = "v1/repositories"
+        resp = await self.apost(path=path, json={"git_url": git_url}, timeout=180.0)
+        raise_for_status(resp, path=path)
+        return self._parser.parse(resp, as_="json")
+
+    @AIXS_RETRY
+    async def alist_repositories(self) -> list[dict[str, Any]]:
+        path = "v1/repositories"
+        resp = await self.aget(path=path, timeout=30.0)
+        raise_for_status(resp, path=path)
+        return self._parser.parse(resp, as_="json")
+
+    async def apull_repository(self, repository_id: str) -> dict[str, Any]:
+        """Refresh the server-side clone and return branches with commit hashes."""
+        path = f"v1/repositories/{repository_id}/pull"
+        resp = await self.apost(path=path, timeout=180.0)
+        raise_for_status(resp, path=path)
+        return self._parser.parse(resp, as_="json")
+
+    # --- analyses ---
+
+    async def astart_analysis(
+        self, repository_id: str, commit_hash: str, branch: str | None = None
+    ) -> dict[str, Any]:
+        """Create an analysis record for a commit (required before starting runs)."""
+        path = f"v1/repositories/{repository_id}/analysis/{commit_hash}"
+        resp = await self.apost(
+            path=path,
+            json={"branch": branch} if branch else {},
+            timeout=30.0,
+        )
+        raise_for_status(resp, path=path)
+        return self._parser.parse(resp, as_="json")
+
+    # --- runs ---
+
+    async def astart_run(
+        self,
+        repository_id: str,
+        commit_hash: str,
+        analyzed_experiment: dict[str, Any],
+        compute_type: str = "cpu-general",
+        compute_id: str | None = None,
+        analysis_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Start a code-execution run. Not retried: a duplicate submission
+        would double the compute cost."""
+        path = f"v1/repositories/{repository_id}/{commit_hash}/runs"
+        body: dict[str, Any] = {
+            "analyzed_experiment": analyzed_experiment,
+            "compute_type": compute_type,
+        }
+        if compute_id is not None:
+            body["compute_id"] = compute_id
+        if analysis_id is not None:
+            body["analysis_id"] = analysis_id
+        resp = await self.apost(path=path, json=body, timeout=60.0)
+        raise_for_status(resp, path=path)
+        return self._parser.parse(resp, as_="json")
+
+    @AIXS_RETRY
+    async def aget_run(self, run_id: str) -> dict[str, Any]:
+        path = f"v1/runs/{run_id}"
+        resp = await self.aget(path=path, timeout=30.0)
+        raise_for_status(resp, path=path)
+        return self._parser.parse(resp, as_="json")
+
+    @AIXS_RETRY
+    async def aget_run_stdout(self, run_id: str) -> str:
+        path = f"v1/runs/{run_id}/stdout"
+        resp = await self.aget(path=path, timeout=60.0)
+        raise_for_status(resp, path=path)
+        return resp.text
+
+    @AIXS_RETRY
+    async def aget_run_stderr(self, run_id: str) -> str:
+        path = f"v1/runs/{run_id}/stderr"
+        resp = await self.aget(path=path, timeout=60.0)
+        raise_for_status(resp, path=path)
+        return resp.text
+
+    async def acancel_run(self, run_id: str) -> dict[str, Any]:
+        path = f"v1/runs/{run_id}/cancel"
+        resp = await self.apost(path=path, timeout=30.0)
+        raise_for_status(resp, path=path)
+        return self._parser.parse(resp, as_="json")

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -70,9 +70,6 @@ from airas.usecases.executors.dispatch_experiment_on_aixs_subgraph.dispatch_expe
 from airas.usecases.executors.dispatch_experiment_on_static_runner_subgraph.dispatch_experiment_on_static_runner_subgraph import (
     DispatchExperimentOnStaticRunnerSubgraph,
 )
-from airas.usecases.executors.dispatch_visualization_subgraph.dispatch_visualization_subgraph import (
-    DispatchVisualizationSubgraph,
-)
 from airas.usecases.executors.fetch_experiment_code_subgraph.fetch_experiment_code_subgraph import (
     FetchExperimentCodeSubgraph,
 )
@@ -81,9 +78,6 @@ from airas.usecases.executors.fetch_experiment_results_subgraph.fetch_experiment
 )
 from airas.usecases.executors.fetch_run_ids_subgraph.fetch_run_ids_subgraph import (
     FetchRunIdsSubgraph,
-)
-from airas.usecases.generators.dispatch_diagram_generation_subgraph.dispatch_diagram_generation_subgraph import (
-    DispatchDiagramGenerationSubgraph,
 )
 from airas.usecases.generators.generate_experimental_design_subgraph.generate_experimental_design_subgraph import (
     GenerateExperimentalDesignSubgraph,
@@ -939,8 +933,8 @@ async def fetch_run_ids(
     """List the experiment run IDs recorded in the experiment repository.
 
     Run IDs identify individual experiment runs defined by the generated
-    code; pass them to `dispatch_experiment` or `dispatch_visualization`.
-    Requires GH_PERSONAL_ACCESS_TOKEN.
+    code; pass them to `dispatch_experiment`, and use them to locate result
+    files when creating figures locally. Requires GH_PERSONAL_ACCESS_TOKEN.
     """
     result = (
         await FetchRunIdsSubgraph(github_client=_github_client())
@@ -956,78 +950,6 @@ async def fetch_run_ids(
         )
     )
     return result["run_ids"]
-
-
-@mcp.tool()
-async def dispatch_visualization(
-    github_owner: str,
-    repository_name: str,
-    branch_name: str,
-    run_ids: list[str],
-    runner_label: list[str] | None = None,
-) -> dict[str, Any]:
-    """Start result-visualization generation on GitHub Actions (asynchronous).
-
-    Generates figures for the given experiment `run_ids` (from
-    `fetch_run_ids`). The figures are used by the paper-writing stage.
-    Returns immediately; track with `get_workflow_runs`.
-    Requires GH_PERSONAL_ACCESS_TOKEN.
-    """
-    result = (
-        await DispatchVisualizationSubgraph(
-            github_client=_github_client(),
-            runner_label=runner_label,
-        )
-        .build_graph()
-        .ainvoke(
-            {
-                "github_config": GitHubConfig(
-                    github_owner=github_owner,
-                    repository_name=repository_name,
-                    branch_name=branch_name,
-                ),
-                "run_ids": run_ids,
-            }
-        )
-    )
-    return {"dispatched": result["dispatched"]}
-
-
-@mcp.tool()
-async def dispatch_diagram_generation(
-    github_owner: str,
-    repository_name: str,
-    branch_name: str,
-    github_actions_agent: Literal["claude_code", "open_code"] = "claude_code",
-    diagram_description: str | None = None,
-) -> dict[str, Any]:
-    """Start method-diagram generation on GitHub Actions (asynchronous).
-
-    Generates an explanatory diagram of the proposed method for the paper.
-    `diagram_description` optionally guides what the diagram should show.
-    Returns immediately; track with `get_workflow_runs`.
-    Requires GH_PERSONAL_ACCESS_TOKEN.
-    """
-    result = (
-        await DispatchDiagramGenerationSubgraph(
-            github_client=_github_client(),
-            diagram_description=diagram_description,
-            prompt_path=None,
-            llm_mapping=None,
-        )
-        .build_graph()
-        .ainvoke(
-            {
-                "github_config": GitHubConfig(
-                    github_owner=github_owner,
-                    repository_name=repository_name,
-                    branch_name=branch_name,
-                ),
-                "github_actions_agent": github_actions_agent,
-            }
-        )
-    )
-    return {"dispatched": result["dispatched"]}
 
 
 @mcp.tool()

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -566,9 +566,13 @@ async def dispatch_experiment(
       Requires GH_PERSONAL_ACCESS_TOKEN.
     - "aixs": executes on the AIXS compute platform (GPU without GitHub
       Actions limits). `compute_type` picks the machine (e.g. "cpu-general",
-      "gpu-a10"). Returns `aixs_run_id`; track progress and fetch execution
-      errors with `get_aixs_run_status`. Requires AIXS_API_KEY, and W&B API
-      keys must be registered as env vars on the AIXS side.
+      "gpu-a10"). Requires AIXS_API_KEY, and W&B API keys must be registered
+      as env vars on the AIXS side.
+
+    Track progress and fetch execution errors with
+    `get_experiment_run_status`. For "aixs" the returned `execution_id` is
+    passed directly; for "github_actions" the workflow-dispatch API returns
+    no id, so discover the run id with `get_workflow_runs` first.
     """
     if backend == "aixs":
         run_stage = RunStage.SANITY if workflow == "sanity_check" else RunStage.FULL
@@ -593,8 +597,8 @@ async def dispatch_experiment(
         return {
             "dispatched": aixs_result["dispatched"],
             "backend": "aixs",
-            "aixs_run_id": aixs_result["aixs_run_id"],
-            "aixs_run_url": aixs_result["aixs_run_url"],
+            "execution_id": aixs_result["aixs_run_id"],
+            "execution_url": aixs_result["aixs_run_url"],
         }
 
     workflow_file = (
@@ -624,21 +628,62 @@ async def dispatch_experiment(
 
 
 @mcp.tool()
-async def get_aixs_run_status(
-    aixs_run_id: str,
+async def get_experiment_run_status(
+    execution_id: str,
+    backend: Literal["github_actions", "aixs"] = "github_actions",
+    github_owner: str | None = None,
+    repository_name: str | None = None,
     log_tail_lines: int = 200,
 ) -> dict[str, Any]:
-    """Check an AIXS experiment run and fetch its execution logs (non-blocking).
+    """Check one experiment run and fetch its execution logs (non-blocking).
 
-    Use for runs started with `dispatch_experiment(backend="aixs")`. Returns
-    the run status ("pending" / "preprocessing" / "running" / "completed" /
-    "failed" / "cancelled") and, once the run has finished, the last
-    `log_tail_lines` lines of stdout and stderr — use stderr to diagnose
-    execution errors and fix the experiment code locally.
-    Requires AIXS_API_KEY.
+    `execution_id` identifies the run on the selected `backend`: the
+    `execution_id` returned by `dispatch_experiment(backend="aixs")`, or a
+    `workflow_run_id` from `get_workflow_runs` for "github_actions" (pass
+    `github_owner` and `repository_name` in that case).
+
+    Returns the run status and, once the run has finished, the last
+    `log_tail_lines` lines of stdout and stderr where the backend provides
+    them — use stderr to diagnose execution errors and fix the experiment
+    code locally.
     """
+    if backend == "github_actions":
+        if not github_owner or not repository_name:
+            raise ValueError(
+                "github_owner and repository_name are required for the "
+                "github_actions backend"
+            )
+        response = await _github_client().alist_workflow_runs(
+            github_owner=github_owner,
+            repository_name=repository_name,
+        )
+        run_info = next(
+            (
+                r
+                for r in (response or {}).get("workflow_runs", [])
+                if str(r.get("id")) == execution_id
+            ),
+            None,
+        )
+        if run_info is None:
+            raise ValueError(
+                f"Workflow run {execution_id} not found in recent runs of "
+                f"{github_owner}/{repository_name}"
+            )
+        return {
+            "execution_id": execution_id,
+            "backend": backend,
+            "status": run_info.get("status"),
+            "conclusion": run_info.get("conclusion"),
+            "execution_url": run_info.get("html_url"),
+            # Actions job logs are not exposed here; inspect the run page or
+            # use download_workflow_artifacts for outputs.
+            "stdout_tail": None,
+            "stderr_tail": None,
+        }
+
     client = _aixs_client()
-    run = await client.aget_run(aixs_run_id)
+    run = await client.aget_run(execution_id)
     status = run.get("status")
 
     def _tail(text: str) -> str:
@@ -649,16 +694,17 @@ async def get_aixs_run_status(
     stderr_tail: str | None = None
     if status in ("completed", "failed"):
         try:
-            stdout_tail = _tail(await client.aget_run_stdout(aixs_run_id))
+            stdout_tail = _tail(await client.aget_run_stdout(execution_id))
         except Exception as exc:  # logs may not be persisted yet
-            logger.warning(f"Failed to fetch AIXS stdout for {aixs_run_id}: {exc}")
+            logger.warning(f"Failed to fetch stdout for run {execution_id}: {exc}")
         try:
-            stderr_tail = _tail(await client.aget_run_stderr(aixs_run_id))
+            stderr_tail = _tail(await client.aget_run_stderr(execution_id))
         except Exception as exc:
-            logger.warning(f"Failed to fetch AIXS stderr for {aixs_run_id}: {exc}")
+            logger.warning(f"Failed to fetch stderr for run {execution_id}: {exc}")
 
     return {
-        "aixs_run_id": aixs_run_id,
+        "execution_id": execution_id,
+        "backend": backend,
         "status": status,
         "compute_type": run.get("compute_type"),
         "duration_seconds": run.get("duration_seconds"),

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -60,6 +60,7 @@ from airas.infra.langchain_client import (
 )
 from airas.infra.llm_provider_resolver import detect_available_providers
 from airas.infra.openalex_client import OpenAlexClient
+from airas.infra.retry_policy import HTTPClientFatalError, HTTPClientRetryableError
 from airas.infra.semantic_scholar_client import SemanticScholarClient
 from airas.usecases.analyzers.analyze_experiment_subgraph.analyze_experiment_subgraph import (
     AnalyzeExperimentSubgraph,
@@ -641,27 +642,24 @@ async def get_experiment_run_status(
     them — use stderr to diagnose execution errors and fix the experiment
     code locally.
     """
+    if log_tail_lines <= 0:
+        raise ValueError("log_tail_lines must be a positive integer")
+    log_tail_lines = min(log_tail_lines, 10_000)
+
     if backend == "github_actions":
         if not github_owner or not repository_name:
             raise ValueError(
                 "github_owner and repository_name are required for the "
                 "github_actions backend"
             )
-        response = await _github_client().alist_workflow_runs(
+        run_info = await _github_client().aget_workflow_run(
             github_owner=github_owner,
             repository_name=repository_name,
-        )
-        run_info = next(
-            (
-                r
-                for r in (response or {}).get("workflow_runs", [])
-                if str(r.get("id")) == execution_id
-            ),
-            None,
+            workflow_run_id=int(execution_id),
         )
         if run_info is None:
             raise ValueError(
-                f"Workflow run {execution_id} not found in recent runs of "
+                f"Workflow run {execution_id} not found in "
                 f"{github_owner}/{repository_name}"
             )
         return {
@@ -686,14 +684,15 @@ async def get_experiment_run_status(
 
     stdout_tail: str | None = None
     stderr_tail: str | None = None
-    if status in ("completed", "failed"):
+    if status in ("completed", "failed", "cancelled"):
         try:
             stdout_tail = _tail(await client.aget_run_stdout(execution_id))
-        except Exception as exc:  # logs may not be persisted yet
+        except (HTTPClientFatalError, HTTPClientRetryableError) as exc:
+            # logs may not be persisted (yet) for this run
             logger.warning(f"Failed to fetch stdout for run {execution_id}: {exc}")
         try:
             stderr_tail = _tail(await client.aget_run_stderr(execution_id))
-        except Exception as exc:
+        except (HTTPClientFatalError, HTTPClientRetryableError) as exc:
             logger.warning(f"Failed to fetch stderr for run {execution_id}: {exc}")
 
     return {

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -14,6 +14,7 @@ Run locally:
     uvx --from "airas[mcp]" airas-mcp
 """
 
+import logging
 import os
 import webbrowser
 from typing import Any, Literal
@@ -26,7 +27,7 @@ from pydantic import BaseModel
 from airas.cli import DEFAULT_DASHBOARD_PORT
 from airas.core.credentials import SETUP_INSTRUCTIONS, refresh_environment
 from airas.core.types.experiment_code import ExperimentCode
-from airas.core.types.experiment_history import ExperimentHistory
+from airas.core.types.experiment_history import ExperimentHistory, RunStage
 from airas.core.types.experimental_design import (
     ComputeEnvironment,
     DatasetSubfield,
@@ -41,7 +42,6 @@ from airas.core.types.paper_search import PAPER_SEARCH_SOURCES
 from airas.core.types.research_history import ResearchHistory
 from airas.core.types.research_hypothesis import ResearchHypothesis
 from airas.core.types.research_study import ResearchStudy
-from airas.core.types.wandb import WandbConfig
 from airas.dashboard.launcher import (
     dashboard_url,
     has_bundled_ui,
@@ -51,6 +51,7 @@ from airas.dashboard.launcher import (
 from airas.dashboard.launcher import (
     stop_dashboard as stop_dashboard_process,
 )
+from airas.infra.aixs_client import AixsClient
 from airas.infra.arxiv_client import ArxivClient
 from airas.infra.github_client import GithubClient
 from airas.infra.langchain_client import (
@@ -62,6 +63,9 @@ from airas.infra.openalex_client import OpenAlexClient
 from airas.infra.semantic_scholar_client import SemanticScholarClient
 from airas.usecases.analyzers.analyze_experiment_subgraph.analyze_experiment_subgraph import (
     AnalyzeExperimentSubgraph,
+)
+from airas.usecases.executors.dispatch_experiment_on_aixs_subgraph.dispatch_experiment_on_aixs_subgraph import (
+    DispatchExperimentOnAixsSubgraph,
 )
 from airas.usecases.executors.dispatch_experiment_on_static_runner_subgraph.dispatch_experiment_on_static_runner_subgraph import (
     DispatchExperimentOnStaticRunnerSubgraph,
@@ -77,9 +81,6 @@ from airas.usecases.executors.fetch_experiment_results_subgraph.fetch_experiment
 )
 from airas.usecases.executors.fetch_run_ids_subgraph.fetch_run_ids_subgraph import (
     FetchRunIdsSubgraph,
-)
-from airas.usecases.generators.dispatch_code_generation_subgraph.dispatch_code_generation_subgraph import (
-    DispatchCodeGenerationSubgraph,
 )
 from airas.usecases.generators.dispatch_diagram_generation_subgraph.dispatch_diagram_generation_subgraph import (
     DispatchDiagramGenerationSubgraph,
@@ -139,6 +140,8 @@ from airas.usecases.writers.generate_bibfile_subgraph.generate_bibfile_subgraph 
 )
 from airas.usecases.writers.write_subgraph.write_subgraph import WriteSubgraph
 
+logger = logging.getLogger(__name__)
+
 mcp = FastMCP("airas")
 
 # BM25 index over the AIRAS papers DB; built lazily on first search and
@@ -168,6 +171,13 @@ def _github_client() -> GithubClient:
         sync_session=_github_sync_session,
         async_session=_github_async_session,
     )
+
+
+def _aixs_client() -> AixsClient:
+    refresh_environment()
+    if not os.getenv("AIXS_API_KEY"):
+        raise RuntimeError(f"AIXS_API_KEY is not configured. {SETUP_INSTRUCTIONS}")
+    return AixsClient(sync_session=_sync_session, async_session=_async_session)
 
 
 def _arxiv_client() -> ArxivClient:
@@ -533,54 +543,6 @@ async def prepare_repository(
 
 
 @mcp.tool()
-async def dispatch_code_generation(
-    github_owner: str,
-    repository_name: str,
-    branch_name: str,
-    research_topic: str,
-    research_hypothesis: dict[str, Any],
-    experimental_design: dict[str, Any],
-    wandb_entity: str,
-    wandb_project: str,
-    github_actions_agent: Literal["claude_code", "open_code"] = "open_code",
-) -> dict[str, Any]:
-    """Start experiment-code generation on GitHub Actions (asynchronous).
-
-    Dispatches a workflow in the experiment repository that generates the
-    experiment code with a coding agent. Returns immediately with
-    `dispatched`; track progress with `get_workflow_runs` and fetch the
-    generated code with `fetch_experiment_code` once the run succeeds.
-    Requires GH_PERSONAL_ACCESS_TOKEN and an LLM provider API key.
-    """
-    result = (
-        await DispatchCodeGenerationSubgraph(
-            github_client=_github_client(),
-            llm_mapping=None,
-        )
-        .build_graph()
-        .ainvoke(
-            {
-                "github_config": GitHubConfig(
-                    github_owner=github_owner,
-                    repository_name=repository_name,
-                    branch_name=branch_name,
-                ),
-                "research_topic": research_topic,
-                "research_hypothesis": ResearchHypothesis.model_validate(
-                    research_hypothesis
-                ),
-                "experimental_design": ExperimentalDesign.model_validate(
-                    experimental_design
-                ),
-                "wandb_config": WandbConfig(entity=wandb_entity, project=wandb_project),
-                "github_actions_agent": github_actions_agent,
-            }
-        )
-    )
-    return {"dispatched": result["dispatched"]}
-
-
-@mcp.tool()
 async def dispatch_experiment(
     github_owner: str,
     repository_name: str,
@@ -588,15 +550,53 @@ async def dispatch_experiment(
     run_id: str,
     workflow: Literal["sanity_check", "main"] = "sanity_check",
     runner_label: list[str] | None = None,
+    backend: Literal["github_actions", "aixs"] = "github_actions",
+    compute_type: str = "gpu-a10",
 ) -> dict[str, Any]:
-    """Start an experiment run on GitHub Actions (asynchronous).
+    """Start an experiment run (asynchronous). The code must already be pushed.
 
     `workflow` selects the stage: "sanity_check" for a quick correctness run,
     "main" for the full experiment. `run_id` identifies the experiment run
-    defined by the generated code. Returns immediately with `dispatched`;
-    track progress with `get_workflow_runs` and collect outputs with
-    `fetch_experiment_results`. Requires GH_PERSONAL_ACCESS_TOKEN.
+    defined by the experiment code (one config/run/{run_id}.yaml).
+
+    `backend` selects where the run executes:
+    - "github_actions" (default): dispatches a workflow in the experiment
+      repository. `runner_label` picks the runner. Track progress with
+      `get_workflow_runs` and collect outputs with `fetch_experiment_results`.
+      Requires GH_PERSONAL_ACCESS_TOKEN.
+    - "aixs": executes on the AIXS compute platform (GPU without GitHub
+      Actions limits). `compute_type` picks the machine (e.g. "cpu-general",
+      "gpu-a10"). Returns `aixs_run_id`; track progress and fetch execution
+      errors with `get_aixs_run_status`. Requires AIXS_API_KEY, and W&B API
+      keys must be registered as env vars on the AIXS side.
     """
+    if backend == "aixs":
+        run_stage = RunStage.SANITY if workflow == "sanity_check" else RunStage.FULL
+        aixs_result = (
+            await DispatchExperimentOnAixsSubgraph(
+                aixs_client=_aixs_client(),
+                run_stage=run_stage,
+                compute_type=compute_type,
+            )
+            .build_graph()
+            .ainvoke(
+                {
+                    "github_config": GitHubConfig(
+                        github_owner=github_owner,
+                        repository_name=repository_name,
+                        branch_name=branch_name,
+                    ),
+                    "run_id": run_id,
+                }
+            )
+        )
+        return {
+            "dispatched": aixs_result["dispatched"],
+            "backend": "aixs",
+            "aixs_run_id": aixs_result["aixs_run_id"],
+            "aixs_run_url": aixs_result["aixs_run_url"],
+        }
+
     workflow_file = (
         "run_sanity_check.yml"
         if workflow == "sanity_check"
@@ -620,7 +620,51 @@ async def dispatch_experiment(
             }
         )
     )
-    return {"dispatched": result["dispatched"]}
+    return {"dispatched": result["dispatched"], "backend": "github_actions"}
+
+
+@mcp.tool()
+async def get_aixs_run_status(
+    aixs_run_id: str,
+    log_tail_lines: int = 200,
+) -> dict[str, Any]:
+    """Check an AIXS experiment run and fetch its execution logs (non-blocking).
+
+    Use for runs started with `dispatch_experiment(backend="aixs")`. Returns
+    the run status ("pending" / "preprocessing" / "running" / "completed" /
+    "failed" / "cancelled") and, once the run has finished, the last
+    `log_tail_lines` lines of stdout and stderr — use stderr to diagnose
+    execution errors and fix the experiment code locally.
+    Requires AIXS_API_KEY.
+    """
+    client = _aixs_client()
+    run = await client.aget_run(aixs_run_id)
+    status = run.get("status")
+
+    def _tail(text: str) -> str:
+        lines = text.splitlines()
+        return "\n".join(lines[-log_tail_lines:])
+
+    stdout_tail: str | None = None
+    stderr_tail: str | None = None
+    if status in ("completed", "failed"):
+        try:
+            stdout_tail = _tail(await client.aget_run_stdout(aixs_run_id))
+        except Exception as exc:  # logs may not be persisted yet
+            logger.warning(f"Failed to fetch AIXS stdout for {aixs_run_id}: {exc}")
+        try:
+            stderr_tail = _tail(await client.aget_run_stderr(aixs_run_id))
+        except Exception as exc:
+            logger.warning(f"Failed to fetch AIXS stderr for {aixs_run_id}: {exc}")
+
+    return {
+        "aixs_run_id": aixs_run_id,
+        "status": status,
+        "compute_type": run.get("compute_type"),
+        "duration_seconds": run.get("duration_seconds"),
+        "stdout_tail": stdout_tail,
+        "stderr_tail": stderr_tail,
+    }
 
 
 @mcp.tool()
@@ -633,9 +677,9 @@ async def get_workflow_runs(
     """Check the status of recent GitHub Actions runs in the experiment repository (non-blocking).
 
     Returns the most recent dispatched workflow runs with their status and
-    conclusion. Use this to track runs started by `dispatch_code_generation`
-    or `dispatch_experiment` — poll it between other work instead of waiting.
-    Requires GH_PERSONAL_ACCESS_TOKEN.
+    conclusion. Use this to track runs started by `dispatch_experiment`
+    (backend "github_actions") — poll it between other work instead of
+    waiting. Requires GH_PERSONAL_ACCESS_TOKEN.
     """
     response = await _github_client().alist_workflow_runs(
         github_owner=github_owner,
@@ -662,11 +706,10 @@ async def fetch_experiment_code(
     repository_name: str,
     branch_name: str,
 ) -> dict[str, Any]:
-    """Fetch the generated experiment code from the experiment repository.
+    """Fetch the experiment code from the experiment repository.
 
-    Use after a `dispatch_code_generation` run has succeeded. The returned
-    object can be passed to `analyze_experiment` as `experiment_code`.
-    Requires GH_PERSONAL_ACCESS_TOKEN.
+    The returned object can be passed to `analyze_experiment` as
+    `experiment_code`. Requires GH_PERSONAL_ACCESS_TOKEN.
     """
     result = (
         await FetchExperimentCodeSubgraph(github_client=_github_client())

--- a/backend/src/airas/usecases/executors/dispatch_experiment_on_aixs_subgraph/dispatch_experiment_on_aixs_subgraph.py
+++ b/backend/src/airas/usecases/executors/dispatch_experiment_on_aixs_subgraph/dispatch_experiment_on_aixs_subgraph.py
@@ -1,0 +1,154 @@
+import logging
+import re
+
+from langgraph.graph import END, START, StateGraph
+from typing_extensions import TypedDict
+
+from airas.core.execution_timers import ExecutionTimeState, time_node
+from airas.core.logging_utils import setup_logging
+from airas.core.types.experiment_history import RunStage
+from airas.core.types.github import GitHubConfig
+from airas.infra.aixs_client import AixsClient
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+# The CLI contract defined by airas-template's AGENTS.md.
+_ENTRY_POINT_TEMPLATE = "uv run python -u -m src.main run={run_id} results_dir=.research/results mode={mode}"
+
+
+def record_execution_time(f):
+    return time_node("dispatch_experiment_on_aixs_subgraph")(f)  # noqa: E731
+
+
+class DispatchExperimentOnAixsSubgraphInputState(TypedDict):
+    github_config: GitHubConfig
+    run_id: str
+
+
+class DispatchExperimentOnAixsSubgraphOutputState(ExecutionTimeState):
+    dispatched: bool
+    aixs_run_id: str
+    aixs_run_url: str
+
+
+class DispatchExperimentOnAixsSubgraphState(
+    DispatchExperimentOnAixsSubgraphInputState,
+    DispatchExperimentOnAixsSubgraphOutputState,
+    total=False,
+):
+    pass
+
+
+class DispatchExperimentOnAixsSubgraph:
+    """Execute one experiment run on the AIXS compute platform.
+
+    AIXS pulls the experiment repository from GitHub, so the run branch must
+    be pushed before dispatching. The subgraph registers the repository
+    (idempotent), refreshes it to resolve the branch head commit, ensures an
+    analysis record exists for that commit, and starts a run whose entry
+    command follows the airas-template CLI contract.
+    """
+
+    def __init__(
+        self,
+        aixs_client: AixsClient,
+        run_stage: RunStage | None = None,
+        compute_type: str = "gpu-a10",
+        compute_id: str | None = None,
+        required_env_vars: list[str] | None = None,
+    ):
+        self.aixs_client = aixs_client
+        self.run_stage = run_stage or RunStage.SANITY
+        self.compute_type = compute_type
+        self.compute_id = compute_id
+        # W&B logging is part of the experiment-code contract, so runs need
+        # the key registered on the AIXS side by default.
+        self.required_env_vars = (
+            required_env_vars if required_env_vars is not None else ["WANDB_API_KEY"]
+        )
+
+    @record_execution_time
+    async def _dispatch_experiment_on_aixs(
+        self, state: DispatchExperimentOnAixsSubgraphState
+    ) -> dict[str, bool | str]:
+        github_config = state["github_config"]
+        run_id = state["run_id"]
+        git_url = (
+            f"https://github.com/{github_config.github_owner}/"
+            f"{github_config.repository_name}"
+        )
+
+        repository = await self.aixs_client.aregister_repository(git_url)
+        repository_id = repository["id"]
+
+        pulled = await self.aixs_client.apull_repository(repository_id)
+        branch = next(
+            (
+                b
+                for b in pulled.get("branches", [])
+                if b.get("name") == github_config.branch_name
+            ),
+            None,
+        )
+        if branch is None:
+            raise ValueError(
+                f"Branch '{github_config.branch_name}' not found in {git_url}. "
+                "Push the experiment code before dispatching."
+            )
+        commit_hash = branch["commit_hash"]
+
+        analysis = await self.aixs_client.astart_analysis(
+            repository_id, commit_hash, branch=github_config.branch_name
+        )
+
+        mode = self.run_stage.value
+        analyzed_experiment = {
+            "id": re.sub(r"[^a-z0-9_]", "_", f"{run_id}_{mode}".lower()),
+            "title": f"{run_id} ({mode})",
+            "description": (
+                f"AIRAS experiment run '{run_id}' in {mode} mode, following the "
+                "airas-template CLI contract."
+            ),
+            "entry_point": _ENTRY_POINT_TEMPLATE.format(run_id=run_id, mode=mode),
+            "language": "Python",
+            "inputs": "config/run/*.yaml (Hydra run configs)",
+            "outputs": ".research/results and W&B metrics",
+            "required_env_vars": self.required_env_vars,
+        }
+
+        logger.info(
+            f"Starting AIXS run for run_id={run_id} (mode={mode}, "
+            f"compute_type={self.compute_type}) at commit {commit_hash[:12]}"
+        )
+        run = await self.aixs_client.astart_run(
+            repository_id,
+            commit_hash,
+            analyzed_experiment,
+            compute_type=self.compute_type,
+            compute_id=self.compute_id,
+            analysis_id=analysis.get("id"),
+        )
+
+        return {
+            "dispatched": True,
+            "aixs_run_id": str(run["run_id"]),
+            "aixs_run_url": run.get("run_url", ""),
+        }
+
+    def build_graph(self):
+        graph_builder = StateGraph(
+            DispatchExperimentOnAixsSubgraphState,
+            input_schema=DispatchExperimentOnAixsSubgraphInputState,
+            output_schema=DispatchExperimentOnAixsSubgraphOutputState,
+        )
+
+        graph_builder.add_node(
+            "dispatch_experiment_on_aixs",
+            self._dispatch_experiment_on_aixs,
+        )
+
+        graph_builder.add_edge(START, "dispatch_experiment_on_aixs")
+        graph_builder.add_edge("dispatch_experiment_on_aixs", END)
+
+        return graph_builder.compile()

--- a/backend/src/airas/usecases/executors/dispatch_experiment_on_aixs_subgraph/dispatch_experiment_on_aixs_subgraph.py
+++ b/backend/src/airas/usecases/executors/dispatch_experiment_on_aixs_subgraph/dispatch_experiment_on_aixs_subgraph.py
@@ -133,7 +133,7 @@ class DispatchExperimentOnAixsSubgraph:
         return {
             "dispatched": True,
             "aixs_run_id": str(run["run_id"]),
-            "aixs_run_url": run.get("run_url", ""),
+            "aixs_run_url": run.get("run_url") or "",
         }
 
     def build_graph(self):

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -69,15 +69,15 @@ Or add it to your project's `.mcp.json`:
 | `retrieve_models` | List curated candidate models for a subfield; no API key required |
 | `retrieve_datasets` | List curated candidate datasets for a subfield; no API key required |
 
-### Experiment execution (GitHub Actions)
+### Experiment execution
 
 | Tool | Description |
 | --- | --- |
 | `prepare_repository` | Create and initialize an experiment repository |
-| `dispatch_code_generation` | Start experiment-code generation on GitHub Actions (async) |
-| `dispatch_experiment` | Start a sanity-check or main experiment run (async) |
+| `dispatch_experiment` | Start a sanity-check or main experiment run (async) on GitHub Actions or the AIXS compute platform (`backend` parameter) |
 | `get_workflow_runs` | Check the status of recent workflow runs (non-blocking) |
-| `fetch_experiment_code` | Fetch the generated experiment code |
+| `get_aixs_run_status` | Check an AIXS run and fetch its stdout/stderr tails for error diagnosis |
+| `fetch_experiment_code` | Fetch the experiment code from the repository |
 | `fetch_run_ids` | List experiment run IDs recorded in the repository |
 | `fetch_experiment_results` | Fetch experiment results |
 | `download_workflow_artifacts` | Download artifacts of a specific workflow run |
@@ -103,9 +103,20 @@ Or add it to your project's `.mcp.json`:
 | `upload_research_history` | Save research state to the experiment repository |
 | `download_research_history` | Restore research state to continue in a later session |
 
-A typical flow: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `dispatch_code_generation` → (poll `get_workflow_runs`) → `fetch_experiment_code` → `dispatch_experiment` → (poll) → `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`.
+A typical flow: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **write the experiment code yourself** (see below) → `dispatch_experiment` → (poll `get_workflow_runs`) → `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`.
 
-Long-running steps (code generation, experiments) execute on GitHub Actions and return immediately; track them with `get_workflow_runs` instead of waiting.
+### Writing the experiment code
+
+The MCP host is expected to be a capable coding agent (Claude Code, Cursor, ...), so AIRAS does not generate the experiment code for you. After `prepare_repository`:
+
+1. Clone the experiment repository locally with git.
+2. Read its `AGENTS.md` — it defines the contract the code must satisfy (allowed files, CLI shape, `sanity` / `pilot` / `full` modes, validation verdict lines, W&B conventions).
+3. Implement the experiment, run `mode=sanity` locally until it prints `SANITY_VALIDATION: PASS`, then commit and push.
+4. Dispatch GPU-scale runs with `dispatch_experiment` and fetch errors/results with `get_aixs_run_status` / `fetch_experiment_results`.
+
+Headless pipelines (the built-in autonomous research workflows) still generate code remotely on GitHub Actions; that path is not exposed as an MCP tool.
+
+Long-running steps (experiments, LaTeX builds) execute on GitHub Actions and return immediately; track them with `get_workflow_runs` instead of waiting.
 
 ## Development
 

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -76,7 +76,7 @@ Or add it to your project's `.mcp.json`:
 | `prepare_repository` | Create and initialize an experiment repository |
 | `dispatch_experiment` | Start a sanity-check or main experiment run (async) on GitHub Actions or the AIXS compute platform (`backend` parameter) |
 | `get_workflow_runs` | Check the status of recent workflow runs (non-blocking) |
-| `get_aixs_run_status` | Check an AIXS run and fetch its stdout/stderr tails for error diagnosis |
+| `get_experiment_run_status` | Check one run on any backend and fetch its stdout/stderr tails for error diagnosis |
 | `fetch_experiment_code` | Fetch the experiment code from the repository |
 | `fetch_run_ids` | List experiment run IDs recorded in the repository |
 | `fetch_experiment_results` | Fetch experiment results |
@@ -112,7 +112,7 @@ The MCP host is expected to be a capable coding agent (Claude Code, Cursor, ...)
 1. Clone the experiment repository locally with git.
 2. Read its `AGENTS.md` — it defines the contract the code must satisfy (allowed files, CLI shape, `sanity` / `pilot` / `full` modes, validation verdict lines, W&B conventions).
 3. Implement the experiment, run `mode=sanity` locally until it prints `SANITY_VALIDATION: PASS`, then commit and push.
-4. Dispatch GPU-scale runs with `dispatch_experiment` and fetch errors/results with `get_aixs_run_status` / `fetch_experiment_results`.
+4. Dispatch GPU-scale runs with `dispatch_experiment` and fetch errors/results with `get_experiment_run_status` / `fetch_experiment_results`.
 
 Headless pipelines (the built-in autonomous research workflows) still generate code remotely on GitHub Actions; that path is not exposed as an MCP tool.
 

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -101,7 +101,7 @@ Or add it to your project's `.mcp.json`:
 | `upload_research_history` | Save research state to the experiment repository |
 | `download_research_history` | Restore research state to continue in a later session |
 
-A typical flow: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **write the experiment code yourself** (see below) → `dispatch_experiment` → (poll `get_workflow_runs`) → `fetch_experiment_results` → `analyze_experiment` → **create figures and diagrams yourself** (see below) → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`.
+A typical flow: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **write the experiment code yourself** (see below) → `dispatch_experiment` → (poll `get_workflow_runs` for GitHub Actions, or `get_experiment_run_status` for AIXS) → `fetch_experiment_results` → `analyze_experiment` → **create figures and diagrams yourself** (see below) → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`.
 
 ### Writing the experiment code
 
@@ -124,7 +124,7 @@ Result figures and method diagrams are also created by the MCP host itself rathe
 
 As with code generation, the autonomous research workflows still run visualization and diagram generation on GitHub Actions; those paths are not exposed as MCP tools.
 
-Long-running steps (experiments, LaTeX builds) execute on GitHub Actions and return immediately; track them with `get_workflow_runs` instead of waiting.
+Long-running steps return immediately instead of blocking. Experiments run on GitHub Actions or on AIXS depending on `dispatch_experiment`'s `backend` — track them with `get_workflow_runs` or `get_experiment_run_status` respectively. LaTeX builds run on GitHub Actions; track them with `get_workflow_runs`.
 
 ## Development
 

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -82,8 +82,6 @@ Or add it to your project's `.mcp.json`:
 | `fetch_experiment_results` | Fetch experiment results |
 | `download_workflow_artifacts` | Download artifacts of a specific workflow run |
 | `analyze_experiment` | Analyze results against the hypothesis and design |
-| `dispatch_visualization` | Generate result figures for given run IDs (async) |
-| `dispatch_diagram_generation` | Generate a method diagram for the paper (async) |
 | `push_files` | Push arbitrary files to the experiment repository |
 
 ### Paper writing & publication
@@ -103,7 +101,7 @@ Or add it to your project's `.mcp.json`:
 | `upload_research_history` | Save research state to the experiment repository |
 | `download_research_history` | Restore research state to continue in a later session |
 
-A typical flow: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **write the experiment code yourself** (see below) → `dispatch_experiment` → (poll `get_workflow_runs`) → `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`.
+A typical flow: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **write the experiment code yourself** (see below) → `dispatch_experiment` → (poll `get_workflow_runs`) → `fetch_experiment_results` → `analyze_experiment` → **create figures and diagrams yourself** (see below) → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`.
 
 ### Writing the experiment code
 
@@ -115,6 +113,16 @@ The MCP host is expected to be a capable coding agent (Claude Code, Cursor, ...)
 4. Dispatch GPU-scale runs with `dispatch_experiment` and fetch errors/results with `get_experiment_run_status` / `fetch_experiment_results`.
 
 Headless pipelines (the built-in autonomous research workflows) still generate code remotely on GitHub Actions; that path is not exposed as an MCP tool.
+
+### Creating figures and diagrams
+
+Result figures and method diagrams are also created by the MCP host itself rather than on GitHub Actions:
+
+1. Fetch the experiment results with `fetch_experiment_results` (or read them from your local clone; `fetch_run_ids` lists the runs).
+2. Generate result figures locally (e.g. with matplotlib) and save them as PDFs under `.research/results/` in the clone. Save method diagrams under `.research/diagrams/`.
+3. Commit and push them with git. `push_latex` and the LaTeX build collect every `*.pdf` from those two directories into the paper's `images/` directory.
+
+As with code generation, the autonomous research workflows still run visualization and diagram generation on GitHub Actions; those paths are not exposed as MCP tools.
 
 Long-running steps (experiments, LaTeX builds) execute on GitHub Actions and return immediately; track them with `get_workflow_runs` instead of waiting.
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -69,15 +69,15 @@ claude mcp add airas -- uvx airas
 | `retrieve_models` | サブ分野ごとの候補モデル一覧を取得。APIキー不要 |
 | `retrieve_datasets` | サブ分野ごとの候補データセット一覧を取得。APIキー不要 |
 
-### 実験実行（GitHub Actions）
+### 実験実行
 
 | ツール | 説明 |
 | --- | --- |
 | `prepare_repository` | 実験用リポジトリの作成・初期化 |
-| `dispatch_code_generation` | 実験コード生成をGitHub Actionsで開始（非同期） |
-| `dispatch_experiment` | サニティチェック／本実験の実行を開始（非同期） |
+| `dispatch_experiment` | サニティチェック／本実験の実行を開始（非同期）。`backend` パラメータで GitHub Actions / AIXS 計算基盤を選択 |
 | `get_workflow_runs` | 直近のワークフロー実行のステータス確認（ノンブロッキング） |
-| `fetch_experiment_code` | 生成された実験コードを取得 |
+| `get_aixs_run_status` | AIXS 実行のステータス確認と stdout/stderr の取得（エラー診断用） |
+| `fetch_experiment_code` | 実験コードを取得 |
 | `fetch_run_ids` | リポジトリに記録された実験run IDの一覧を取得 |
 | `fetch_experiment_results` | 実験結果を取得 |
 | `download_workflow_artifacts` | 特定のワークフロー実行のアーティファクトを取得 |
@@ -103,9 +103,20 @@ claude mcp add airas -- uvx airas
 | `upload_research_history` | 研究状態を実験リポジトリに保存 |
 | `download_research_history` | 保存した研究状態を復元し、別セッションで継続 |
 
-典型的なフロー: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → `dispatch_code_generation` →（`get_workflow_runs` でポーリング）→ `fetch_experiment_code` → `dispatch_experiment` →（ポーリング）→ `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`
+典型的なフロー: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **実験コードを自分で書く**（下記参照）→ `dispatch_experiment` →（`get_workflow_runs` でポーリング）→ `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`
 
-時間のかかるステップ（コード生成・実験）はGitHub Actions上で実行され、ツール自体は即座に返ります。完了待ちはせず `get_workflow_runs` で追跡してください。
+### 実験コードの書き方
+
+MCP ホストは有能なコーディングエージェント（Claude Code、Cursor など）である前提のため、AIRAS は実験コードを代わりに生成しません。`prepare_repository` の後:
+
+1. 実験リポジトリを git でローカルに clone する
+2. リポジトリ内の `AGENTS.md` を読む — コードが満たすべき規約（編集可能ファイル、CLI の形、`sanity` / `pilot` / `full` モード、検証判定行、W&B 規約）が定義されています
+3. 実験を実装し、ローカルで `mode=sanity` を実行して `SANITY_VALIDATION: PASS` が出るまで修正してから commit・push する
+4. GPU 規模の実行は `dispatch_experiment` でディスパッチし、エラーと結果は `get_aixs_run_status` / `fetch_experiment_results` で取得する
+
+ヘッドレスなパイプライン（組み込みの全自動研究ワークフロー）は従来どおり GitHub Actions 上でコードをリモート生成しますが、その経路は MCP ツールとしては公開していません。
+
+時間のかかるステップ（実験・LaTeX ビルド）はGitHub Actions上で実行され、ツール自体は即座に返ります。完了待ちはせず `get_workflow_runs` で追跡してください。
 
 ## 開発
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -76,7 +76,7 @@ claude mcp add airas -- uvx airas
 | `prepare_repository` | 実験用リポジトリの作成・初期化 |
 | `dispatch_experiment` | サニティチェック／本実験の実行を開始（非同期）。`backend` パラメータで GitHub Actions / AIXS 計算基盤を選択 |
 | `get_workflow_runs` | 直近のワークフロー実行のステータス確認（ノンブロッキング） |
-| `get_aixs_run_status` | AIXS 実行のステータス確認と stdout/stderr の取得（エラー診断用） |
+| `get_experiment_run_status` | 任意のバックエンドの実行1件のステータス確認と stdout/stderr の取得（エラー診断用） |
 | `fetch_experiment_code` | 実験コードを取得 |
 | `fetch_run_ids` | リポジトリに記録された実験run IDの一覧を取得 |
 | `fetch_experiment_results` | 実験結果を取得 |
@@ -112,7 +112,7 @@ MCP ホストは有能なコーディングエージェント（Claude Code、Cu
 1. 実験リポジトリを git でローカルに clone する
 2. リポジトリ内の `AGENTS.md` を読む — コードが満たすべき規約（編集可能ファイル、CLI の形、`sanity` / `pilot` / `full` モード、検証判定行、W&B 規約）が定義されています
 3. 実験を実装し、ローカルで `mode=sanity` を実行して `SANITY_VALIDATION: PASS` が出るまで修正してから commit・push する
-4. GPU 規模の実行は `dispatch_experiment` でディスパッチし、エラーと結果は `get_aixs_run_status` / `fetch_experiment_results` で取得する
+4. GPU 規模の実行は `dispatch_experiment` でディスパッチし、エラーと結果は `get_experiment_run_status` / `fetch_experiment_results` で取得する
 
 ヘッドレスなパイプライン（組み込みの全自動研究ワークフロー）は従来どおり GitHub Actions 上でコードをリモート生成しますが、その経路は MCP ツールとしては公開していません。
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -82,8 +82,6 @@ claude mcp add airas -- uvx airas
 | `fetch_experiment_results` | 実験結果を取得 |
 | `download_workflow_artifacts` | 特定のワークフロー実行のアーティファクトを取得 |
 | `analyze_experiment` | 仮説・実験設計に照らして結果を解析 |
-| `dispatch_visualization` | 指定run IDの結果グラフを生成（非同期） |
-| `dispatch_diagram_generation` | 論文用の手法ダイアグラムを生成（非同期） |
 | `push_files` | 任意のファイルを実験リポジトリにプッシュ |
 
 ### 論文執筆・出版
@@ -103,7 +101,7 @@ claude mcp add airas -- uvx airas
 | `upload_research_history` | 研究状態を実験リポジトリに保存 |
 | `download_research_history` | 保存した研究状態を復元し、別セッションで継続 |
 
-典型的なフロー: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **実験コードを自分で書く**（下記参照）→ `dispatch_experiment` →（`get_workflow_runs` でポーリング）→ `fetch_experiment_results` → `analyze_experiment` → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`
+典型的なフロー: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **実験コードを自分で書く**（下記参照）→ `dispatch_experiment` →（`get_workflow_runs` でポーリング）→ `fetch_experiment_results` → `analyze_experiment` → **図とダイアグラムを自分で作る**（下記参照）→ `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`
 
 ### 実験コードの書き方
 
@@ -115,6 +113,16 @@ MCP ホストは有能なコーディングエージェント（Claude Code、Cu
 4. GPU 規模の実行は `dispatch_experiment` でディスパッチし、エラーと結果は `get_experiment_run_status` / `fetch_experiment_results` で取得する
 
 ヘッドレスなパイプライン（組み込みの全自動研究ワークフロー）は従来どおり GitHub Actions 上でコードをリモート生成しますが、その経路は MCP ツールとしては公開していません。
+
+### 図とダイアグラムの作り方
+
+結果の図と手法ダイアグラムも、GitHub Actions ではなく MCP ホスト自身が作成します:
+
+1. `fetch_experiment_results` で実験結果を取得する（ローカルの clone から直接読んでもよい。run の一覧は `fetch_run_ids` で取得できます）
+2. 結果の図をローカルで生成し（matplotlib など）、clone 内の `.research/results/` 配下に PDF として保存する。手法ダイアグラムは `.research/diagrams/` 配下に保存する
+3. git で commit・push する。`push_latex` と LaTeX ビルドが、この2つのディレクトリ内の `*.pdf` を論文の `images/` ディレクトリに収集します
+
+コード生成と同様に、全自動研究ワークフローは従来どおり GitHub Actions 上で可視化・ダイアグラム生成を実行しますが、その経路は MCP ツールとしては公開していません。
 
 時間のかかるステップ（実験・LaTeX ビルド）はGitHub Actions上で実行され、ツール自体は即座に返ります。完了待ちはせず `get_workflow_runs` で追跡してください。
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -101,7 +101,7 @@ claude mcp add airas -- uvx airas
 | `upload_research_history` | 研究状態を実験リポジトリに保存 |
 | `download_research_history` | 保存した研究状態を復元し、別セッションで継続 |
 
-典型的なフロー: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **実験コードを自分で書く**（下記参照）→ `dispatch_experiment` →（`get_workflow_runs` でポーリング）→ `fetch_experiment_results` → `analyze_experiment` → **図とダイアグラムを自分で作る**（下記参照）→ `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`
+典型的なフロー: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **実験コードを自分で書く**（下記参照）→ `dispatch_experiment` →（GitHub Actions は `get_workflow_runs`、AIXS は `get_experiment_run_status` でポーリング）→ `fetch_experiment_results` → `analyze_experiment` → **図とダイアグラムを自分で作る**（下記参照）→ `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`
 
 ### 実験コードの書き方
 
@@ -124,7 +124,7 @@ MCP ホストは有能なコーディングエージェント（Claude Code、Cu
 
 コード生成と同様に、全自動研究ワークフローは従来どおり GitHub Actions 上で可視化・ダイアグラム生成を実行しますが、その経路は MCP ツールとしては公開していません。
 
-時間のかかるステップ（実験・LaTeX ビルド）はGitHub Actions上で実行され、ツール自体は即座に返ります。完了待ちはせず `get_workflow_runs` で追跡してください。
+時間のかかるステップは完了を待たず、ツール自体は即座に返ります。実験は `dispatch_experiment` の `backend` に応じて GitHub Actions または AIXS 上で実行されます — 追跡はそれぞれ `get_workflow_runs` / `get_experiment_run_status` を使ってください。LaTeX ビルドは GitHub Actions 上で実行され、`get_workflow_runs` で追跡します。
 
 ## 開発
 

--- a/frontend/src/components/pages/settings/api-keys.tsx
+++ b/frontend/src/components/pages/settings/api-keys.tsx
@@ -25,6 +25,10 @@ const CATEGORIES: { key: string; names: string[] }[] = [
     names: ["SEMANTIC_SCHOLAR_API_KEY", "OPENALEX_API_KEY"],
   },
   {
+    key: "compute",
+    names: ["AIXS_API_KEY", "AIXS_BASE_URL"],
+  },
+  {
     key: "integrations",
     names: ["WANDB_API_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_PUBLIC_KEY", "LANGFUSE_BASE_URL"],
   },

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -849,6 +849,7 @@
       "github": "GitHub",
       "llm": "LLM Providers",
       "papers": "Papers",
+      "compute": "Compute (AIXS)",
       "integrations": "Optional Integrations",
       "other": "Other"
     }

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -848,6 +848,7 @@
       "github": "GitHub",
       "llm": "LLMプロバイダー",
       "papers": "論文",
+      "compute": "計算基盤 (AIXS)",
       "integrations": "オプション連携",
       "other": "その他"
     }


### PR DESCRIPTION
## Summary

コード生成をリモートエージェント(GitHub Actions)に委ねるのではなく、**MCP ホスト(Claude Code 等のローカルエージェント)自身が実験コードを書く**フローに転換します。AIRAS の役割は「コンテキスト提供・実行基盤・検証」に絞ります。あわせて GPU 実行バックエンドとして **AIXS 計算基盤**を追加します。

関連: airas-org/airas-template#14(実験コード規約を `AGENTS.md` として明文化する PR。本 PR の前提)

## Changes

### MCP ツール
- **`dispatch_code_generation` を削除**(サブグラフは autonomous_research 用に温存)
- **`dispatch_visualization` / `dispatch_diagram_generation` を削除**(サブグラフは autonomous_research・ダッシュボードAPI用に温存)。結果の図・手法ダイアグラムも MCP ホスト自身がローカルで生成し、`.research/results/` / `.research/diagrams/` に PDF として git push する(既存の `prepare_images_for_latex` が論文の `images/` に収集)。ツール数は 31 → 29(削除 3 + 追加 1)
- **`dispatch_experiment` に `backend` パラメータを追加**: `"github_actions"`(デフォルト、従来動作)/ `"aixs"`。aixs 時は `compute_type`(例 `gpu-a10`)で計算環境を指定し、`aixs_run_id` / `aixs_run_url` を返します
- **`get_aixs_run_status` を新規追加**: 実行ステータスと、終了後の stdout / stderr 末尾(行数指定可)を返し、ローカルエージェントが実行エラーを見てコードを修正できるようにします

### AIXS 連携
- `infra/aixs_client.py` 新規: `BaseHTTPClient` ベース、`Authorization: Bearer aixs_pat_...`。リポジトリ登録(冪等)→ pull(ブランチ先頭 commit 解決)→ analysis レコード作成 → run 開始 → run 取得 / stdout / stderr / cancel
- `usecases/executors/dispatch_experiment_on_aixs_subgraph/` 新規: 上記の段取りを1ノードで実行。エントリコマンドは airas-template の CLI 規約(`uv run python -u -m src.main run={run_id} results_dir=.research/results mode={mode}`)から構築
- 認証情報に `AIXS_API_KEY` / `AIXS_BASE_URL` を追加し、ダッシュボードの API キーページに「計算基盤 (AIXS)」カテゴリを追加(en/ja の翻訳含む)

### docs
- MCP ドキュメント(en/ja)の典型フローを「`prepare_repository` → clone して `AGENTS.md` を読んで自分で書く → ローカル sanity → push → `dispatch_experiment`」に書き換え
- MCP ドキュメント(en/ja)に「図とダイアグラムの作り方」セクションを追加(ローカル生成 → 規約ディレクトリへ git push)

## Verification

- [x] MCP サーバーをロードしてツール列挙: 29 ツール、`dispatch_code_generation` / `dispatch_visualization` / `dispatch_diagram_generation` 不在、`dispatch_experiment` の schema に `backend` あり
- [x] AIXS サブグラフの `build_graph()` が成功
- [x] `pre-commit run ruff / mypy / biome --all-files` すべて Passed
- [x] フロントエンドの `pnpm run build` 成功
- [ ] AIXS 実 API に対する E2E は未実施(AIXS 側に API キーと W&B env var の登録が必要なため。手元の AIXS リポジトリのルート実装から仕様を確認して実装)

## Notes / Follow-ups

- `dispatch_experiment(backend="aixs")` の前提: 実験リポジトリが public であること(private は AIXS 側で GitHub OAuth 連携が必要)、AIXS 側に `WANDB_API_KEY` が env var 登録済みであること(未登録なら missing_env_vars を含む 400 が返り、そのままエラーメッセージとして見えます)
- AIXS 実行では結果ファイルはリポジトリに書き戻されないため、メトリクスは W&B、ログは `get_aixs_run_status` で取得する分担です
- ダッシュボード API / autonomous workflows への aixs バックエンド展開(#547 の RunnerConfig 抽象化の完成形)は本 PR ではスコープ外です

🤖 Generated with [Claude Code](https://claude.com/claude-code)
