### PR TITLE
feat: add render_chart and render_diagram MCP tools

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     "litellm>=1.80.16",
     "boto3>=1.35.0",
     "mcp[cli]>=1.6.0",
+    "vl-convert-python>=1.9.0.post1",
+    "pillow>=12.3.0",
 ]
 
 [project.urls]

--- a/backend/src/airas/dashboard/api/dependencies.py
+++ b/backend/src/airas/dashboard/api/dependencies.py
@@ -135,3 +135,27 @@ async def get_github_client(
         sync_session=github_sync_session,
         async_session=github_async_session,
     )
+
+
+@inject
+async def get_github_client_or_none(
+    github_sync_session: Annotated[
+        httpx.Client, Depends(Provide[Container.github_sync_session])
+    ],
+    github_async_session: Annotated[
+        httpx.AsyncClient, Depends(Provide[Container.github_async_session])
+    ],
+) -> GithubClient | None:
+    """Like get_github_client, but yields None when no token is configured.
+
+    For endpoints where GitHub access is only one of several modes (e.g. the
+    Overleaf export, which can read from a local clone instead).
+    """
+    refresh_environment()
+    if not os.getenv("GH_PERSONAL_ACCESS_TOKEN", ""):
+        return None
+    return GithubClient(
+        github_token=_resolve_github_token(),
+        sync_session=github_sync_session,
+        async_session=github_async_session,
+    )

--- a/backend/src/airas/dashboard/api/routes/v1/latex.py
+++ b/backend/src/airas/dashboard/api/routes/v1/latex.py
@@ -89,7 +89,6 @@ async def push_latex(
     )
     return PushLatexSubgraphResponseBody(
         is_upload_successful=result["is_upload_successful"],
-        is_images_prepared=result["is_images_prepared"],
         execution_time=result["execution_time"],
     )
 
