### PR TITLE
feat: trim repo read/write MCP tools and add deprecation plan

### DIFF
--- a/backend/src/airas/dashboard/api/routes/v1/experiments.py
+++ b/backend/src/airas/dashboard/api/routes/v1/experiments.py
@@ -217,6 +217,9 @@ async def dispatch_main_experiment(
     )
 
 
+# NOTE: In the local-agent flow figures are rendered locally (render_chart /
+# render_diagram); this GHA-dispatch endpoint remains for the dashboard UI and
+# is scheduled for removal in the next major release (see issue #913).
 @router.post(
     "/visualizations/dispatch", response_model=DispatchVisualizationResponseBody
 )
@@ -246,6 +249,8 @@ async def dispatch_visualization(
     )
 
 
+# NOTE: Scheduled for removal in the next major release together with the
+# visualization dispatch above (see issue #913).
 @router.post("/diagrams/dispatch", response_model=DispatchDiagramGenerationResponseBody)
 @inject
 @observe()

--- a/backend/src/airas/dashboard/api/routes/v1/latex.py
+++ b/backend/src/airas/dashboard/api/routes/v1/latex.py
@@ -70,6 +70,9 @@ async def generate_latex(
     )
 
 
+# NOTE: In the local-agent flow main.tex is pushed with git; this endpoint
+# remains for the dashboard UI and E2E and is a removal candidate in the next
+# major release (see issue #913).
 @router.post("/push", response_model=PushLatexSubgraphResponseBody)
 @inject
 @observe()

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -77,14 +77,8 @@ from airas.usecases.executors.dispatch_experiment_on_aixs_subgraph.dispatch_expe
 from airas.usecases.executors.dispatch_experiment_on_static_runner_subgraph.dispatch_experiment_on_static_runner_subgraph import (
     DispatchExperimentOnStaticRunnerSubgraph,
 )