@@ -112,18 +111,24 @@ async def open_in_overleaf(
     branch_name: str,
     github_client: Annotated[GithubClient, Depends(get_github_client)],
     latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
+    local_path: str | None = None,
 ) -> HTMLResponse:
     """Serve a page that forwards the paper's LaTeX project to Overleaf.
 
     Opened in a browser (not called as a JSON API): the page carries the
     zipped LaTeX sources inline and immediately POSTs them to Overleaf,
     which creates a new project in the user's Overleaf account.
+
+    With `local_path` (path to a local clone of the experiment repository)
+    the project is read from the working tree on disk instead of GitHub,
+    so unpushed changes and locally rendered figures are included.
     """
     try:
         result = (
             await OpenInOverleafSubgraph(
                 github_client=github_client,
                 latex_template_name=latex_template_name,
+                local_repo_path=local_path,
             )
             .build_graph()
             .ainvoke(

--- a/backend/src/airas/dashboard/api/routes/v1/latex.py
+++ b/backend/src/airas/dashboard/api/routes/v1/latex.py
@@ -1,14 +1,18 @@
 from typing import Annotated
 
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import HTMLResponse
 from langfuse import observe
 
 from airas.container import Container
 from airas.core.types.github import GitHubConfig
 from airas.core.types.latex import LATEX_TEMPLATE_NAME
-from airas.dashboard.api.dependencies import get_github_client, get_langchain_client
+from airas.dashboard.api.dependencies import (
+    get_github_client,
+    get_github_client_or_none,
+    get_langchain_client,
+)
 from airas.dashboard.api.schemas.latex import (
     CompileLatexSubgraphRequestBody,
     CompileLatexSubgraphResponseBody,
@@ -109,7 +113,7 @@ async def open_in_overleaf(
     github_owner: str,
     repository_name: str,
     branch_name: str,
-    github_client: Annotated[GithubClient, Depends(get_github_client)],
+    github_client: Annotated[GithubClient | None, Depends(get_github_client_or_none)],
     latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
     local_path: str | None = None,
 ) -> HTMLResponse:
@@ -121,8 +125,15 @@ async def open_in_overleaf(
 
     With `local_path` (path to a local clone of the experiment repository)
     the project is read from the working tree on disk instead of GitHub,
-    so unpushed changes and locally rendered figures are included.
+    so unpushed changes and locally rendered figures are included — and no
+    GitHub token is required.
     """
+    if local_path is None and github_client is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="GH_PERSONAL_ACCESS_TOKEN is not configured (required "
+            "unless local_path is provided).",
+        )
     try:
         result = (
             await OpenInOverleafSubgraph(

--- a/backend/src/airas/dashboard/api/schemas/latex.py
+++ b/backend/src/airas/dashboard/api/schemas/latex.py
@@ -31,7 +31,6 @@ class PushLatexSubgraphRequestBody(BaseModel):
 
 class PushLatexSubgraphResponseBody(BaseModel):
     is_upload_successful: bool
-    is_images_prepared: bool
     execution_time: dict[str, list[float]]
 
 

--- a/backend/src/airas/infra/kroki_client.py
+++ b/backend/src/airas/infra/kroki_client.py
@@ -1,0 +1,58 @@
+import os
+from logging import getLogger
+
+import httpx
+
+from airas.infra.base_http_client import BaseHTTPClient
+from airas.infra.retry_policy import make_retry_policy, raise_for_status
+
+logger = getLogger(__name__)
+
+KROKI_RETRY = make_retry_policy()
+
+DEFAULT_KROKI_BASE_URL = "https://kroki.io"
+
+
+class KrokiClient(BaseHTTPClient):
+    """Client for a Kroki diagram-rendering service.
+
+    Kroki renders text diagram notations (mermaid, graphviz, d2, plantuml,
+    and 20+ more) into images through a single API. The endpoint defaults
+    to the public instance and can be pointed at a self-hosted one via
+    KROKI_BASE_URL, which keeps unpublished diagrams on-premises.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        sync_session: httpx.Client | None = None,
+        async_session: httpx.AsyncClient | None = None,
+    ):
+        super().__init__(
+            base_url=(
+                base_url or os.getenv("KROKI_BASE_URL") or DEFAULT_KROKI_BASE_URL
+            ).rstrip("/"),
+            sync_session=sync_session,
+            async_session=async_session,
+        )
+
+    @KROKI_RETRY
+    async def arender(
+        self,
+        diagram_type: str,
+        diagram_source: str,
+        output_format: str = "svg",
+    ) -> bytes:
+        path = ""
+        resp = await self.apost(
+            path=path,
+            json={
+                "diagram_source": diagram_source,
+                "diagram_type": diagram_type,
+                "output_format": output_format,
+            },
+            timeout=60.0,
+        )
+        raise_for_status(resp, path=f"{diagram_type}/{output_format}")
+        return resp.content

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -14,14 +14,19 @@ Run locally:
     uvx --from "airas[mcp]" airas-mcp
 """
 
+import asyncio
 import logging
 import os
 import webbrowser
+from io import BytesIO
+from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlencode
 
 import httpx
+import vl_convert as vlc
 from mcp.server.fastmcp import FastMCP
+from PIL import Image
 from pydantic import BaseModel
 
 from airas.cli import DEFAULT_DASHBOARD_PORT
@@ -54,6 +59,7 @@ from airas.dashboard.launcher import (
 from airas.infra.aixs_client import AixsClient
 from airas.infra.arxiv_client import ArxivClient
 from airas.infra.github_client import GithubClient
+from airas.infra.kroki_client import KrokiClient
 from airas.infra.langchain_client import (
     PROVIDER_REQUIRED_ENV_VARS,
     LangChainClient,
@@ -173,6 +179,11 @@ def _aixs_client() -> AixsClient:
     if not os.getenv("AIXS_API_KEY"):
         raise RuntimeError(f"AIXS_API_KEY is not configured. {SETUP_INSTRUCTIONS}")
     return AixsClient(sync_session=_sync_session, async_session=_async_session)
+
+
+def _kroki_client() -> KrokiClient:
+    refresh_environment()
+    return KrokiClient(sync_session=_sync_session, async_session=_async_session)
 
 
 def _arxiv_client() -> ArxivClient:
@@ -949,6 +960,94 @@ async def fetch_run_ids(
         )
     )
     return result["run_ids"]
+
+
+def _resolve_render_output(output_path: str) -> tuple[Path, str]:
+    path = Path(output_path).expanduser()
+    suffix = path.suffix.lower().lstrip(".")
+    if suffix not in ("pdf", "svg", "png"):
+        raise ValueError("output_path must end with .pdf, .svg, or .png")
+    return path, suffix
+
+
+def _png_to_pdf(png: bytes) -> bytes:
+    image = Image.open(BytesIO(png))
+    if image.mode != "RGB":
+        # Flatten transparency onto white instead of the black that a
+        # plain RGB conversion would produce.
+        rgba = image.convert("RGBA")
+        image = Image.new("RGB", rgba.size, (255, 255, 255))
+        image.paste(rgba, mask=rgba.getchannel("A"))
+    buffer = BytesIO()
+    image.save(buffer, format="PDF")
+    return buffer.getvalue()
+
+
+@mcp.tool()
+async def render_chart(
+    vega_lite_spec: dict[str, Any],
+    output_path: str,
+) -> dict[str, Any]:
+    """Render a Vega-Lite spec to a chart file, entirely locally.
+
+    Use this for publication-quality result figures: build a Vega-Lite JSON
+    spec from the experiment results (inline the data under `data.values`)
+    and save the chart as a PDF under `.research/results/` in your local
+    clone of the experiment repository, then commit and push — the LaTeX
+    build collects every `*.pdf` there. `output_path` must end with .pdf,
+    .svg, or .png. Rendering runs in-process (vl-convert); no data leaves
+    the machine and no API keys are required.
+    """
+    path, suffix = _resolve_render_output(output_path)
+    if suffix == "pdf":
+        data = await asyncio.to_thread(vlc.vegalite_to_pdf, vega_lite_spec)
+    elif suffix == "svg":
+        svg = await asyncio.to_thread(vlc.vegalite_to_svg, vega_lite_spec)
+        data = svg.encode("utf-8")
+    else:
+        data = await asyncio.to_thread(vlc.vegalite_to_png, vega_lite_spec)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return {"output_path": str(path), "bytes_written": len(data)}
+
+
+@mcp.tool()
+async def render_diagram(
+    diagram_type: str,
+    diagram_source: str,
+    output_path: str,
+) -> dict[str, Any]:
+    """Render a text diagram (diagram-as-code) to a file via Kroki.
+
+    Use this for method/architecture diagrams: write the diagram source in
+    a text notation (`diagram_type`: "mermaid", "graphviz", "d2",
+    "plantuml", and 20+ more Kroki types) and save the result as a PDF
+    under `.research/diagrams/` in your local clone of the experiment
+    repository, then commit and push — the LaTeX build collects every
+    `*.pdf` there. `output_path` must end with .pdf, .svg, or .png; PDF
+    conversion happens locally from the SVG (vector). Types whose SVG embeds
+    HTML labels (e.g. mermaid) fall back to a raster PDF automatically —
+    prefer "graphviz" / "plantuml" when you want vector text. Rendering uses
+    the public https://kroki.io by default — set KROKI_BASE_URL to a
+    self-hosted instance to keep unpublished diagrams private. No API keys
+    required.
+    """
+    path, suffix = _resolve_render_output(output_path)
+    client = _kroki_client()
+    if suffix == "pdf":
+        svg = await client.arender(diagram_type, diagram_source, "svg")
+        if b"<foreignObject" in svg:
+            # HTML-in-SVG labels (mermaid etc.) are dropped by the local
+            # SVG-to-PDF converter, so rasterize via Kroki's PNG instead.
+            png = await client.arender(diagram_type, diagram_source, "png")
+            data = await asyncio.to_thread(_png_to_pdf, png)
+        else:
+            data = await asyncio.to_thread(vlc.svg_to_pdf, svg.decode("utf-8"))
+    else:
+        data = await client.arender(diagram_type, diagram_source, suffix)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return {"output_path": str(path), "bytes_written": len(data)}
 
 
 @mcp.tool()

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -115,9 +115,6 @@ from airas.usecases.publication.compile_latex_subgraph.compile_latex_subgraph im
 from airas.usecases.publication.generate_latex_subgraph.generate_latex_subgraph import (
     GenerateLatexSubgraph,
 )
-from airas.usecases.publication.push_latex_subgraph.push_latex_subgraph import (
-    PushLatexSubgraph,
-)
 from airas.usecases.retrieve.fetch_paper_fulltext_subgraph.fetch_paper_fulltext_subgraph import (
     FetchPaperFulltextSubgraph,
 )
@@ -1152,10 +1149,11 @@ async def generate_latex(
     """Convert paper content into a full LaTeX document.
 
     `paper_content` should be the output of `generate_paper`. Available
-    templates: "mdpi", "iclr2024", "agents4science_2025". Push the returned
-    LaTeX to the experiment repository with `push_latex`, then build the PDF
-    with `compile_latex`. Requires an LLM provider API key and
-    GH_PERSONAL_ACCESS_TOKEN.
+    templates: "mdpi", "iclr2024", "agents4science_2025". Write the returned
+    LaTeX to `.research/latex/{template}/main.tex` in your local clone of
+    the experiment repository and push it with git, then build the PDF with
+    `compile_latex` and/or hand it over with `open_in_overleaf`. Requires an
+    LLM provider API key and GH_PERSONAL_ACCESS_TOKEN.
     """
     result = (
         await GenerateLatexSubgraph(
@@ -1175,44 +1173,6 @@ async def generate_latex(
 
 
 @mcp.tool()
-async def push_latex(
-    github_owner: str,
-    repository_name: str,
-    branch_name: str,
-    latex_text: str,
-    latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
-) -> dict[str, Any]:
-    """Push the LaTeX document to the experiment repository.
-
-    Uploads the LaTeX source (from `generate_latex`) as
-    `.research/latex/{template}/main.tex`. Figures need no separate step:
-    `compile_latex` and `open_in_overleaf` pick up every figure PDF under
-    `.research/results/` and `.research/diagrams/` automatically.
-    Requires GH_PERSONAL_ACCESS_TOKEN.
-    """
-    result = (
-        await PushLatexSubgraph(
-            github_client=_github_client(),
-            latex_template_name=latex_template_name,
-        )
-        .build_graph()
-        .ainvoke(
-            {
-                "github_config": GitHubConfig(
-                    github_owner=github_owner,
-                    repository_name=repository_name,
-                    branch_name=branch_name,
-                ),
-                "latex_text": latex_text,
-            }
-        )
-    )
-    return {
-        "is_upload_successful": result["is_upload_successful"],
-    }
-
-
-@mcp.tool()
 async def compile_latex(
     github_owner: str,
     repository_name: str,
@@ -1222,8 +1182,9 @@ async def compile_latex(
 ) -> dict[str, Any]:
     """Build the paper PDF on GitHub Actions (asynchronous).
 
-    One of the two publication exits after `push_latex` (the other is
-    `open_in_overleaf`; they are independent and can both be used).
+    One of the two publication exits after main.tex has been pushed to
+    `.research/latex/{template}/` (the other is `open_in_overleaf`; they
+    are independent and can both be used).
     Dispatches the LaTeX compilation workflow for the pushed sources;
     figure PDFs under `.research/results/` and `.research/diagrams/` are
     materialized into `images/` at build time. Returns immediately with
@@ -1263,7 +1224,7 @@ def open_in_overleaf(
 ) -> dict[str, Any]:
     """Create a link that opens the paper in Overleaf for editing.
 
-    One of the two publication exits after `push_latex` (the other is
+    One of the two publication exits for the paper (the other is
     `compile_latex`; they are independent and can both be used).
     Returns `overleaf_url`, which must be shown to the user as a clickable
     link. Opening it in a browser packages the LaTeX project (main.tex,
@@ -1273,8 +1234,8 @@ def open_in_overleaf(
     Overleaf account (login required; each click creates a new project).
 
     By default the project is read from the experiment repository on GitHub
-    (push_latex must have run; requires GH_PERSONAL_ACCESS_TOKEN, private
-    repositories work). Pass `local_path` — the absolute path of your local
+    (main.tex must have been pushed; requires GH_PERSONAL_ACCESS_TOKEN,
+    private repositories work). Pass `local_path` — the absolute path of your local
     clone — to read the working tree on disk instead: no push needed, and
     locally rendered figures are included as-is. Starts the local dashboard
     API in the background if needed.

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -1222,9 +1222,13 @@ async def compile_latex(
 ) -> dict[str, Any]:
     """Build the paper PDF on GitHub Actions (asynchronous).
 
-    Dispatches the LaTeX compilation workflow for the sources pushed by
-    `push_latex`. Returns immediately with `paper_url` (when available);
-    track the run with `get_workflow_runs`. Requires GH_PERSONAL_ACCESS_TOKEN.
+    One of the two publication exits after `push_latex` (the other is
+    `open_in_overleaf`; they are independent and can both be used).
+    Dispatches the LaTeX compilation workflow for the pushed sources;
+    figure PDFs under `.research/results/` and `.research/diagrams/` are
+    materialized into `images/` at build time. Returns immediately with
+    `paper_url` (when available); track the run with `get_workflow_runs`.
+    Requires GH_PERSONAL_ACCESS_TOKEN.
     """
     result = (
         await CompileLatexSubgraph(
@@ -1259,6 +1263,8 @@ def open_in_overleaf(
 ) -> dict[str, Any]:
     """Create a link that opens the paper in Overleaf for editing.
 
+    One of the two publication exits after `push_latex` (the other is
+    `compile_latex`; they are independent and can both be used).
     Returns `overleaf_url`, which must be shown to the user as a clickable
     link. Opening it in a browser packages the LaTeX project (main.tex,
     bibliography, template assets, plus every figure PDF under

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -991,12 +991,13 @@ async def render_chart(
     """Render a Vega-Lite spec to a chart file, entirely locally.
 
     Use this for publication-quality result figures: build a Vega-Lite JSON
-    spec from the experiment results (inline the data under `data.values`)
-    and save the chart as a PDF under `.research/results/` in your local
-    clone of the experiment repository, then commit and push — the LaTeX
-    build collects every `*.pdf` there. `output_path` must end with .pdf,
-    .svg, or .png. Rendering runs in-process (vl-convert); no data leaves
-    the machine and no API keys are required.
+    spec from the experiment results (inline the data under `data.values`).
+    When rendering into a local clone of the experiment repository, save
+    the chart as a PDF under `.research/results/chart/`, then commit and
+    push — the LaTeX build collects every `*.pdf` under
+    `.research/results/`. `output_path` must end with .pdf, .svg, or .png.
+    Rendering runs in-process (vl-convert); no data leaves the machine and
+    no API keys are required.
     """
     path, suffix = _resolve_render_output(output_path)
     if suffix == "pdf":
@@ -1021,11 +1022,12 @@ async def render_diagram(
 
     Use this for method/architecture diagrams: write the diagram source in
     a text notation (`diagram_type`: "mermaid", "graphviz", "d2",
-    "plantuml", and 20+ more Kroki types) and save the result as a PDF
-    under `.research/diagrams/` in your local clone of the experiment
-    repository, then commit and push — the LaTeX build collects every
-    `*.pdf` there. `output_path` must end with .pdf, .svg, or .png; PDF
-    conversion happens locally from the SVG (vector). Types whose SVG embeds
+    "plantuml", and 20+ more Kroki types). When rendering into a local
+    clone of the experiment repository, save the result as a PDF under
+    `.research/results/diagram/`, then commit and push — the LaTeX build
+    collects every `*.pdf` under `.research/results/`. `output_path` must
+    end with .pdf, .svg, or .png; PDF conversion happens locally from the
+    SVG (vector). Types whose SVG embeds
     HTML labels (e.g. mermaid) fall back to a raster PDF automatically —
     prefer "graphviz" / "plantuml" when you want vector text. Rendering uses
     the public https://kroki.io by default — set KROKI_BASE_URL to a

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -1182,10 +1182,13 @@ async def push_latex(
     latex_text: str,
     latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
 ) -> dict[str, Any]:
-    """Push the LaTeX document and figures to the experiment repository.
+    """Push the LaTeX document to the experiment repository.
 
-    Uploads the LaTeX source (from `generate_latex`) and prepares the images
-    so that `compile_latex` can build the PDF. Requires GH_PERSONAL_ACCESS_TOKEN.
+    Uploads the LaTeX source (from `generate_latex`) as
+    `.research/latex/{template}/main.tex`. Figures need no separate step:
+    `compile_latex` and `open_in_overleaf` pick up every figure PDF under
+    `.research/results/` and `.research/diagrams/` automatically.
+    Requires GH_PERSONAL_ACCESS_TOKEN.
     """
     result = (
         await PushLatexSubgraph(
@@ -1206,7 +1209,6 @@ async def push_latex(
     )
     return {
         "is_upload_successful": result["is_upload_successful"],
-        "is_images_prepared": result["is_images_prepared"],
     }
 
 
@@ -1253,16 +1255,23 @@ def open_in_overleaf(
     repository_name: str,
     branch_name: str,
     latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
+    local_path: str | None = None,
 ) -> dict[str, Any]:
     """Create a link that opens the paper in Overleaf for editing.
 
     Returns `overleaf_url`, which must be shown to the user as a clickable
-    link. Opening it in a browser downloads the LaTeX project pushed by
-    `push_latex` (main.tex, bibliography, figures, template assets) from the
-    experiment repository and submits it to Overleaf, creating a new project
-    in the user's Overleaf account (login required; each click creates a new
-    project). Starts the local dashboard API in the background if needed.
-    Requires GH_PERSONAL_ACCESS_TOKEN; private repositories work too.
+    link. Opening it in a browser packages the LaTeX project (main.tex,
+    bibliography, template assets, plus every figure PDF under
+    `.research/results/` and `.research/diagrams/` mapped into `images/`)
+    and submits it to Overleaf, creating a new project in the user's
+    Overleaf account (login required; each click creates a new project).
+
+    By default the project is read from the experiment repository on GitHub
+    (push_latex must have run; requires GH_PERSONAL_ACCESS_TOKEN, private
+    repositories work). Pass `local_path` — the absolute path of your local
+    clone — to read the working tree on disk instead: no push needed, and
+    locally rendered figures are included as-is. Starts the local dashboard
+    API in the background if needed.
     """
     refresh_environment()
 
@@ -1272,14 +1281,15 @@ def open_in_overleaf(
         start_dashboard(port)
         dashboard_status = "started"
 
-    params = urlencode(
-        {
-            "github_owner": github_owner,
-            "repository_name": repository_name,
-            "branch_name": branch_name,
-            "latex_template_name": latex_template_name,
-        }
-    )
+    query: dict[str, str] = {
+        "github_owner": github_owner,
+        "repository_name": repository_name,
+        "branch_name": branch_name,
+        "latex_template_name": latex_template_name,
+    }
+    if local_path:
+        query["local_path"] = local_path
+    params = urlencode(query)
     overleaf_url = f"{dashboard_url(port)}/airas/v1/latex/overleaf?{params}"
     return {
         "overleaf_url": overleaf_url,

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -968,15 +968,17 @@ def _resolve_render_output(output_path: str) -> tuple[Path, str]:
 
 
 def _png_to_pdf(png: bytes) -> bytes:
-    image = Image.open(BytesIO(png))
-    if image.mode != "RGB":
-        # Flatten transparency onto white instead of the black that a
-        # plain RGB conversion would produce.
-        rgba = image.convert("RGBA")
-        image = Image.new("RGB", rgba.size, (255, 255, 255))
-        image.paste(rgba, mask=rgba.getchannel("A"))
     buffer = BytesIO()
-    image.save(buffer, format="PDF")
+    with Image.open(BytesIO(png)) as image:
+        if image.mode != "RGB":
+            # Flatten transparency onto white instead of the black that a
+            # plain RGB conversion would produce.
+            rgba = image.convert("RGBA")
+            rgb = Image.new("RGB", rgba.size, (255, 255, 255))
+            rgb.paste(rgba, mask=rgba.getchannel("A"))
+        else:
+            rgb = image.copy()
+    rgb.save(buffer, format="PDF")
     return buffer.getvalue()
 
 

--- a/backend/src/airas/usecases/executors/fetch_experiment_results_subgraph/nodes/fetch_results.py
+++ b/backend/src/airas/usecases/executors/fetch_experiment_results_subgraph/nodes/fetch_results.py
@@ -140,17 +140,28 @@ async def _process_comparison_data(
 async def _fetch_diagram_files(
     github_client: GithubClient,
     github_config: GitHubConfig,
-    diagrams_dir: str = ".research/diagrams",
+    diagrams_dirs: tuple[str, ...] = (
+        ".research/results/diagram",  # current convention
+        ".research/diagrams",  # legacy location, kept for older repositories
+    ),
 ) -> list[str]:
-    files = await _fetch_file_paths(
-        github_client,
-        github_config.github_owner,
-        github_config.repository_name,
-        diagrams_dir,
-        github_config.branch_name,
+    per_dir = await asyncio.gather(
+        *(
+            _fetch_file_paths(
+                github_client,
+                github_config.github_owner,
+                github_config.repository_name,
+                diagrams_dir,
+                github_config.branch_name,
+            )
+            for diagrams_dir in diagrams_dirs
+        )
     )
+    files = [f for dir_files in per_dir for f in dir_files]
     if files:
-        logger.info(f"Retrieved {len(files)} diagram files from {diagrams_dir}")
+        logger.info(
+            f"Retrieved {len(files)} diagram files from {', '.join(diagrams_dirs)}"
+        )
     return files
 
 

--- a/backend/src/airas/usecases/generators/dispatch_diagram_generation_subgraph/dispatch_diagram_generation_subgraph.py
+++ b/backend/src/airas/usecases/generators/dispatch_diagram_generation_subgraph/dispatch_diagram_generation_subgraph.py
@@ -70,6 +70,9 @@ class DispatchDiagramGenerationSubgraph:
             "branch_name": github_config.branch_name,
             "github_actions_agent": github_actions_agent,
             "model_name": self.llm_mapping.dispatch_diagram_generation.llm_name,
+            # Align with the local-agent convention: method diagrams live
+            # under .research/results/diagram/ (collected into images/).
+            "output_dir": ".research/results/diagram",
         }
 
         if self.diagram_description is not None:

--- a/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
+++ b/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
@@ -134,6 +134,7 @@ def collect_latex_project_files_local(
 def _require_main_tex(latex_files: dict[str, bytes], prefix: str, source: str) -> None:
     if "main.tex" not in latex_files:
         raise ValueError(
-            f"main.tex not found under {prefix} in {source}. Run push_latex "
-            "first (or, for a local clone, write main.tex there)."
+            f"main.tex not found under {prefix} in {source}. Write the "
+            "generated LaTeX there first (push it with git, or for a local "
+            "clone just save the file)."
         )

--- a/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
+++ b/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
@@ -19,6 +19,18 @@ _EXCLUDED_FILES = {"template.tex", "template.pdf"}
 _FIGURE_SOURCE_DIRS = (".research/results/", ".research/diagrams/")
 
 
+def _is_safe_local_file(path: Path, containing_dir: Path) -> bool:
+    # Symlinks could point outside the repository (e.g. at secrets) and the
+    # contents end up in the zip handed to Overleaf, so only read regular
+    # files whose real location stays inside the directory being collected.
+    if path.is_symlink() or not path.is_file():
+        return False
+    if not path.resolve().is_relative_to(containing_dir.resolve()):
+        logger.warning(f"Skipping file outside the collected directory: {path}")
+        return False
+    return True
+
+
 def _is_unsafe_relative_path(relative_path: str) -> bool:
     # Guard against zip-slip style entries: the paths end up inside the
     # zip handed to Overleaf, so never pass through empty, absolute, or
@@ -75,7 +87,11 @@ def collect_latex_project_files(
                     )
                     continue
                 latex_files[relative_path] = archive.read(info)
-            elif repo_path.startswith(_FIGURE_SOURCE_DIRS):
+            elif repo_path.startswith(
+                _FIGURE_SOURCE_DIRS
+            ) and repo_path.lower().endswith(".pdf"):
+                # Only figure PDFs are read: these directories can also hold
+                # large experiment artifacts that must not be loaded here.
                 if _is_unsafe_relative_path(repo_path):
                     logger.warning(
                         f"Skipping suspicious path in repository zip: {info.filename}"
@@ -109,7 +125,7 @@ def collect_latex_project_files_local(
     latex_files: dict[str, bytes] = {}
     if latex_dir.is_dir():
         for path in sorted(latex_dir.rglob("*")):
-            if not path.is_file():
+            if not _is_safe_local_file(path, latex_dir):
                 continue
             relative_path = path.relative_to(latex_dir).as_posix()
             if relative_path in _EXCLUDED_FILES:
@@ -121,7 +137,7 @@ def collect_latex_project_files_local(
         if not figure_root.is_dir():
             continue
         for path in sorted(figure_root.rglob("*.pdf")):
-            if not path.is_file():
+            if not _is_safe_local_file(path, figure_root):
                 continue
             repo_path = source_dir + path.relative_to(figure_root).as_posix()
             _merge_figure(latex_files, repo_path, path.read_bytes())

--- a/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
+++ b/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
@@ -1,6 +1,7 @@
 import io
 import logging
 import zipfile
+from pathlib import Path
 
 from airas.core.types.github import GitHubConfig
 from airas.core.types.latex import LATEX_TEMPLATE_NAME
@@ -12,12 +13,43 @@ logger = logging.getLogger(__name__)
 # leaving template.tex in the project confuses Overleaf's main-file detection.
 _EXCLUDED_FILES = {"template.tex", "template.pdf"}
 
+# Figure sources are merged into the project's images/ directory at export
+# time (structure preserved), so nothing has to be copied into the LaTeX
+# directory beforehand. Generated LaTeX references figures as images/<path>.
+_FIGURE_SOURCE_DIRS = (".research/results/", ".research/diagrams/")
+
+
+def _is_unsafe_relative_path(relative_path: str) -> bool:
+    # Guard against zip-slip style entries: the paths end up inside the
+    # zip handed to Overleaf, so never pass through empty, absolute, or
+    # parent-escaping paths.
+    return (
+        not relative_path
+        or relative_path.startswith("/")
+        or ".." in relative_path.split("/")
+    )
+
+
+def _merge_figure(
+    latex_files: dict[str, bytes], repo_path: str, content: bytes
+) -> None:
+    if not repo_path.lower().endswith(".pdf"):
+        return
+    for source_dir in _FIGURE_SOURCE_DIRS:
+        if repo_path.startswith(source_dir):
+            image_path = f"images/{repo_path[len(source_dir) :]}"
+            # Files already in the LaTeX directory win (explicitly placed).
+            if image_path not in latex_files:
+                latex_files[image_path] = content
+            return
+
 
 def collect_latex_project_files(
     github_config: GitHubConfig,
     latex_template_name: LATEX_TEMPLATE_NAME,
     github_client: GithubClient,
 ) -> dict[str, bytes]:
+    """Collect the LaTeX project from the repository on GitHub."""
     repo_zip = github_client.download_repository_zip(
         github_owner=github_config.github_owner,
         repository_name=github_config.repository_name,
@@ -27,36 +59,81 @@ def collect_latex_project_files(
     # GitHub zipball entries are prefixed with a "{repo}-{sha}/" directory.
     prefix = f".research/latex/{latex_template_name}/"
     latex_files: dict[str, bytes] = {}
+    figure_entries: list[tuple[str, bytes]] = []
     with zipfile.ZipFile(io.BytesIO(repo_zip)) as archive:
         for info in archive.infolist():
             if info.is_dir():
                 continue
             _, _, repo_path = info.filename.partition("/")
-            if not repo_path.startswith(prefix):
-                continue
-            relative_path = repo_path[len(prefix) :]
-            if relative_path in _EXCLUDED_FILES:
-                continue
-            # Guard against zip-slip style entries: the paths end up inside the
-            # zip handed to Overleaf, so never pass through empty, absolute, or
-            # parent-escaping paths.
-            if (
-                not relative_path
-                or relative_path.startswith("/")
-                or ".." in relative_path.split("/")
-            ):
-                logger.warning(
-                    f"Skipping suspicious path in repository zip: {info.filename}"
-                )
-                continue
-            latex_files[relative_path] = archive.read(info)
+            if repo_path.startswith(prefix):
+                relative_path = repo_path[len(prefix) :]
+                if relative_path in _EXCLUDED_FILES:
+                    continue
+                if _is_unsafe_relative_path(relative_path):
+                    logger.warning(
+                        f"Skipping suspicious path in repository zip: {info.filename}"
+                    )
+                    continue
+                latex_files[relative_path] = archive.read(info)
+            elif repo_path.startswith(_FIGURE_SOURCE_DIRS):
+                if _is_unsafe_relative_path(repo_path):
+                    logger.warning(
+                        f"Skipping suspicious path in repository zip: {info.filename}"
+                    )
+                    continue
+                figure_entries.append((repo_path, archive.read(info)))
 
-    if "main.tex" not in latex_files:
-        raise ValueError(
-            f"main.tex not found under {prefix} in "
-            f"{github_config.github_owner}/{github_config.repository_name}"
-            f"@{github_config.branch_name}. Run push_latex first."
-        )
+    for repo_path, content in figure_entries:
+        _merge_figure(latex_files, repo_path, content)
 
+    _require_main_tex(latex_files, prefix, source=github_config.repository_name)
     logger.info(f"Collected {len(latex_files)} LaTeX project files from {prefix}")
     return latex_files
+
+
+def collect_latex_project_files_local(
+    local_repo_path: str,
+    latex_template_name: LATEX_TEMPLATE_NAME,
+) -> dict[str, bytes]:
+    """Collect the LaTeX project from a local clone's working tree.
+
+    Reads the current state on disk (no push required), so figures rendered
+    locally (e.g. by render_chart / render_diagram) are included as-is.
+    """
+    root = Path(local_repo_path).expanduser().resolve()
+    if not root.is_dir():
+        raise ValueError(f"local_repo_path is not a directory: {root}")
+
+    prefix = f".research/latex/{latex_template_name}/"
+    latex_dir = root / ".research" / "latex" / latex_template_name
+    latex_files: dict[str, bytes] = {}
+    if latex_dir.is_dir():
+        for path in sorted(latex_dir.rglob("*")):
+            if not path.is_file():
+                continue
+            relative_path = path.relative_to(latex_dir).as_posix()
+            if relative_path in _EXCLUDED_FILES:
+                continue
+            latex_files[relative_path] = path.read_bytes()
+
+    for source_dir in _FIGURE_SOURCE_DIRS:
+        figure_root = root / source_dir.rstrip("/")
+        if not figure_root.is_dir():
+            continue
+        for path in sorted(figure_root.rglob("*.pdf")):
+            if not path.is_file():
+                continue
+            repo_path = source_dir + path.relative_to(figure_root).as_posix()
+            _merge_figure(latex_files, repo_path, path.read_bytes())
+
+    _require_main_tex(latex_files, prefix, source=str(root))
+    logger.info(f"Collected {len(latex_files)} LaTeX project files from {latex_dir}")
+    return latex_files
+
+
+def _require_main_tex(latex_files: dict[str, bytes], prefix: str, source: str) -> None:
+    if "main.tex" not in latex_files:
+        raise ValueError(
+            f"main.tex not found under {prefix} in {source}. Run push_latex "
+            "first (or, for a local clone, write main.tex there)."
+        )

--- a/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/open_in_overleaf_subgraph.py
+++ b/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/open_in_overleaf_subgraph.py
@@ -49,10 +49,14 @@ class OpenInOverleafSubgraphState(
 class OpenInOverleafSubgraph:
     def __init__(
         self,
-        github_client: GithubClient,
+        github_client: GithubClient | None,
         latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
         local_repo_path: str | None = None,
     ):
+        if github_client is None and local_repo_path is None:
+            raise ValueError(
+                "github_client is required unless local_repo_path is provided"
+            )
         self.github_client = github_client
         self.latex_template_name = latex_template_name
         self.local_repo_path = local_repo_path
@@ -67,6 +71,7 @@ class OpenInOverleafSubgraph:
                 latex_template_name=cast(LATEX_TEMPLATE_NAME, self.latex_template_name),
             )
         else:
+            assert self.github_client is not None  # enforced in __init__
             latex_files = collect_latex_project_files(
                 github_config=state["github_config"],
                 latex_template_name=cast(LATEX_TEMPLATE_NAME, self.latex_template_name),

--- a/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/open_in_overleaf_subgraph.py
+++ b/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/open_in_overleaf_subgraph.py
@@ -14,6 +14,7 @@ from airas.usecases.publication.open_in_overleaf_subgraph.nodes.build_overleaf_e
 )
 from airas.usecases.publication.open_in_overleaf_subgraph.nodes.collect_latex_project_files import (
     collect_latex_project_files,
+    collect_latex_project_files_local,
 )
 
 setup_logging()
@@ -39,30 +40,38 @@ class OpenInOverleafSubgraphState(
 
 
 # NOTE: Overleaf 自体は GitHub を要求しない（zip を base64 の data URL としてブラウザから
-# POST するだけ）が、このサブグラフは実験リポジトリの .research/latex/{template}/ に
-# push_latex 済みであることを前提にしている。main.tex・図版（GitHub Actions の実験成果物）・
-# テンプレート資材（.cls / .bst 等）がそこに揃っているため。
-# TODO: push_latex 前でも使えるように、latex_text を直接受け取る変種も検討する。
-# その場合テンプレート資材は airas-org/airas-template から取得できるが、図版は手元に
-# ないため含められない（\includegraphics が壊れた状態で Overleaf に渡る）。
+# POST するだけ）。ソースは2系統:
+# - GitHub モード: 実験リポジトリの .research/latex/{template}/ に push_latex 済みであること
+#   が前提（main.tex とテンプレート資材が揃っているため）
+# - ローカルモード (local_repo_path): clone のワーキングツリーをそのまま読む。push 不要
+# どちらのモードでも、図版は .research/results/ と .research/diagrams/ の *.pdf を
+# エクスポート時に images/ 配下へマージする（事前コピーのコミットは不要）。
 class OpenInOverleafSubgraph:
     def __init__(
         self,
         github_client: GithubClient,
         latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
+        local_repo_path: str | None = None,
     ):
         self.github_client = github_client
         self.latex_template_name = latex_template_name
+        self.local_repo_path = local_repo_path
 
     @record_execution_time
     def _collect_latex_project_files(
         self, state: OpenInOverleafSubgraphState
     ) -> dict[str, dict[str, bytes] | list[str]]:
-        latex_files = collect_latex_project_files(
-            github_config=state["github_config"],
-            latex_template_name=cast(LATEX_TEMPLATE_NAME, self.latex_template_name),
-            github_client=self.github_client,
-        )
+        if self.local_repo_path:
+            latex_files = collect_latex_project_files_local(
+                local_repo_path=self.local_repo_path,
+                latex_template_name=cast(LATEX_TEMPLATE_NAME, self.latex_template_name),
+            )
+        else:
+            latex_files = collect_latex_project_files(
+                github_config=state["github_config"],
+                latex_template_name=cast(LATEX_TEMPLATE_NAME, self.latex_template_name),
+                github_client=self.github_client,
+            )
         return {
             "latex_files": latex_files,
             "file_names": sorted(latex_files),

--- a/backend/src/airas/usecases/publication/push_latex_subgraph/push_latex_subgraph.py
+++ b/backend/src/airas/usecases/publication/push_latex_subgraph/push_latex_subgraph.py
@@ -9,7 +9,6 @@ from airas.core.logging_utils import setup_logging
 from airas.core.types.github import GitHubConfig
 from airas.core.types.latex import LATEX_TEMPLATE_NAME
 from airas.infra.github_client import GithubClient
-from airas.usecases.github.nodes.dispatch_workflow import dispatch_workflow
 from airas.usecases.publication.push_latex_subgraph.nodes.upload_latex_file import (
     upload_latex_file,
 )
@@ -26,7 +25,6 @@ class PushLatexSubgraphInputState(TypedDict):
 
 class PushLatexSubgraphOutputState(ExecutionTimeState):
     is_upload_successful: bool
-    is_images_prepared: bool
 
 
 class PushLatexSubgraphState(
@@ -37,6 +35,9 @@ class PushLatexSubgraphState(
     pass
 
 
+# NOTE: Figures are no longer copied into the LaTeX directory here. The
+# compile workflow and the Overleaf export materialize every figure PDF from
+# .research/results/ and .research/diagrams/ into images/ at run time.
 class PushLatexSubgraph:
     def __init__(
         self,
@@ -57,24 +58,6 @@ class PushLatexSubgraph:
         )
         return {"is_upload_successful": is_upload_successful}
 
-    @record_execution_time
-    async def _prepare_images_for_latex(
-        self, state: PushLatexSubgraphState
-    ) -> dict[str, bool]:
-        is_images_prepared = await dispatch_workflow(
-            github_client=self.github_client,
-            github_owner=state["github_config"].github_owner,
-            repository_name=state["github_config"].repository_name,
-            branch_name=state["github_config"].branch_name,
-            workflow_file="prepare_images_for_latex.yml",
-            inputs={
-                "branch_name": state["github_config"].branch_name,
-                "subdir": self.latex_template_name,
-            },
-        )
-
-        return {"is_images_prepared": is_images_prepared}
-
     def build_graph(self):
         graph_builder = StateGraph(
             PushLatexSubgraphState,
@@ -83,12 +66,8 @@ class PushLatexSubgraph:
         )
 
         graph_builder.add_node("upload_latex_file", self._upload_latex_file)
-        graph_builder.add_node(
-            "prepare_images_for_latex", self._prepare_images_for_latex
-        )
 
         graph_builder.add_edge(START, "upload_latex_file")
-        graph_builder.add_edge("upload_latex_file", "prepare_images_for_latex")
-        graph_builder.add_edge("prepare_images_for_latex", END)
+        graph_builder.add_edge("upload_latex_file", END)
 
         return graph_builder.compile()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -128,6 +128,7 @@ dependencies = [
     { name = "nltk" },
     { name = "openai" },
     { name = "pandas" },
+    { name = "pillow" },
     { name = "pymupdf" },
     { name = "pynacl" },
     { name = "pypdf" },
@@ -142,6 +143,7 @@ dependencies = [
     { name = "tomli-w" },
     { name = "typing-extensions" },
     { name = "uvicorn" },
+    { name = "vl-convert-python" },
     { name = "wandb" },
 ]
 
@@ -183,6 +185,7 @@ requires-dist = [
     { name = "nltk", specifier = ">=3.9.2" },
     { name = "openai", specifier = ">=1.35.13" },
     { name = "pandas", specifier = ">=2.3.0" },
+    { name = "pillow", specifier = ">=12.3.0" },
     { name = "pymupdf", specifier = ">=1.25.5" },
     { name = "pynacl", specifier = ">=1.6.0" },
     { name = "pypdf", specifier = ">=4.3.1" },
@@ -197,6 +200,7 @@ requires-dist = [
     { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
     { name = "uvicorn", specifier = ">=0.34.2" },
+    { name = "vl-convert-python", specifier = ">=1.9.0.post1" },
     { name = "wandb", specifier = ">=0.22.2" },
 ]
 provides-extras = ["mcp"]
@@ -2949,6 +2953,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/c2/669d88644cddb1485bd9534e63e8cf476c8e51cb3c3a1297677023505c0e/pillow-12.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:6c0016e7b354317c4e9e525b937ac8596c38d2d232b419529b9cd7a1cd46e39a", size = 5392418, upload-time = "2026-07-01T11:53:27.808Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ba/3762f376a2948e3036488d773a146e0ae6ecc2ca03ac20e2615bd0b2ba02/pillow-12.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bcc33feacfaefce60c12fd500a277533bdc02b10a19f7f6d348763d8140bbba7", size = 4785287, upload-time = "2026-07-01T11:53:29.761Z" },
+    { url = "https://files.pythonhosted.org/packages/07/50/b5d688cc9c52d4482f3d5bcab6ce20bc2a74a85d2343841c907444a3be2c/pillow-12.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5594fc43d548a7ed94949d139aa1341b270f1863f11cfd37f5a6c8b778a6b67f", size = 6253754, upload-time = "2026-07-01T11:53:32.298Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/89/36f4cd76cf4baf05c50ababb976249153f18c959171c7f6ba09a6f217260/pillow-12.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0606c8bf2cdefea14a43530f7657cbbb7ecf1c4222512492ef4a4434a9501ec", size = 6925605, upload-time = "2026-07-01T11:53:34.487Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/c0/4de58cf6633b9e3a6061ef4be6fb91fc3c90b812ece886f531e3c523d777/pillow-12.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:85f998ea1848bc6757289e739cfbdda3a04adfd58b02fc018ce54d754a5ce468", size = 6327788, upload-time = "2026-07-01T11:53:36.433Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/14d53682a19550dbbaf3b598f807d5457646c510805a44c7d7891cd1cd1a/pillow-12.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:25b9b82bb22e6e2b3cd07b39c68b7b862001226cb3dff7130d1cb914121b39ed", size = 7036288, upload-time = "2026-07-01T11:53:38.712Z" },
+    { url = "https://files.pythonhosted.org/packages/38/1d/36279e3c77efe034e4cc2b0393ee74ffdb5a62391dacbf9b916154f5f0b8/pillow-12.3.0-cp310-cp310-win32.whl", hash = "sha256:37dc8f7bbb66efe481bb60defacef820c950c24713fb44962ed6aa2a50966de1", size = 6472396, upload-time = "2026-07-01T11:53:40.781Z" },
+    { url = "https://files.pythonhosted.org/packages/48/7c/8fa0039574c476d7c6fa57dd7c32a130436877c6ec1e5ce1cc8ec44878c1/pillow-12.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:300557495eb45ebb8aec96c2da9c4be642fbf7cd937278b4013ba894ea8eb0eb", size = 7226887, upload-time = "2026-07-01T11:53:42.764Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/17/e324be141d173c1c919428066c3259f21c1b8982e564e01a4a81e96dbdcf/pillow-12.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:514435a37670e3e5e08f3945b68718b6ed329bb84367777e16f9f4dfe1e61a0f", size = 2568039, upload-time = "2026-07-01T11:53:45.372Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c8/0a78b0e02d7ac54bc03e5321c9220da52f0c2ea83b21f7c40e7f3169c502/pillow-12.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:00808c5e14ef63ac5161091d242999076604ff74b883423a11e5d7bbb38bf756", size = 5392415, upload-time = "2026-07-01T11:53:47.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/5b/a02d30018abd97ced9f5a6c63d28597694a00d066516b9c1c6de45859fc9/pillow-12.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:37d6d0a00072fd2948eb22bce7e1475f34569d90c87c59f7a2ec59541b77f7a6", size = 4785266, upload-time = "2026-07-01T11:53:49.079Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/98/766667a4be768150a202836acd9fad19c06824ca86c4286d3cf6b274964e/pillow-12.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bcb46e2f9feff8d06323983bd83ed00c201fdcab3d74973e7072a889b3979fcd", size = 6263814, upload-time = "2026-07-01T11:53:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2d/ede717bc1144f63886c21fd349bb95860b0d1a21149ff16f2bb362b612b6/pillow-12.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23d27a3e0307ec2244cc51e7287b919aa68d097504ebe19df4e76a98a3eea5bd", size = 6934408, upload-time = "2026-07-01T11:53:53.487Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/48/9c58b685e69d49c31af6c8eb9012055fab7e665785165c84796e2c73ce72/pillow-12.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4f883547d4b7f0495ebe7056b0cc2aea76094e7a4abc8e933540f3271df27d9c", size = 6337160, upload-time = "2026-07-01T11:53:55.457Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/fa/dc2a5c0ba6df93f67c31d34b808b7ce440b40cdbf96f0b81cde1d1e6fa93/pillow-12.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:236ff70b9312fb68943c703aa842ca6a758abfa45ac187a5e7c1452e96ef72b5", size = 7045172, upload-time = "2026-07-01T11:53:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a5/444817a4d4c4c2417df00513086ca196f388d8f9ef40c2e4ccd1ad1af54b/pillow-12.3.0-cp311-cp311-win32.whl", hash = "sha256:10e41f0fbf1eec8cfd234b8fe17a4caac7c9d0db4c204d3c173a8f9f6ef3232b", size = 6472232, upload-time = "2026-07-01T11:53:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c6/4bad1b18d132a50b27e1365e1ab163616f7a5bb56d330f66f9d1d9d4f9d4/pillow-12.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:8e95e1385e4998ae9694eeaa4730ba5457ff61185b3a55e2e7bea0880aef452a", size = 7233653, upload-time = "2026-07-01T11:54:02.066Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/16/00f91ab7760dc842f5aad55217e80fc4a7067a0604535249bc8a2d6d9870/pillow-12.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:ebaea975e03d3141d9d3a507df75c9b3ec90fa9d2ffd07567b3a978d9d790b26", size = 2568195, upload-time = "2026-07-01T11:54:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/37/bf/fb3ebff8ddcb76aac5a01389251bbbb9519922a9b520d8247c1ca864a25d/pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965", size = 5345969, upload-time = "2026-07-01T11:54:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7", size = 4780323, upload-time = "2026-07-01T11:54:09.351Z" },
+    { url = "https://files.pythonhosted.org/packages/25/27/ac8f99618ffd3dde21db0f4d4b1d2ab00c0880595bfd17df103f7f39fd0c/pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9", size = 6266838, upload-time = "2026-07-01T11:54:11.71Z" },
+    { url = "https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91", size = 6940830, upload-time = "2026-07-01T11:54:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/51/8b08617af3ad95e33ce6d7dd2c99ed6c8298f7fb131636303956be022e25/pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c", size = 6344383, upload-time = "2026-07-01T11:54:15.756Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/cf78ac9780bb93c28328f408973845a309d4d145041665f734572ced1b52/pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df", size = 7052934, upload-time = "2026-07-01T11:54:17.721Z" },
+    { url = "https://files.pythonhosted.org/packages/20/20/25e0f4dc178a6bc0696793720055519a0de89e7661dae886992decbd2f81/pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f", size = 6472684, upload-time = "2026-07-01T11:54:19.839Z" },
+    { url = "https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09", size = 7227137, upload-time = "2026-07-01T11:54:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/de/47/4845a0a6c0dbf1db8456bd9fc791f13c5ced7ced20606d08a0aacfd25b49/pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510", size = 2568267, upload-time = "2026-07-01T11:54:24.051Z" },
+    { url = "https://files.pythonhosted.org/packages/75/18/2e8b40223153ccbc60df07f9e8928dc0c76202aa4e55ae9f53962b6510d6/pillow-12.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b3c777e849237620b022f7f297dd67705f9f5cf1685f09f02e46f93e92725468", size = 5302510, upload-time = "2026-07-01T11:56:25.736Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3e/51fabf59d5ab801ceab709453d3ab6b180083496579549de4c45ced6528a/pillow-12.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b343699e8308bdc51978310e1c959c584e7869cc8c40780058c87da7781a1e94", size = 4736058, upload-time = "2026-07-01T11:56:28.041Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/20/22fe9384b7949e25fb1293bcfc84fb82590ff4ea6b37c95b24d26d793d86/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbd139c8447d25dd750ab79ee274cc5e1fe80fc56340ab10b18a195e1b6eca3e", size = 5237776, upload-time = "2026-07-01T11:56:30.263Z" },
+    { url = "https://files.pythonhosted.org/packages/08/14/f6ba68107680ffa74b39985f3f30884e41318fbc4250caa423c79b4788bb/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7e480451b9fa137494bccd3a7d69adbe8ac65a87d97be61e11f1b1050a5bac3", size = 5860358, upload-time = "2026-07-01T11:56:32.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0169bc772ec491108b62f644f8ecf1fe5d8ae5ebafde2ee2142210166903/pillow-12.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a", size = 7231786, upload-time = "2026-07-01T11:56:35.046Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4317,6 +4361,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258, upload-time = "2026-01-09T18:20:59.425Z" },
+]
+
+[[package]]
+name = "vl-convert-python"
+version = "1.9.0.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/89/36722344d1758ec2106f4e8eca980f173cfe8f8d0358c1b77cc5d2e035a4/vl_convert_python-1.9.0.post1.tar.gz", hash = "sha256:a5b06b3128037519001166f5341ec7831e19fbd7f3a5f78f73d557ac2d5859ef", size = 4663469, upload-time = "2026-01-21T00:09:55.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/59/e5862245972ff467d38b0eb5ad28154685e23ecabb47e14f2b6962da7b56/vl_convert_python-1.9.0.post1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:43e9515f65bbcd317d1ef328787fd7bf0344c2fde9292eb7a0e64d5d3d29fccb", size = 30512930, upload-time = "2026-01-21T00:09:43.198Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e6/e7d0b538c2f0daaf120901dc113bd5d5d1fa51a9532fa5ffd90234e8c69e/vl_convert_python-1.9.0.post1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:b0e7a3245f32addec7e7abeb1badf72b1513ed71ba1dba7aca853901217b3f4e", size = 29738742, upload-time = "2026-01-21T00:09:46.016Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e2/5645a1bc174c53ff8cd305ed76a4a76ba36e155302db20b42b7e78daeef8/vl_convert_python-1.9.0.post1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6ecfe4b7e2ea9e8c30fd6d6eaea3ef85475be1ad249407d9796dce4ecdb5b32", size = 33366278, upload-time = "2026-01-21T00:09:48.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/18/88e02899b72fa8273ffb32bde12b0e5776ee0fd9fb29559a49c48ec4c5fa/vl_convert_python-1.9.0.post1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c1558fa0055e88c465bd3d71760cde9fa2c94a95f776a0ef9178252fd820b1f", size = 33520215, upload-time = "2026-01-21T00:09:50.992Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/db/6e8616587035bf0745d0f10b1791c7e945180ac5d6b28677d2f2b3ca693c/vl_convert_python-1.9.0.post1-cp37-abi3-win_amd64.whl", hash = "sha256:7e263269ac0d304640ca842b44dfe430ed863accd9edecff42e279bfc48ce940", size = 32051516, upload-time = "2026-01-21T00:09:53.47Z" },
 ]
 
 [[package]]

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -82,6 +82,8 @@ Or add it to your project's `.mcp.json`:
 | `fetch_experiment_results` | Fetch experiment results |
 | `download_workflow_artifacts` | Download artifacts of a specific workflow run |
 | `analyze_experiment` | Analyze results against the hypothesis and design |
+| `render_chart` | Render a Vega-Lite spec to a figure file (PDF/SVG/PNG) locally; no API keys required |
+| `render_diagram` | Render a text diagram (mermaid, graphviz, d2, plantuml, …) via Kroki; no API keys required |
 | `push_files` | Push arbitrary files to the experiment repository |
 
 ### Paper writing & publication
@@ -119,8 +121,10 @@ Headless pipelines (the built-in autonomous research workflows) still generate c
 Result figures and method diagrams are also created by the MCP host itself rather than on GitHub Actions:
 
 1. Fetch the experiment results with `fetch_experiment_results` (or read them from your local clone; `fetch_run_ids` lists the runs).
-2. Generate result figures locally (e.g. with matplotlib) and save them as PDFs under `.research/results/` in the clone. Save method diagrams under `.research/diagrams/`.
+2. Build a Vega-Lite spec from the results and render it with `render_chart`, saving the PDF under `.research/results/` in the clone. For method diagrams, write the diagram as text (mermaid, graphviz, d2, …) and render it with `render_diagram` into `.research/diagrams/`. (Generating figures yourself, e.g. with matplotlib, works too — only the output location matters.)
 3. Commit and push them with git. `push_latex` and the LaTeX build collect every `*.pdf` from those two directories into the paper's `images/` directory.
+
+`render_chart` renders entirely locally. `render_diagram` uses the public https://kroki.io by default; set `KROKI_BASE_URL` to a self-hosted Kroki instance to keep unpublished diagrams on-premises.
 
 As with code generation, the autonomous research workflows still run visualization and diagram generation on GitHub Actions; those paths are not exposed as MCP tools.
 

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -121,8 +121,8 @@ Headless pipelines (the built-in autonomous research workflows) still generate c
 Result figures and method diagrams are also created by the MCP host itself rather than on GitHub Actions:
 
 1. Fetch the experiment results with `fetch_experiment_results` (or read them from your local clone; `fetch_run_ids` lists the runs).
-2. Build a Vega-Lite spec from the results and render it with `render_chart`, saving the PDF under `.research/results/` in the clone. For method diagrams, write the diagram as text (mermaid, graphviz, d2, …) and render it with `render_diagram` into `.research/diagrams/`. (Generating figures yourself, e.g. with matplotlib, works too — only the output location matters.)
-3. Commit and push them with git. `push_latex` and the LaTeX build collect every `*.pdf` from those two directories into the paper's `images/` directory.
+2. Build a Vega-Lite spec from the results and render it with `render_chart`, saving the PDF under `.research/results/chart/` in the clone. For method diagrams, write the diagram as text (mermaid, graphviz, d2, …) and render it with `render_diagram` into `.research/results/diagram/`. (Generating figures yourself, e.g. with matplotlib, works too — only the output location matters.)
+3. Commit and push them with git. `push_latex` and the LaTeX build collect every `*.pdf` under `.research/results/` (and `.research/diagrams/`) into the paper's `images/` directory.
 
 `render_chart` renders entirely locally. `render_diagram` uses the public https://kroki.io by default; set `KROKI_BASE_URL` to a self-hosted Kroki instance to keep unpublished diagrams on-premises.
 

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -93,8 +93,9 @@ Or add it to your project's `.mcp.json`:
 | `generate_bibfile` | Generate a BibTeX references file from research studies; no API key required |
 | `generate_paper` | Write structured paper content (title, abstract, sections) from the completed research |
 | `generate_latex` | Convert paper content into a full LaTeX document (templates: mdpi / iclr2024 / agents4science_2025) |
-| `push_latex` | Push the LaTeX source and figures to the experiment repository |
-| `compile_latex` | Build the paper PDF on GitHub Actions (async) |
+| `push_latex` | Push the LaTeX source to the experiment repository |
+| `compile_latex` | Build the paper PDF on GitHub Actions (async); figures are picked up from `.research/results/` and `.research/diagrams/` automatically |
+| `open_in_overleaf` | Create a link that opens the paper in Overleaf; pass `local_path` to export the local working tree without pushing |
 
 ### Research history persistence
 
@@ -122,7 +123,7 @@ Result figures and method diagrams are also created by the MCP host itself rathe
 
 1. Fetch the experiment results with `fetch_experiment_results` (or read them from your local clone; `fetch_run_ids` lists the runs).
 2. Build a Vega-Lite spec from the results and render it with `render_chart`, saving the PDF under `.research/results/chart/` in the clone. For method diagrams, write the diagram as text (mermaid, graphviz, d2, …) and render it with `render_diagram` into `.research/results/diagram/`. (Generating figures yourself, e.g. with matplotlib, works too — only the output location matters.)
-3. Commit and push them with git. `push_latex` and the LaTeX build collect every `*.pdf` under `.research/results/` (and `.research/diagrams/`) into the paper's `images/` directory.
+3. Commit and push them with git. No copy step is needed: `compile_latex` and `open_in_overleaf` automatically pick up every figure PDF under `.research/results/` and `.research/diagrams/`, exposed to LaTeX as `images/<path relative to that directory>` (e.g. `.research/results/chart/loss.pdf` → `images/chart/loss.pdf`) with the directory structure preserved. Reference figures accordingly in the paper.
 
 `render_chart` renders entirely locally. `render_diagram` uses the public https://kroki.io by default; set `KROKI_BASE_URL` to a self-hosted Kroki instance to keep unpublished diagrams on-premises.
 

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -104,7 +104,7 @@ Or add it to your project's `.mcp.json`:
 | `upload_research_history` | Save research state to the experiment repository |
 | `download_research_history` | Restore research state to continue in a later session |
 
-A typical flow: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **write the experiment code yourself** (see below) → `dispatch_experiment` → (poll `get_workflow_runs` for GitHub Actions, or `get_experiment_run_status` for AIXS) → `fetch_experiment_results` → `analyze_experiment` → **create figures and diagrams yourself** (see below) → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`.
+A typical flow: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **write the experiment code yourself** (see below) → `dispatch_experiment` → (poll `get_workflow_runs` for GitHub Actions, or `get_experiment_run_status` for AIXS) → `fetch_experiment_results` → `analyze_experiment` → **create figures and diagrams yourself** (see below) → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → **either or both of** `compile_latex` (build the PDF on GitHub Actions) / `open_in_overleaf` (hand the project to the user for editing) → `upload_research_history`.
 
 ### Writing the experiment code
 

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -93,7 +93,6 @@ Or add it to your project's `.mcp.json`:
 | `generate_bibfile` | Generate a BibTeX references file from research studies; no API key required |
 | `generate_paper` | Write structured paper content (title, abstract, sections) from the completed research |
 | `generate_latex` | Convert paper content into a full LaTeX document (templates: mdpi / iclr2024 / agents4science_2025) |
-| `push_latex` | Push the LaTeX source to the experiment repository |
 | `compile_latex` | Build the paper PDF on GitHub Actions (async); figures are picked up from `.research/results/` and `.research/diagrams/` automatically |
 | `open_in_overleaf` | Create a link that opens the paper in Overleaf; pass `local_path` to export the local working tree without pushing |
 
@@ -104,7 +103,7 @@ Or add it to your project's `.mcp.json`:
 | `upload_research_history` | Save research state to the experiment repository |
 | `download_research_history` | Restore research state to continue in a later session |
 
-A typical flow: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **write the experiment code yourself** (see below) → `dispatch_experiment` → (poll `get_workflow_runs` for GitHub Actions, or `get_experiment_run_status` for AIXS) → `fetch_experiment_results` → `analyze_experiment` → **create figures and diagrams yourself** (see below) → `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → **either or both of** `compile_latex` (build the PDF on GitHub Actions) / `open_in_overleaf` (hand the project to the user for editing) → `upload_research_history`.
+A typical flow: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **write the experiment code yourself** (see below) → `dispatch_experiment` → (poll `get_workflow_runs` for GitHub Actions, or `get_experiment_run_status` for AIXS) → `fetch_experiment_results` → `analyze_experiment` → **create figures and diagrams yourself** (see below) → `generate_bibfile` → `generate_paper` → `generate_latex` → **write the returned LaTeX to `.research/latex/{template}/main.tex` in your clone and push it with git** → **either or both of** `compile_latex` (build the PDF on GitHub Actions) / `open_in_overleaf` (hand the project to the user for editing; with `local_path`, no push needed) → `upload_research_history`.
 
 ### Writing the experiment code
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -93,8 +93,9 @@ claude mcp add airas -- uvx airas
 | `generate_bibfile` | 研究データからBibTeX参考文献ファイルを生成。APIキー不要 |
 | `generate_paper` | 完了した研究から論文本文（タイトル・アブストラクト・各セクション）を執筆 |
 | `generate_latex` | 論文本文をLaTeX文書に変換（テンプレート: mdpi / iclr2024 / agents4science_2025） |
-| `push_latex` | LaTeXソースと図を実験リポジトリにプッシュ |
-| `compile_latex` | GitHub Actionsで論文PDFをビルド（非同期） |
+| `push_latex` | LaTeXソースを実験リポジトリにプッシュ |
+| `compile_latex` | GitHub Actionsで論文PDFをビルド（非同期）。図は `.research/results/` と `.research/diagrams/` から自動で取り込まれる |
+| `open_in_overleaf` | 論文をOverleafで開くリンクを作成。`local_path` を渡すと push 不要でローカルのワーキングツリーをエクスポート |
 
 ### 研究履歴の永続化
 
@@ -122,7 +123,7 @@ MCP ホストは有能なコーディングエージェント（Claude Code、Cu
 
 1. `fetch_experiment_results` で実験結果を取得する（ローカルの clone から直接読んでもよい。run の一覧は `fetch_run_ids` で取得できます）
 2. 結果から Vega-Lite 仕様を組み立てて `render_chart` でレンダリングし、clone 内の `.research/results/chart/` 配下に PDF として保存する。手法ダイアグラムはテキスト記法（mermaid, graphviz, d2 など）で書き、`render_diagram` で `.research/results/diagram/` 配下にレンダリングする（matplotlib などで自分で図を生成しても構いません — 重要なのは出力先だけです）
-3. git で commit・push する。`push_latex` と LaTeX ビルドが、`.research/results/` 配下（および `.research/diagrams/` 配下）の `*.pdf` を論文の `images/` ディレクトリに収集します
+3. git で commit・push する。コピーの手順は不要です: `compile_latex` と `open_in_overleaf` が `.research/results/` と `.research/diagrams/` 配下の図PDFを自動で取り込み、LaTeX からは `images/<そのディレクトリからの相対パス>` として参照できます（例: `.research/results/chart/loss.pdf` → `images/chart/loss.pdf`。ディレクトリ構造は保持されます）。論文中の図参照はこの規約に合わせてください
 
 `render_chart` は完全にローカルでレンダリングします。`render_diagram` はデフォルトでパブリックの https://kroki.io を使います — 未公開のダイアグラムを外に出したくない場合は `KROKI_BASE_URL` でセルフホストの Kroki インスタンスを指定してください。
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -104,7 +104,7 @@ claude mcp add airas -- uvx airas
 | `upload_research_history` | 研究状態を実験リポジトリに保存 |
 | `download_research_history` | 保存した研究状態を復元し、別セッションで継続 |
 
-典型的なフロー: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **実験コードを自分で書く**（下記参照）→ `dispatch_experiment` →（GitHub Actions は `get_workflow_runs`、AIXS は `get_experiment_run_status` でポーリング）→ `fetch_experiment_results` → `analyze_experiment` → **図とダイアグラムを自分で作る**（下記参照）→ `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → `compile_latex` → `upload_research_history`
+典型的なフロー: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **実験コードを自分で書く**（下記参照）→ `dispatch_experiment` →（GitHub Actions は `get_workflow_runs`、AIXS は `get_experiment_run_status` でポーリング）→ `fetch_experiment_results` → `analyze_experiment` → **図とダイアグラムを自分で作る**（下記参照）→ `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → **出口は2つ（片方でも両方でも）**: `compile_latex`（GitHub ActionsでPDFをビルド）/ `open_in_overleaf`（ユーザーが編集できる形でOverleafに引き渡し）→ `upload_research_history`
 
 ### 実験コードの書き方
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -93,7 +93,6 @@ claude mcp add airas -- uvx airas
 | `generate_bibfile` | 研究データからBibTeX参考文献ファイルを生成。APIキー不要 |
 | `generate_paper` | 完了した研究から論文本文（タイトル・アブストラクト・各セクション）を執筆 |
 | `generate_latex` | 論文本文をLaTeX文書に変換（テンプレート: mdpi / iclr2024 / agents4science_2025） |
-| `push_latex` | LaTeXソースを実験リポジトリにプッシュ |
 | `compile_latex` | GitHub Actionsで論文PDFをビルド（非同期）。図は `.research/results/` と `.research/diagrams/` から自動で取り込まれる |
 | `open_in_overleaf` | 論文をOverleafで開くリンクを作成。`local_path` を渡すと push 不要でローカルのワーキングツリーをエクスポート |
 
@@ -104,7 +103,7 @@ claude mcp add airas -- uvx airas
 | `upload_research_history` | 研究状態を実験リポジトリに保存 |
 | `download_research_history` | 保存した研究状態を復元し、別セッションで継続 |
 
-典型的なフロー: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **実験コードを自分で書く**（下記参照）→ `dispatch_experiment` →（GitHub Actions は `get_workflow_runs`、AIXS は `get_experiment_run_status` でポーリング）→ `fetch_experiment_results` → `analyze_experiment` → **図とダイアグラムを自分で作る**（下記参照）→ `generate_bibfile` → `generate_paper` → `generate_latex` → `push_latex` → **出口は2つ（片方でも両方でも）**: `compile_latex`（GitHub ActionsでPDFをビルド）/ `open_in_overleaf`（ユーザーが編集できる形でOverleafに引き渡し）→ `upload_research_history`
+典型的なフロー: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **実験コードを自分で書く**（下記参照）→ `dispatch_experiment` →（GitHub Actions は `get_workflow_runs`、AIXS は `get_experiment_run_status` でポーリング）→ `fetch_experiment_results` → `analyze_experiment` → **図とダイアグラムを自分で作る**（下記参照）→ `generate_bibfile` → `generate_paper` → `generate_latex` → **返された LaTeX を clone 内の `.research/latex/{テンプレート}/main.tex` に書いて git で push** → **出口は2つ（片方でも両方でも）**: `compile_latex`（GitHub ActionsでPDFをビルド）/ `open_in_overleaf`（ユーザーが編集できる形でOverleafに引き渡し。`local_path` 指定なら push 不要）→ `upload_research_history`
 
 ### 実験コードの書き方
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -121,8 +121,8 @@ MCP ホストは有能なコーディングエージェント（Claude Code、Cu
 結果の図と手法ダイアグラムも、GitHub Actions ではなく MCP ホスト自身が作成します:
 
 1. `fetch_experiment_results` で実験結果を取得する（ローカルの clone から直接読んでもよい。run の一覧は `fetch_run_ids` で取得できます）
-2. 結果から Vega-Lite 仕様を組み立てて `render_chart` でレンダリングし、clone 内の `.research/results/` 配下に PDF として保存する。手法ダイアグラムはテキスト記法（mermaid, graphviz, d2 など）で書き、`render_diagram` で `.research/diagrams/` 配下にレンダリングする（matplotlib などで自分で図を生成しても構いません — 重要なのは出力先だけです）
-3. git で commit・push する。`push_latex` と LaTeX ビルドが、この2つのディレクトリ内の `*.pdf` を論文の `images/` ディレクトリに収集します
+2. 結果から Vega-Lite 仕様を組み立てて `render_chart` でレンダリングし、clone 内の `.research/results/chart/` 配下に PDF として保存する。手法ダイアグラムはテキスト記法（mermaid, graphviz, d2 など）で書き、`render_diagram` で `.research/results/diagram/` 配下にレンダリングする（matplotlib などで自分で図を生成しても構いません — 重要なのは出力先だけです）
+3. git で commit・push する。`push_latex` と LaTeX ビルドが、`.research/results/` 配下（および `.research/diagrams/` 配下）の `*.pdf` を論文の `images/` ディレクトリに収集します
 
 `render_chart` は完全にローカルでレンダリングします。`render_diagram` はデフォルトでパブリックの https://kroki.io を使います — 未公開のダイアグラムを外に出したくない場合は `KROKI_BASE_URL` でセルフホストの Kroki インスタンスを指定してください。
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -82,6 +82,8 @@ claude mcp add airas -- uvx airas
 | `fetch_experiment_results` | 実験結果を取得 |
 | `download_workflow_artifacts` | 特定のワークフロー実行のアーティファクトを取得 |
 | `analyze_experiment` | 仮説・実験設計に照らして結果を解析 |
+| `render_chart` | Vega-Lite仕様を図ファイル（PDF/SVG/PNG）にローカルでレンダリング。APIキー不要 |
+| `render_diagram` | テキスト記法のダイアグラム（mermaid, graphviz, d2, plantuml など）をKroki経由でレンダリング。APIキー不要 |
 | `push_files` | 任意のファイルを実験リポジトリにプッシュ |
 
 ### 論文執筆・出版
@@ -119,8 +121,10 @@ MCP ホストは有能なコーディングエージェント（Claude Code、Cu
 結果の図と手法ダイアグラムも、GitHub Actions ではなく MCP ホスト自身が作成します:
 
 1. `fetch_experiment_results` で実験結果を取得する（ローカルの clone から直接読んでもよい。run の一覧は `fetch_run_ids` で取得できます）
-2. 結果の図をローカルで生成し（matplotlib など）、clone 内の `.research/results/` 配下に PDF として保存する。手法ダイアグラムは `.research/diagrams/` 配下に保存する
+2. 結果から Vega-Lite 仕様を組み立てて `render_chart` でレンダリングし、clone 内の `.research/results/` 配下に PDF として保存する。手法ダイアグラムはテキスト記法（mermaid, graphviz, d2 など）で書き、`render_diagram` で `.research/diagrams/` 配下にレンダリングする（matplotlib などで自分で図を生成しても構いません — 重要なのは出力先だけです）
 3. git で commit・push する。`push_latex` と LaTeX ビルドが、この2つのディレクトリ内の `*.pdf` を論文の `images/` ディレクトリに収集します
+
+`render_chart` は完全にローカルでレンダリングします。`render_diagram` はデフォルトでパブリックの https://kroki.io を使います — 未公開のダイアグラムを外に出したくない場合は `KROKI_BASE_URL` でセルフホストの Kroki インスタンスを指定してください。
 
 コード生成と同様に、全自動研究ワークフローは従来どおり GitHub Actions 上で可視化・ダイアグラム生成を実行しますが、その経路は MCP ツールとしては公開していません。
 

--- a/frontend/src/lib/api/models/PushLatexSubgraphResponseBody.ts
+++ b/frontend/src/lib/api/models/PushLatexSubgraphResponseBody.ts
@@ -4,7 +4,6 @@
 /* eslint-disable */
 export type PushLatexSubgraphResponseBody = {
     is_upload_successful: boolean;
-    is_images_prepared: boolean;
     execution_time: Record<string, Array<number>>;
 };
 

--- a/frontend/src/lib/api/services/LatexService.ts
+++ b/frontend/src/lib/api/services/LatexService.ts
@@ -60,7 +60,8 @@ export class LatexService {
      *
      * With `local_path` (path to a local clone of the experiment repository)
      * the project is read from the working tree on disk instead of GitHub,
-     * so unpushed changes and locally rendered figures are included.
+     * so unpushed changes and locally rendered figures are included — and no
+     * GitHub token is required.
      * @param githubOwner
      * @param repositoryName
      * @param branchName

--- a/frontend/src/lib/api/services/LatexService.ts
+++ b/frontend/src/lib/api/services/LatexService.ts
@@ -57,10 +57,15 @@ export class LatexService {
      * Opened in a browser (not called as a JSON API): the page carries the
      * zipped LaTeX sources inline and immediately POSTs them to Overleaf,
      * which creates a new project in the user's Overleaf account.
+     *
+     * With `local_path` (path to a local clone of the experiment repository)
+     * the project is read from the working tree on disk instead of GitHub,
+     * so unpushed changes and locally rendered figures are included.
      * @param githubOwner
      * @param repositoryName
      * @param branchName
      * @param latexTemplateName
+     * @param localPath
      * @returns string Successful Response
      * @throws ApiError
      */
@@ -69,6 +74,7 @@ export class LatexService {
         repositoryName: string,
         branchName: string,
         latexTemplateName: 'iclr2024' | 'agents4science_2025' | 'mdpi' = 'mdpi',
+        localPath?: (string | null),
     ): CancelablePromise<string> {
         return __request(OpenAPI, {
             method: 'GET',
@@ -78,6 +84,7 @@ export class LatexService {
                 'repository_name': repositoryName,
                 'branch_name': branchName,
                 'latex_template_name': latexTemplateName,
+                'local_path': localPath,
             },
             errors: {
                 404: `LaTeX project not found in the repository (push_latex has not been run)`,

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -632,7 +632,9 @@ paths:
 
         the project is read from the working tree on disk instead of GitHub,
 
-        so unpushed changes and locally rendered figures are included.'
+        so unpushed changes and locally rendered figures are included — and no
+
+        GitHub token is required.'
       operationId: open_in_overleaf_airas_v1_latex_overleaf_get
       parameters:
       - name: github_owner

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -625,7 +625,14 @@ paths:
 
         zipped LaTeX sources inline and immediately POSTs them to Overleaf,
 
-        which creates a new project in the user''s Overleaf account.'
+        which creates a new project in the user''s Overleaf account.
+
+
+        With `local_path` (path to a local clone of the experiment repository)
+
+        the project is read from the working tree on disk instead of GitHub,
+
+        so unpushed changes and locally rendered figures are included.'
       operationId: open_in_overleaf_airas_v1_latex_overleaf_get
       parameters:
       - name: github_owner
@@ -657,6 +664,14 @@ paths:
           type: string
           default: mdpi
           title: Latex Template Name
+      - name: local_path
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Local Path
       responses:
         '200':
           description: Successful Response
@@ -4208,9 +4223,6 @@ components:
         is_upload_successful:
           type: boolean
           title: Is Upload Successful
-        is_images_prepared:
-          type: boolean
-          title: Is Images Prepared
         execution_time:
           additionalProperties:
             items:
@@ -4221,7 +4233,6 @@ components:
       type: object
       required:
       - is_upload_successful
-      - is_images_prepared
       - execution_time
       title: PushLatexSubgraphResponseBody
     RefineExperimentalDesignLLMMapping:


### PR DESCRIPTION
## Summary
可視化・図表生成のローカル実行化（#911）を実際に支えるレンダリングツールを2つ追加します。エージェントが matplotlib コードを書く代わりに、宣言的な仕様を渡すだけで論文品質の図を生成できます。

## Changes

### `render_chart`（結果の図）
- Vega-Lite の JSON 仕様を **vl-convert で完全ローカル**に PDF/SVG/PNG へレンダリング
- 未公開の実験データがマシンの外に出ない・API キー不要
- `.research/results/` に保存 → git push → 既存の LaTeX ビルドが収集、という規約にそのまま乗る

### `render_diagram`（手法・アーキテクチャ図）
- テキスト記法（mermaid / graphviz / d2 / plantuml など Kroki の25種以上）を Kroki 経由でレンダリング
- デフォルトはパブリック https://kroki.io、**`KROKI_BASE_URL` でセルフホストに切替可**（未公開図の私設運用）
- PDF 出力は SVG からローカル変換（ベクター）。mermaid のように SVG に HTML ラベル（`foreignObject`）を埋め込む記法はローカル変換でテキストが欠落するため、**自動で PNG→PDF（白背景合成）にフォールバック**

### その他
- `infra/kroki_client.py` 新規（BaseHTTPClient ベース、リトライ付き）
- 依存追加: `vl-convert-python`（純wheel、node不要）、`pillow`（PNG→PDF用）
- MCP ドキュメント（en/ja）のツール表・図作成フローを更新。ツール数 29 → 31

## Verification
- [x] ruff / mypy Passed、MCP サーバーロードで31ツール列挙
- [x] render_chart: 折れ線チャート（凡例・軸ラベル付き）の PDF を生成し目視確認
- [x] render_diagram(graphviz): ベクターPDF、テキスト含め正常
- [x] render_diagram(mermaid): foreignObject 検出 → PNG フォールバック、白背景・ラベル付きで正常
- [x] 拡張子バリデーション（.pdf/.svg/.png 以外はエラー）

## 採用理由（検討ログ）
- QuickChart(Chart.js): 統計的可視化の表現力不足・未公開データの外部送信・AGPL のため不採用
- Eraser: 有料SaaS限定・APIキー必須で「uvxだけで動くOSS」方針に反するため不採用
- Vega-Lite はローカルレンダリング(vl-convert)できるため API サービス自体が不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)