-from airas.usecases.executors.fetch_experiment_code_subgraph.fetch_experiment_code_subgraph import (
-    FetchExperimentCodeSubgraph,
-)
 from airas.usecases.executors.fetch_experiment_results_subgraph.fetch_experiment_results_subgraph import (
     FetchExperimentResultsSubgraph,
-)
-from airas.usecases.executors.fetch_run_ids_subgraph.fetch_run_ids_subgraph import (
-    FetchRunIdsSubgraph,
 )
 from airas.usecases.generators.generate_experimental_design_subgraph.generate_experimental_design_subgraph import (
     GenerateExperimentalDesignSubgraph,
@@ -105,9 +99,6 @@ from airas.usecases.github.github_download_subgraph import GithubDownloadSubgrap
 from airas.usecases.github.github_upload_subgraph import GithubUploadSubgraph
 from airas.usecases.github.prepare_repository_subgraph.prepare_repository_subgraph import (
     PrepareRepositorySubgraph,
-)
-from airas.usecases.github.push_github_subgraph.push_github_subgraph import (
-    PushGitHubSubgraph,
 )
 from airas.usecases.publication.compile_latex_subgraph.compile_latex_subgraph import (
     CompileLatexSubgraph,
@@ -748,33 +739,6 @@ async def get_workflow_runs(
 
 
 @mcp.tool()
-async def fetch_experiment_code(
-    github_owner: str,
-    repository_name: str,
-    branch_name: str,
-) -> dict[str, Any]:
-    """Fetch the experiment code from the experiment repository.
-
-    The returned object can be passed to `analyze_experiment` as
-    `experiment_code`. Requires GH_PERSONAL_ACCESS_TOKEN.
-    """
-    result = (
-        await FetchExperimentCodeSubgraph(github_client=_github_client())
-        .build_graph()
-        .ainvoke(
-            {
-                "github_config": GitHubConfig(
-                    github_owner=github_owner,
-                    repository_name=repository_name,
-                    branch_name=branch_name,
-                )
-            }
-        )
-    )
-    return _dump(result["experiment_code"])
-
-
-@mcp.tool()
 async def fetch_experiment_results(
     github_owner: str,
     repository_name: str,
@@ -841,9 +805,11 @@ async def analyze_experiment(
     """Analyze experiment results against the hypothesis and design.
 
     Takes the outputs of `generate_hypothesis`, `generate_experimental_design`,
-    `fetch_experiment_code`, and `fetch_experiment_results`, and returns a
-    structured analysis (findings, whether the hypothesis is supported, and
-    suggested next steps). Requires an LLM provider API key.
+    and `fetch_experiment_results`, and returns a structured analysis
+    (findings, whether the hypothesis is supported, and suggested next
+    steps). For `experiment_code`, read the code from your local clone and
+    pass `{"files": {"<relative path>": "<content>", ...}}`.
+    Requires an LLM provider API key.
     """
     result = (
         await AnalyzeExperimentSubgraph(
@@ -929,34 +895,6 @@ async def download_research_history(
         )
     )
     return _dump(result["research_history"])
-
-
-@mcp.tool()
-async def fetch_run_ids(
-    github_owner: str,
-    repository_name: str,
-    branch_name: str,
-) -> list[str]:
-    """List the experiment run IDs recorded in the experiment repository.
-
-    Run IDs identify individual experiment runs defined by the generated
-    code; pass them to `dispatch_experiment`, and use them to locate result
-    files when creating figures locally. Requires GH_PERSONAL_ACCESS_TOKEN.
-    """
-    result = (
-        await FetchRunIdsSubgraph(github_client=_github_client())
-        .build_graph()
-        .ainvoke(
-            {
-                "github_config": GitHubConfig(
-                    github_owner=github_owner,
-                    repository_name=repository_name,
-                    branch_name=branch_name,
-                )
-            }
-        )
-    )
-    return result["run_ids"]
 
 
 def _resolve_render_output(output_path: str) -> tuple[Path, str]:
@@ -1049,36 +987,6 @@ async def render_diagram(
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(data)
     return {"output_path": str(path), "bytes_written": len(data)}
-
-
-@mcp.tool()
-async def push_files(
-    github_owner: str,
-    repository_name: str,
-    branch_name: str,
-    files: dict[str, str],
-) -> dict[str, Any]:
-    """Push files to the experiment repository.
-
-    `files` maps repository paths to file contents (text). Useful for
-    manual fixes to experiment code or configuration between runs.
-    Requires GH_PERSONAL_ACCESS_TOKEN.
-    """
-    result = (
-        await PushGitHubSubgraph(github_client=_github_client())
-        .build_graph()
-        .ainvoke(
-            {
-                "github_config": GitHubConfig(
-                    github_owner=github_owner,
-                    repository_name=repository_name,
-                    branch_name=branch_name,
-                ),
-                "push_files": files,
-            }
-        )
-    )
-    return {"is_file_pushed": result["is_file_pushed"]}
 
 
 # --- Paper writing & publication ---

--- a/backend/src/airas/usecases/executors/fetch_experiment_results_subgraph/nodes/fetch_results.py
+++ b/backend/src/airas/usecases/executors/fetch_experiment_results_subgraph/nodes/fetch_results.py
@@ -142,7 +142,9 @@ async def _fetch_diagram_files(
     github_config: GitHubConfig,
     diagrams_dirs: tuple[str, ...] = (
         ".research/results/diagram",  # current convention
-        ".research/diagrams",  # legacy location, kept for older repositories
+        # Legacy location, kept for older repositories; remove in the next
+        # major release (see issue #913).
+        ".research/diagrams",
     ),
 ) -> list[str]:
     per_dir = await asyncio.gather(

--- a/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
+++ b/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
@@ -16,6 +16,8 @@ _EXCLUDED_FILES = {"template.tex", "template.pdf"}
 # Figure sources are merged into the project's images/ directory at export
 # time (structure preserved), so nothing has to be copied into the LaTeX
 # directory beforehand. Generated LaTeX references figures as images/<path>.
+# The legacy .research/diagrams/ entry is scheduled for removal in the next
+# major release (see issue #913).
 _FIGURE_SOURCE_DIRS = (".research/results/", ".research/diagrams/")
 
 

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -77,14 +77,11 @@ Or add it to your project's `.mcp.json`:
 | `dispatch_experiment` | Start a sanity-check or main experiment run (async) on GitHub Actions or the AIXS compute platform (`backend` parameter) |
 | `get_workflow_runs` | Check the status of recent workflow runs (non-blocking) |
 | `get_experiment_run_status` | Check one run on any backend and fetch its stdout/stderr tails for error diagnosis |
-| `fetch_experiment_code` | Fetch the experiment code from the repository |
-| `fetch_run_ids` | List experiment run IDs recorded in the repository |
 | `fetch_experiment_results` | Fetch experiment results |
 | `download_workflow_artifacts` | Download artifacts of a specific workflow run |
 | `analyze_experiment` | Analyze results against the hypothesis and design |
 | `render_chart` | Render a Vega-Lite spec to a figure file (PDF/SVG/PNG) locally; no API keys required |
 | `render_diagram` | Render a text diagram (mermaid, graphviz, d2, plantuml, …) via Kroki; no API keys required |
-| `push_files` | Push arbitrary files to the experiment repository |
 
 ### Paper writing & publication
 
@@ -120,7 +117,7 @@ Headless pipelines (the built-in autonomous research workflows) still generate c
 
 Result figures and method diagrams are also created by the MCP host itself rather than on GitHub Actions:
 
-1. Fetch the experiment results with `fetch_experiment_results` (or read them from your local clone; `fetch_run_ids` lists the runs).
+1. Fetch the experiment results with `fetch_experiment_results` (or read them from your local clone — run directories live under `.research/results/`).
 2. Build a Vega-Lite spec from the results and render it with `render_chart`, saving the PDF under `.research/results/chart/` in the clone. For method diagrams, write the diagram as text (mermaid, graphviz, d2, …) and render it with `render_diagram` into `.research/results/diagram/`. (Generating figures yourself, e.g. with matplotlib, works too — only the output location matters.)
 3. Commit and push them with git. No copy step is needed: `compile_latex` and `open_in_overleaf` automatically pick up every figure PDF under `.research/results/` and `.research/diagrams/`, exposed to LaTeX as `images/<path relative to that directory>` (e.g. `.research/results/chart/loss.pdf` → `images/chart/loss.pdf`) with the directory structure preserved. Reference figures accordingly in the paper.
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -77,14 +77,11 @@ claude mcp add airas -- uvx airas
 | `dispatch_experiment` | サニティチェック／本実験の実行を開始（非同期）。`backend` パラメータで GitHub Actions / AIXS 計算基盤を選択 |
 | `get_workflow_runs` | 直近のワークフロー実行のステータス確認（ノンブロッキング） |
 | `get_experiment_run_status` | 任意のバックエンドの実行1件のステータス確認と stdout/stderr の取得（エラー診断用） |
-| `fetch_experiment_code` | 実験コードを取得 |
-| `fetch_run_ids` | リポジトリに記録された実験run IDの一覧を取得 |
 | `fetch_experiment_results` | 実験結果を取得 |
 | `download_workflow_artifacts` | 特定のワークフロー実行のアーティファクトを取得 |
 | `analyze_experiment` | 仮説・実験設計に照らして結果を解析 |
 | `render_chart` | Vega-Lite仕様を図ファイル（PDF/SVG/PNG）にローカルでレンダリング。APIキー不要 |
 | `render_diagram` | テキスト記法のダイアグラム（mermaid, graphviz, d2, plantuml など）をKroki経由でレンダリング。APIキー不要 |
-| `push_files` | 任意のファイルを実験リポジトリにプッシュ |
 
 ### 論文執筆・出版
 
@@ -120,7 +117,7 @@ MCP ホストは有能なコーディングエージェント（Claude Code、Cu
 
 結果の図と手法ダイアグラムも、GitHub Actions ではなく MCP ホスト自身が作成します:
 
-1. `fetch_experiment_results` で実験結果を取得する（ローカルの clone から直接読んでもよい。run の一覧は `fetch_run_ids` で取得できます）
+1. `fetch_experiment_results` で実験結果を取得する（ローカルの clone から直接読んでもよい。run ごとのディレクトリは `.research/results/` 配下にあります）
 2. 結果から Vega-Lite 仕様を組み立てて `render_chart` でレンダリングし、clone 内の `.research/results/chart/` 配下に PDF として保存する。手法ダイアグラムはテキスト記法（mermaid, graphviz, d2 など）で書き、`render_diagram` で `.research/results/diagram/` 配下にレンダリングする（matplotlib などで自分で図を生成しても構いません — 重要なのは出力先だけです）
 3. git で commit・push する。コピーの手順は不要です: `compile_latex` と `open_in_overleaf` が `.research/results/` と `.research/diagrams/` 配下の図PDFを自動で取り込み、LaTeX からは `images/<そのディレクトリからの相対パス>` として参照できます（例: `.research/results/chart/loss.pdf` → `images/chart/loss.pdf`。ディレクトリ構造は保持されます）。論文中の図参照はこの規約に合わせてください
 


### PR DESCRIPTION
## 概要
ローカルエージェントフロー（#911/#912）の方針に合わせ、clone + git で代替できる MCP ツールを削除します（30 → 27）。あわせて互換レイヤーの削除計画を整備します。

## Changes

### MCP ツール削除（3件）
- **`push_files`**: push_latex 削除と同じ理屈（clone があるなら git push でよい）。テキスト専用でバイナリ不可という制約もあった
- **`fetch_experiment_code`**: clone を直接読めばよい。`analyze_experiment` の docstring に「clone から読んで `{files: {...}}` で渡す」案内を追加
- **`fetch_run_ids`**: 同上（run ディレクトリは `.research/results/` 配下）

`fetch_experiment_results` はメトリクス集約ロジックがあるため残しています。サブグラフ本体はすべてダッシュボード・E2E 用に温存。

### 廃止予定レイヤーの削除計画（#913）
- 追跡 Issue #913 を起票しプロジェクトボードに追加
- 対象: `.research/diagrams` 読み取り互換、ダッシュボードの GHA 委譲エンドポイント（visualizations/diagrams dispatch, /latex/push）、テンプレートの `prepare_images_for_latex.yml`
- 該当コード5箇所に Issue 参照付きの目印コメントを追加

## Verification
- [x] MCP サーバーロードで 27 ツール、削除3件の不在と既存ツールの健在を確認
- [x] ruff / mypy Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)