### PR TITLE
feat: dual-mode generation (backend LLM / host authoring) via get_generation_prompt

### DIFF
--- a/backend/src/airas/mcp/prompt_registry.py
+++ b/backend/src/airas/mcp/prompt_registry.py
@@ -10,10 +10,12 @@ Each generation step in AIRAS can run in one of two modes:
   template files the backend nodes use — this module is a thin renderer on
   top of them, so the two modes cannot drift apart.
 
-Every step returns a list of prompt steps plus a ``flow`` description. A
-prompt step is either fully rendered (``ready: true``) or a template whose
-documented placeholders the host must substitute (e.g. the refine prompt
-needs the host's own current draft).
+Every step returns a single fully rendered ``prompt``, an
+``output_json_schema`` describing exactly the data format to produce, and a
+``flow`` note on how the output is used next. Steps that loop internally on
+the backend (hypothesis refinement, paper refinement) are intentionally
+single-shot in host mode: the host produces the artifact once, at its best,
+instead of replaying the backend's iteration loop.
 """
 
 import json
@@ -29,10 +31,7 @@ from airas.core.types.experimental_design import (
 )
 from airas.core.types.experimental_results import ExperimentalResults
 from airas.core.types.paper import PaperContent
-from airas.core.types.research_hypothesis import (
-    HypothesisEvaluation,
-    ResearchHypothesis,
-)
+from airas.core.types.research_hypothesis import ResearchHypothesis
 from airas.core.types.research_study import ResearchStudy
 from airas.resources.datasets.prompt_engineering_datasets import (
     PROMPT_ENGINEERING_DATASETS,
@@ -50,14 +49,8 @@ from airas.usecases.generators.generate_experimental_design_subgraph.nodes.gener
 from airas.usecases.generators.generate_experimental_design_subgraph.prompts.generate_experimental_design_prompt import (
     generate_experimental_design_prompt,
 )
-from airas.usecases.generators.generate_hypothesis_subgraph.prompts.evaluate_novelty_and_significance_prompt import (
-    evaluate_novelty_and_significance_prompt,
-)
 from airas.usecases.generators.generate_hypothesis_subgraph.prompts.generate_simple_hypothesis_prompt import (
     generate_simple_hypothesis_prompt,
-)
-from airas.usecases.generators.generate_hypothesis_subgraph.prompts.refine_hypothesis_prompt import (
-    refine_hypothesis_prompt,
 )
 from airas.usecases.generators.generate_queries_subgraph.nodes.generate_queries import (
     LLMOutput as GenerateQueriesOutput,
@@ -69,7 +62,6 @@ from airas.usecases.publication.generate_latex_subgraph.prompts.convert_to_latex
     convert_to_latex_prompt,
 )
 from airas.usecases.writers.write_subgraph.nodes.generate_note import generate_note
-from airas.usecases.writers.write_subgraph.prompts.refine_prompt import refine_prompt
 from airas.usecases.writers.write_subgraph.prompts.section_tips_prompt import (
     section_tips_prompt,
 )
@@ -98,14 +90,8 @@ def _research_queries(inputs: dict[str, Any]) -> dict[str, Any]:
         },
     )
     return {
-        "steps": [
-            {
-                "name": "generate_queries",
-                "ready": True,
-                "prompt": prompt,
-                "output_json_schema": GenerateQueriesOutput.model_json_schema(),
-            }
-        ],
+        "prompt": prompt,
+        "output_json_schema": GenerateQueriesOutput.model_json_schema(),
         "flow": (
             "Produce output matching output_json_schema; the query_list is "
             "what you would pass to search_papers."
@@ -114,79 +100,23 @@ def _research_queries(inputs: dict[str, Any]) -> dict[str, Any]:
 
 
 def _hypothesis(inputs: dict[str, Any]) -> dict[str, Any]:
-    formatted_studies = [
-        ResearchStudy.to_formatted_json(ResearchStudy.model_validate(study))
-        for study in inputs["research_study_list"]
-    ]
-    refinement_rounds = inputs.get("refinement_rounds", 2)
-    generate_message = _render(
+    prompt = _render(
         generate_simple_hypothesis_prompt,
         {
             "research_topic": inputs["research_topic"],
-            "research_study_list": formatted_studies,
-        },
-    )
-    evaluate_message = _render(
-        evaluate_novelty_and_significance_prompt,
-        {
-            "research_topic": inputs["research_topic"],
-            "research_study_list": formatted_studies,
-            "new_hypothesis": "{{ new_hypothesis }}",
-        },
-    )
-    refine_message = _render(
-        refine_hypothesis_prompt,
-        {
-            "research_topic": inputs["research_topic"],
-            "research_study_list": formatted_studies,
-            "current_hypothesis": "{{ current_hypothesis }}",
-            "novelty_reason": "{{ novelty_reason }}",
-            "significance_reason": "{{ significance_reason }}",
-            "evaluated_hypothesis_history": "{{ evaluated_hypothesis_history }}",
+            "research_study_list": [
+                ResearchStudy.to_formatted_json(ResearchStudy.model_validate(study))
+                for study in inputs["research_study_list"]
+            ],
         },
     )
     return {
-        "steps": [
-            {
-                "name": "generate_hypothesis",
-                "ready": True,
-                "prompt": generate_message,
-                "output_json_schema": ResearchHypothesis.model_json_schema(),
-            },
-            {
-                "name": "evaluate_novelty_and_significance",
-                "ready": False,
-                "placeholders": {
-                    "{{ new_hypothesis }}": "the hypothesis to evaluate, as JSON"
-                },
-                "prompt": evaluate_message,
-                "output_json_schema": HypothesisEvaluation.model_json_schema(),
-            },
-            {
-                "name": "refine_hypothesis",
-                "ready": False,
-                "placeholders": {
-                    "{{ current_hypothesis }}": "the latest hypothesis as JSON",
-                    "{{ novelty_reason }}": "novelty_reason from its evaluation",
-                    "{{ significance_reason }}": (
-                        "significance_reason from its evaluation"
-                    ),
-                    "{{ evaluated_hypothesis_history }}": (
-                        "earlier (hypothesis, evaluation) pairs as JSON, "
-                        "oldest first; empty string on the first refinement"
-                    ),
-                },
-                "prompt": refine_message,
-                "output_json_schema": ResearchHypothesis.model_json_schema(),
-            },
-        ],
+        "prompt": prompt,
+        "output_json_schema": ResearchHypothesis.model_json_schema(),
         "flow": (
-            "1) Author a hypothesis with the generate_hypothesis prompt. "
-            "2) Evaluate it with evaluate_novelty_and_significance. "
-            "3) If novelty_score >= 9 and significance_score >= 9, stop. "
-            f"Otherwise refine with refine_hypothesis and re-evaluate, up to "
-            f"{refinement_rounds} refinement round(s). The final hypothesis "
-            "is what you would pass to the experimental_design step."
+            "Produce a single, novel and significant hypothesis matching "
+            "output_json_schema. The result is what you would pass to the "
+            "experimental_design step."
         ),
     }
 
@@ -212,14 +142,8 @@ def _experimental_design(inputs: dict[str, Any]) -> dict[str, Any]:
         },
     )
     return {
-        "steps": [
-            {
-                "name": "generate_experimental_design",
-                "ready": True,
-                "prompt": prompt,
-                "output_json_schema": ExperimentalDesignOutput.model_json_schema(),
-            }
-        ],
+        "prompt": prompt,
+        "output_json_schema": ExperimentalDesignOutput.model_json_schema(),
         "flow": (
             "Produce output matching output_json_schema. The result is the "
             "experimental design used to write the experiment code and, "
@@ -245,14 +169,8 @@ def _experiment_analysis(inputs: dict[str, Any]) -> dict[str, Any]:
         },
     )
     return {
-        "steps": [
-            {
-                "name": "analyze_experiment",
-                "ready": True,
-                "prompt": prompt,
-                "output_json_schema": AnalyzeExperimentOutput.model_json_schema(),
-            }
-        ],
+        "prompt": prompt,
+        "output_json_schema": AnalyzeExperimentOutput.model_json_schema(),
         "flow": (
             "Produce output matching output_json_schema; analysis_report is "
             "the analysis text used by the paper-writing step."
@@ -275,38 +193,14 @@ def _paper_writing(inputs: dict[str, Any]) -> dict[str, Any]:
         ],
         references_bib=inputs["references_bib"],
     )
-    write_message = _render(
-        write_prompt, {"note": note, "tips_dict": section_tips_prompt}
-    )
-    refinement_rounds = inputs.get("writing_refinement_rounds", 2)
+    prompt = _render(write_prompt, {"note": note, "tips_dict": section_tips_prompt})
     return {
-        "steps": [
-            {
-                "name": "write_paper",
-                "ready": True,
-                "prompt": write_message,
-                "output_json_schema": PaperContent.model_json_schema(),
-            },
-            {
-                "name": "refine_paper",
-                "ready": False,
-                "placeholders": {
-                    "{{ content }}": "your current PaperContent draft as JSON"
-                },
-                "prompt": refine_prompt,
-                "prompt_prefix": (
-                    "Prepend the write_paper prompt above, then append this "
-                    "refine prompt with the placeholder substituted."
-                ),
-                "output_json_schema": PaperContent.model_json_schema(),
-            },
-        ],
+        "prompt": prompt,
+        "output_json_schema": PaperContent.model_json_schema(),
         "flow": (
-            "1) Author the full paper with the write_paper prompt. "
-            f"2) Run the refine_paper step {refinement_rounds} time(s): each "
-            "round, substitute {{ content }} with your latest draft and "
-            "produce an improved PaperContent. The final draft is what you "
-            "would pass to generate_latex as paper_content."
+            "Author the full paper in one pass, matching output_json_schema. "
+            "The result is what you would pass to the latex_conversion step "
+            "as paper_content."
         ),
     }
 
@@ -325,14 +219,8 @@ def _latex_conversion(inputs: dict[str, Any]) -> dict[str, Any]:
         },
     )
     return {
-        "steps": [
-            {
-                "name": "convert_to_latex",
-                "ready": True,
-                "prompt": prompt,
-                "output_json_schema": PaperContent.model_json_schema(),
-            }
-        ],
+        "prompt": prompt,
+        "output_json_schema": PaperContent.model_json_schema(),
         "flow": (
             "1) Produce LaTeX-formatted PaperContent matching "
             "output_json_schema. 2) Embed it into the template yourself: "

--- a/backend/src/airas/mcp/prompt_registry.py
+++ b/backend/src/airas/mcp/prompt_registry.py
@@ -16,28 +16,57 @@ documented placeholders the host must substitute (e.g. the refine prompt
 needs the host's own current draft).
 """
 
+import json
 from typing import Any
 
 from jinja2 import Environment
 
 from airas.core.types.experiment_code import ExperimentCode
 from airas.core.types.experiment_history import ExperimentHistory
-from airas.core.types.experimental_design import ExperimentalDesign
+from airas.core.types.experimental_design import (
+    ComputeEnvironment,
+    ExperimentalDesign,
+)
 from airas.core.types.experimental_results import ExperimentalResults
 from airas.core.types.paper import PaperContent
-from airas.core.types.research_hypothesis import ResearchHypothesis
+from airas.core.types.research_hypothesis import (
+    HypothesisEvaluation,
+    ResearchHypothesis,
+)
 from airas.core.types.research_study import ResearchStudy
+from airas.resources.datasets.prompt_engineering_datasets import (
+    PROMPT_ENGINEERING_DATASETS,
+)
+from airas.resources.models.llm_api_models import LLM_API_MODELS
 from airas.usecases.analyzers.analyze_experiment_subgraph.nodes.analyze_experiment import (
     LLMOutput as AnalyzeExperimentOutput,
 )
 from airas.usecases.analyzers.analyze_experiment_subgraph.prompts.analyze_experiment_prompt import (
     analyze_experiment_prompt,
 )
+from airas.usecases.generators.generate_experimental_design_subgraph.nodes.generate_experimental_design import (
+    LLMOutput as ExperimentalDesignOutput,
+)
+from airas.usecases.generators.generate_experimental_design_subgraph.prompts.generate_experimental_design_prompt import (
+    generate_experimental_design_prompt,
+)
+from airas.usecases.generators.generate_hypothesis_subgraph.prompts.evaluate_novelty_and_significance_prompt import (
+    evaluate_novelty_and_significance_prompt,
+)
+from airas.usecases.generators.generate_hypothesis_subgraph.prompts.generate_simple_hypothesis_prompt import (
+    generate_simple_hypothesis_prompt,
+)
+from airas.usecases.generators.generate_hypothesis_subgraph.prompts.refine_hypothesis_prompt import (
+    refine_hypothesis_prompt,
+)
 from airas.usecases.generators.generate_queries_subgraph.nodes.generate_queries import (
     LLMOutput as GenerateQueriesOutput,
 )
 from airas.usecases.generators.generate_queries_subgraph.prompt.generate_queries_prompt import (
     generate_queries_prompt,
+)
+from airas.usecases.publication.generate_latex_subgraph.prompts.convert_to_latex_prompt import (
+    convert_to_latex_prompt,
 )
 from airas.usecases.writers.write_subgraph.nodes.generate_note import generate_note
 from airas.usecases.writers.write_subgraph.prompts.refine_prompt import refine_prompt
@@ -46,7 +75,14 @@ from airas.usecases.writers.write_subgraph.prompts.section_tips_prompt import (
 )
 from airas.usecases.writers.write_subgraph.prompts.write_prompt import write_prompt
 
-GENERATION_STEPS = ("research_queries", "experiment_analysis", "paper_writing")
+GENERATION_STEPS = (
+    "research_queries",
+    "hypothesis",
+    "experimental_design",
+    "experiment_analysis",
+    "paper_writing",
+    "latex_conversion",
+)
 
 
 def _render(template: str, data: dict[str, Any]) -> str:
@@ -73,6 +109,121 @@ def _research_queries(inputs: dict[str, Any]) -> dict[str, Any]:
         "flow": (
             "Produce output matching output_json_schema; the query_list is "
             "what you would pass to search_papers."
+        ),
+    }
+
+
+def _hypothesis(inputs: dict[str, Any]) -> dict[str, Any]:
+    formatted_studies = [
+        ResearchStudy.to_formatted_json(ResearchStudy.model_validate(study))
+        for study in inputs["research_study_list"]
+    ]
+    refinement_rounds = inputs.get("refinement_rounds", 2)
+    generate_message = _render(
+        generate_simple_hypothesis_prompt,
+        {
+            "research_topic": inputs["research_topic"],
+            "research_study_list": formatted_studies,
+        },
+    )
+    evaluate_message = _render(
+        evaluate_novelty_and_significance_prompt,
+        {
+            "research_topic": inputs["research_topic"],
+            "research_study_list": formatted_studies,
+            "new_hypothesis": "{{ new_hypothesis }}",
+        },
+    )
+    refine_message = _render(
+        refine_hypothesis_prompt,
+        {
+            "research_topic": inputs["research_topic"],
+            "research_study_list": formatted_studies,
+            "current_hypothesis": "{{ current_hypothesis }}",
+            "novelty_reason": "{{ novelty_reason }}",
+            "significance_reason": "{{ significance_reason }}",
+            "evaluated_hypothesis_history": "{{ evaluated_hypothesis_history }}",
+        },
+    )
+    return {
+        "steps": [
+            {
+                "name": "generate_hypothesis",
+                "ready": True,
+                "prompt": generate_message,
+                "output_json_schema": ResearchHypothesis.model_json_schema(),
+            },
+            {
+                "name": "evaluate_novelty_and_significance",
+                "ready": False,
+                "placeholders": {
+                    "{{ new_hypothesis }}": "the hypothesis to evaluate, as JSON"
+                },
+                "prompt": evaluate_message,
+                "output_json_schema": HypothesisEvaluation.model_json_schema(),
+            },
+            {
+                "name": "refine_hypothesis",
+                "ready": False,
+                "placeholders": {
+                    "{{ current_hypothesis }}": "the latest hypothesis as JSON",
+                    "{{ novelty_reason }}": "novelty_reason from its evaluation",
+                    "{{ significance_reason }}": (
+                        "significance_reason from its evaluation"
+                    ),
+                    "{{ evaluated_hypothesis_history }}": (
+                        "earlier (hypothesis, evaluation) pairs as JSON, "
+                        "oldest first; empty string on the first refinement"
+                    ),
+                },
+                "prompt": refine_message,
+                "output_json_schema": ResearchHypothesis.model_json_schema(),
+            },
+        ],
+        "flow": (
+            "1) Author a hypothesis with the generate_hypothesis prompt. "
+            "2) Evaluate it with evaluate_novelty_and_significance. "
+            "3) If novelty_score >= 9 and significance_score >= 9, stop. "
+            f"Otherwise refine with refine_hypothesis and re-evaluate, up to "
+            f"{refinement_rounds} refinement round(s). The final hypothesis "
+            "is what you would pass to the experimental_design step."
+        ),
+    }
+
+
+def _experimental_design(inputs: dict[str, Any]) -> dict[str, Any]:
+    compute_environment = ComputeEnvironment.model_validate(
+        inputs.get("compute_environment") or {}
+    )
+    prompt = _render(
+        generate_experimental_design_prompt,
+        {
+            "research_hypothesis": ResearchHypothesis.model_validate(
+                inputs["research_hypothesis"]
+            ),
+            "compute_environment": compute_environment,
+            "model_list": json.dumps(LLM_API_MODELS, indent=4, ensure_ascii=False),
+            "dataset_list": json.dumps(
+                PROMPT_ENGINEERING_DATASETS, indent=4, ensure_ascii=False
+            ),
+            "num_models_to_use": inputs.get("num_models_to_use", 2),
+            "num_datasets_to_use": inputs.get("num_datasets_to_use", 2),
+            "num_comparative_methods": inputs.get("num_comparative_methods", 2),
+        },
+    )
+    return {
+        "steps": [
+            {
+                "name": "generate_experimental_design",
+                "ready": True,
+                "prompt": prompt,
+                "output_json_schema": ExperimentalDesignOutput.model_json_schema(),
+            }
+        ],
+        "flow": (
+            "Produce output matching output_json_schema. The result is the "
+            "experimental design used to write the experiment code and, "
+            "later, by the experiment_analysis and paper_writing steps."
         ),
     }
 
@@ -160,10 +311,49 @@ def _paper_writing(inputs: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _latex_conversion(inputs: dict[str, Any]) -> dict[str, Any]:
+    paper_content = PaperContent.model_validate(inputs["paper_content"])
+    prompt = _render(
+        convert_to_latex_prompt,
+        {
+            "figures_dir": inputs.get("figures_dir", "images"),
+            "sections": [
+                {"name": field, "content": getattr(paper_content, field)}
+                for field in PaperContent.model_fields.keys()
+                if getattr(paper_content, field)
+            ],
+        },
+    )
+    return {
+        "steps": [
+            {
+                "name": "convert_to_latex",
+                "ready": True,
+                "prompt": prompt,
+                "output_json_schema": PaperContent.model_json_schema(),
+            }
+        ],
+        "flow": (
+            "1) Produce LaTeX-formatted PaperContent matching "
+            "output_json_schema. 2) Embed it into the template yourself: "
+            "read .research/latex/{template}/template.tex from your local "
+            "clone — it marks insertion points with << title >>, "
+            "<< abstract >>, << introduction >>, << related_work >>, "
+            "<< background >>, << method >>, << experimental_setup >>, "
+            "<< results >>, << conclusion >> — replace each marker with the "
+            "corresponding section and save the result as "
+            ".research/latex/{template}/main.tex, then push it with git."
+        ),
+    }
+
+
 _STEP_BUILDERS = {
     "research_queries": _research_queries,
+    "hypothesis": _hypothesis,
+    "experimental_design": _experimental_design,
     "experiment_analysis": _experiment_analysis,
     "paper_writing": _paper_writing,
+    "latex_conversion": _latex_conversion,
 }
 
 

--- a/backend/src/airas/mcp/prompt_registry.py
+++ b/backend/src/airas/mcp/prompt_registry.py
@@ -1,0 +1,175 @@
+"""Host-authoring prompt registry (dual-mode generation).
+
+Each generation step in AIRAS can run in one of two modes:
+
+- Backend mode: the corresponding MCP tool (e.g. ``generate_paper``) calls
+  the backend LLM with AIRAS's curated prompts. Requires an LLM provider
+  API key.
+- Host mode: the MCP host (Claude Code etc.) authors the artifact itself.
+  ``get_generation_prompt`` assembles the *same* prompts from the *same*
+  template files the backend nodes use — this module is a thin renderer on
+  top of them, so the two modes cannot drift apart.
+
+Every step returns a list of prompt steps plus a ``flow`` description. A
+prompt step is either fully rendered (``ready: true``) or a template whose
+documented placeholders the host must substitute (e.g. the refine prompt
+needs the host's own current draft).
+"""
+
+from typing import Any
+
+from jinja2 import Environment
+
+from airas.core.types.experiment_code import ExperimentCode
+from airas.core.types.experiment_history import ExperimentHistory
+from airas.core.types.experimental_design import ExperimentalDesign
+from airas.core.types.experimental_results import ExperimentalResults
+from airas.core.types.paper import PaperContent
+from airas.core.types.research_hypothesis import ResearchHypothesis
+from airas.core.types.research_study import ResearchStudy
+from airas.usecases.analyzers.analyze_experiment_subgraph.nodes.analyze_experiment import (
+    LLMOutput as AnalyzeExperimentOutput,
+)
+from airas.usecases.analyzers.analyze_experiment_subgraph.prompts.analyze_experiment_prompt import (
+    analyze_experiment_prompt,
+)
+from airas.usecases.generators.generate_queries_subgraph.nodes.generate_queries import (
+    LLMOutput as GenerateQueriesOutput,
+)
+from airas.usecases.generators.generate_queries_subgraph.prompt.generate_queries_prompt import (
+    generate_queries_prompt,
+)
+from airas.usecases.writers.write_subgraph.nodes.generate_note import generate_note
+from airas.usecases.writers.write_subgraph.prompts.refine_prompt import refine_prompt
+from airas.usecases.writers.write_subgraph.prompts.section_tips_prompt import (
+    section_tips_prompt,
+)
+from airas.usecases.writers.write_subgraph.prompts.write_prompt import write_prompt
+
+GENERATION_STEPS = ("research_queries", "experiment_analysis", "paper_writing")
+
+
+def _render(template: str, data: dict[str, Any]) -> str:
+    return Environment().from_string(template).render(data)
+
+
+def _research_queries(inputs: dict[str, Any]) -> dict[str, Any]:
+    prompt = _render(
+        generate_queries_prompt,
+        {
+            "research_topic": inputs["research_topic"],
+            "n_queries": inputs.get("num_queries", 2),
+        },
+    )
+    return {
+        "steps": [
+            {
+                "name": "generate_queries",
+                "ready": True,
+                "prompt": prompt,
+                "output_json_schema": GenerateQueriesOutput.model_json_schema(),
+            }
+        ],
+        "flow": (
+            "Produce output matching output_json_schema; the query_list is "
+            "what you would pass to search_papers."
+        ),
+    }
+
+
+def _experiment_analysis(inputs: dict[str, Any]) -> dict[str, Any]:
+    prompt = _render(
+        analyze_experiment_prompt,
+        {
+            "research_hypothesis": ResearchHypothesis.model_validate(
+                inputs["research_hypothesis"]
+            ),
+            "experimental_design": ExperimentalDesign.model_validate(
+                inputs["experimental_design"]
+            ),
+            "experiment_code": ExperimentCode.model_validate(inputs["experiment_code"]),
+            "experimental_results": ExperimentalResults.model_validate(
+                inputs["experimental_results"]
+            ),
+        },
+    )
+    return {
+        "steps": [
+            {
+                "name": "analyze_experiment",
+                "ready": True,
+                "prompt": prompt,
+                "output_json_schema": AnalyzeExperimentOutput.model_json_schema(),
+            }
+        ],
+        "flow": (
+            "Produce output matching output_json_schema; analysis_report is "
+            "the analysis text used by the paper-writing step."
+        ),
+    }
+
+
+def _paper_writing(inputs: dict[str, Any]) -> dict[str, Any]:
+    note = generate_note(
+        research_hypothesis=ResearchHypothesis.model_validate(
+            inputs["research_hypothesis"]
+        ),
+        experiment_history=ExperimentHistory.model_validate(
+            inputs["experiment_history"]
+        ),
+        experiment_code=ExperimentCode.model_validate(inputs["experiment_code"]),
+        research_study_list=[
+            ResearchStudy.model_validate(study)
+            for study in inputs["research_study_list"]
+        ],
+        references_bib=inputs["references_bib"],
+    )
+    write_message = _render(
+        write_prompt, {"note": note, "tips_dict": section_tips_prompt}
+    )
+    refinement_rounds = inputs.get("writing_refinement_rounds", 2)
+    return {
+        "steps": [
+            {
+                "name": "write_paper",
+                "ready": True,
+                "prompt": write_message,
+                "output_json_schema": PaperContent.model_json_schema(),
+            },
+            {
+                "name": "refine_paper",
+                "ready": False,
+                "placeholders": {
+                    "{{ content }}": "your current PaperContent draft as JSON"
+                },
+                "prompt": refine_prompt,
+                "prompt_prefix": (
+                    "Prepend the write_paper prompt above, then append this "
+                    "refine prompt with the placeholder substituted."
+                ),
+                "output_json_schema": PaperContent.model_json_schema(),
+            },
+        ],
+        "flow": (
+            "1) Author the full paper with the write_paper prompt. "
+            f"2) Run the refine_paper step {refinement_rounds} time(s): each "
+            "round, substitute {{ content }} with your latest draft and "
+            "produce an improved PaperContent. The final draft is what you "
+            "would pass to generate_latex as paper_content."
+        ),
+    }
+
+
+_STEP_BUILDERS = {
+    "research_queries": _research_queries,
+    "experiment_analysis": _experiment_analysis,
+    "paper_writing": _paper_writing,
+}
+
+
+def build_generation_prompt(step: str, inputs: dict[str, Any]) -> dict[str, Any]:
+    if step not in _STEP_BUILDERS:
+        raise ValueError(
+            f"Unknown step '{step}'. Available: {', '.join(GENERATION_STEPS)}"
+        )
+    return {"step": step, **_STEP_BUILDERS[step](inputs)}

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -218,11 +218,17 @@ def get_generation_prompt(step: str, inputs: dict[str, Any]) -> dict[str, Any]:
 
     `step` and the required `inputs` keys:
     - "research_queries": research_topic, num_queries (optional)
+    - "hypothesis": research_topic, research_study_list,
+      refinement_rounds (optional) — generate/evaluate/refine loop
+    - "experimental_design": research_hypothesis, compute_environment
+      (optional), num_models_to_use / num_datasets_to_use /
+      num_comparative_methods (optional)
     - "experiment_analysis": research_hypothesis, experimental_design,
       experiment_code ({"files": {path: content}}), experimental_results
     - "paper_writing": research_hypothesis, experiment_history,
       experiment_code, research_study_list, references_bib,
       writing_refinement_rounds (optional)
+    - "latex_conversion": paper_content, figures_dir (optional)
 
     Returns `steps` (each with a prompt and an output_json_schema to match)
     and `flow` (how to run multi-step loops). Steps with `ready: false`
@@ -393,11 +399,13 @@ async def generate_hypothesis(
     research_study_list: list[dict[str, Any]],
     refinement_rounds: int = 1,
 ) -> dict[str, Any]:
-    """Generate a novel research hypothesis from a topic and related studies.
+    """Generate a novel research hypothesis from a topic and related studies (backend LLM).
 
     `research_study_list` should be the output of `retrieve_papers`. Higher
     `refinement_rounds` improves quality at the cost of more LLM calls.
-    Requires an LLM provider API key.
+    Requires an LLM provider API key — without one, use
+    `get_generation_prompt(step="hypothesis", ...)` and run the
+    generate/evaluate/refine loop yourself.
     """
     studies = [ResearchStudy.model_validate(study) for study in research_study_list]
     result = (
@@ -427,12 +435,15 @@ async def generate_experimental_design(
     num_datasets_to_use: int = 1,
     num_comparative_methods: int = 1,
 ) -> dict[str, Any]:
-    """Design experiments to test a research hypothesis.
+    """Design experiments to test a research hypothesis (backend LLM).
 
     `research_hypothesis` should be the output of `generate_hypothesis`.
     `compute_environment` optionally describes the hardware the experiments
     will run on (e.g. {"gpu_type": "A100", "gpu_count": 1}); it constrains
-    the design to what is actually runnable. Requires an LLM provider API key.
+    the design to what is actually runnable. Requires an LLM provider API
+    key — without one, use
+    `get_generation_prompt(step="experimental_design", ...)` and author the
+    design yourself.
     """
     env = ComputeEnvironment.model_validate(compute_environment or {})
     result = (
@@ -1046,14 +1057,16 @@ async def generate_latex(
     references_bib: str,
     latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
 ) -> str:
-    """Convert paper content into a full LaTeX document.
+    """Convert paper content into a full LaTeX document (backend LLM).
 
     `paper_content` should be the output of `generate_paper`. Available
     templates: "mdpi", "iclr2024", "agents4science_2025". Write the returned
     LaTeX to `.research/latex/{template}/main.tex` in your local clone of
     the experiment repository and push it with git, then build the PDF with
     `compile_latex` and/or hand it over with `open_in_overleaf`. Requires an
-    LLM provider API key and GH_PERSONAL_ACCESS_TOKEN.
+    LLM provider API key and GH_PERSONAL_ACCESS_TOKEN — without them, use
+    `get_generation_prompt(step="latex_conversion", ...)` and do the
+    conversion yourself with the template from your local clone.
     """
     result = (
         await GenerateLatexSubgraph(

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -68,6 +68,7 @@ from airas.infra.llm_provider_resolver import detect_available_providers
 from airas.infra.openalex_client import OpenAlexClient
 from airas.infra.retry_policy import HTTPClientFatalError, HTTPClientRetryableError
 from airas.infra.semantic_scholar_client import SemanticScholarClient
+from airas.mcp.prompt_registry import build_generation_prompt
 from airas.usecases.analyzers.analyze_experiment_subgraph.analyze_experiment_subgraph import (
     AnalyzeExperimentSubgraph,
 )
@@ -207,14 +208,44 @@ def _dump(value: Any) -> Any:
 
 
 @mcp.tool()
+def get_generation_prompt(step: str, inputs: dict[str, Any]) -> dict[str, Any]:
+    """Assemble AIRAS's curated prompt(s) for a generation step so you (the
+    MCP host) can author the artifact yourself — no LLM API key required.
+
+    Generation steps run in one of two modes: the backend-LLM tool
+    (`generate_research_queries` / `analyze_experiment` / `generate_paper`,
+    needs a provider key) or host mode via this tool. Both use the same
+    prompt templates, so quality guidance is identical. Prefer host mode
+    when no LLM provider key is configured, or when your own context (the
+    conversation, code you wrote) should inform the writing.
+
+    `step` and the required `inputs` keys:
+    - "research_queries": research_topic, num_queries (optional)
+    - "experiment_analysis": research_hypothesis, experimental_design,
+      experiment_code ({"files": {path: content}}), experimental_results
+    - "paper_writing": research_hypothesis, experiment_history,
+      experiment_code, research_study_list, references_bib,
+      writing_refinement_rounds (optional)
+
+    Returns `steps` (each with a prompt and an output_json_schema to match)
+    and `flow` (how to run multi-step loops). Steps with `ready: false`
+    contain documented placeholders you must substitute.
+    """
+    return build_generation_prompt(step, inputs)
+
+
+@mcp.tool()
 async def generate_research_queries(
     research_topic: str,
     num_queries: int = 2,
 ) -> list[str]:
-    """Generate academic paper search queries from a research topic.
+    """Generate academic paper search queries from a research topic (backend LLM).
 
     Use this first to turn a free-form research topic into effective
-    search queries, then pass them to `search_papers`.
+    search queries, then pass them to `search_papers`. Requires an LLM
+    provider API key — without one, use
+    `get_generation_prompt(step="research_queries", ...)` and author the
+    queries yourself.
     """
     result = (
         await GenerateQueriesSubgraph(
@@ -809,7 +840,9 @@ async def analyze_experiment(
     (findings, whether the hypothesis is supported, and suggested next
     steps). For `experiment_code`, read the code from your local clone and
     pass `{"files": {"<relative path>": "<content>", ...}}`.
-    Requires an LLM provider API key.
+    Requires an LLM provider API key — without one, use
+    `get_generation_prompt(step="experiment_analysis", ...)` and write the
+    analysis yourself.
     """
     result = (
         await AnalyzeExperimentSubgraph(
@@ -1018,12 +1051,14 @@ async def generate_paper(
     references_bib: str,
     writing_refinement_rounds: int = 2,
 ) -> dict[str, Any]:
-    """Write the paper content from the completed research.
+    """Write the paper content from the completed research (backend LLM).
 
     Takes the hypothesis, experiment history, experiment code, related
     studies, and the BibTeX file (from `generate_bibfile`), and produces
     structured paper content (title, abstract, sections). Pass the result
-    to `generate_latex`. Requires an LLM provider API key.
+    to `generate_latex`. Requires an LLM provider API key — without one, use
+    `get_generation_prompt(step="paper_writing", ...)` and author the paper
+    yourself with the same curated prompts.
     """
     result = (
         await WriteSubgraph(

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -218,21 +218,19 @@ def get_generation_prompt(step: str, inputs: dict[str, Any]) -> dict[str, Any]:
 
     `step` and the required `inputs` keys:
     - "research_queries": research_topic, num_queries (optional)
-    - "hypothesis": research_topic, research_study_list,
-      refinement_rounds (optional) — generate/evaluate/refine loop
+    - "hypothesis": research_topic, research_study_list
     - "experimental_design": research_hypothesis, compute_environment
       (optional), num_models_to_use / num_datasets_to_use /
       num_comparative_methods (optional)
     - "experiment_analysis": research_hypothesis, experimental_design,
       experiment_code ({"files": {path: content}}), experimental_results
     - "paper_writing": research_hypothesis, experiment_history,
-      experiment_code, research_study_list, references_bib,
-      writing_refinement_rounds (optional)
+      experiment_code, research_study_list, references_bib
     - "latex_conversion": paper_content, figures_dir (optional)
 
-    Returns `steps` (each with a prompt and an output_json_schema to match)
-    and `flow` (how to run multi-step loops). Steps with `ready: false`
-    contain documented placeholders you must substitute.
+    Returns a fully rendered `prompt`, an `output_json_schema` describing
+    exactly the data format to produce in one pass, and a `flow` note on
+    how the output feeds the next step.
     """
     return build_generation_prompt(step, inputs)
 
@@ -404,8 +402,8 @@ async def generate_hypothesis(
     `research_study_list` should be the output of `retrieve_papers`. Higher
     `refinement_rounds` improves quality at the cost of more LLM calls.
     Requires an LLM provider API key — without one, use
-    `get_generation_prompt(step="hypothesis", ...)` and run the
-    generate/evaluate/refine loop yourself.
+    `get_generation_prompt(step="hypothesis", ...)` and author the
+    hypothesis yourself.
     """
     studies = [ResearchStudy.model_validate(study) for study in research_study_list]
     result = (
@@ -1024,7 +1022,7 @@ async def generate_paper(
     structured paper content (title, abstract, sections). Pass the result
     to `generate_latex`. Requires an LLM provider API key — without one, use
     `get_generation_prompt(step="paper_writing", ...)` and author the paper
-    yourself with the same curated prompts.
+    yourself in one pass with the same curated prompt.
     """
     result = (
         await WriteSubgraph(

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -90,9 +90,6 @@ from airas.usecases.generators.generate_hypothesis_subgraph.generate_hypothesis_
 from airas.usecases.generators.generate_queries_subgraph.generate_queries_subgraph import (
     GenerateQueriesSubgraph,
 )
-from airas.usecases.generators.refine_experimental_design_subgraph.refine_experimental_design_subgraph import (
-    RefineExperimentalDesignSubgraph,
-)
 from airas.usecases.github.download_github_actions_artifacts_subgraph.download_github_actions_artifacts_subgraph import (
     DownloadGithubActionsArtifactsSubgraph,
 )
@@ -452,48 +449,6 @@ async def generate_experimental_design(
                 "research_hypothesis": ResearchHypothesis.model_validate(
                     research_hypothesis
                 ),
-            }
-        )
-    )
-    return _dump(result["experimental_design"])
-
-
-@mcp.tool()
-async def refine_experimental_design(
-    research_hypothesis: dict[str, Any],
-    experiment_history: dict[str, Any],
-    design_instruction: str,
-    compute_environment: dict[str, Any] | None = None,
-    num_models_to_use: int = 1,
-    num_datasets_to_use: int = 1,
-    num_comparative_methods: int = 1,
-) -> dict[str, Any]:
-    """Refine an experimental design based on results so far and an instruction.
-
-    Use after experiments have run: `experiment_history` carries the designs
-    and results accumulated so far, and `design_instruction` states what to
-    change (e.g. "add an ablation for the attention variant"). Returns the
-    revised experimental design. Requires an LLM provider API key.
-    """
-    env = ComputeEnvironment.model_validate(compute_environment or {})
-    result = (
-        await RefineExperimentalDesignSubgraph(
-            langchain_client=_langchain_client(),
-            compute_environment=env,
-            num_models_to_use=num_models_to_use,
-            num_datasets_to_use=num_datasets_to_use,
-            num_comparative_methods=num_comparative_methods,
-        )
-        .build_graph()
-        .ainvoke(
-            {
-                "research_hypothesis": ResearchHypothesis.model_validate(
-                    research_hypothesis
-                ),
-                "experiment_history": ExperimentHistory.model_validate(
-                    experiment_history
-                ),
-                "design_instruction": design_instruction,
             }
         )
     )

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -59,7 +59,8 @@ Or add it to your project's `.mcp.json`:
 
 | Tool | Description |
 | --- | --- |
-| `generate_research_queries` | Generate paper search queries from a research topic |
+| `get_generation_prompt` | Assemble AIRAS's curated prompts for a generation step (research_queries / experiment_analysis / paper_writing) so the MCP host can author the artifact itself; no API keys required |
+| `generate_research_queries` | Generate paper search queries from a research topic (backend LLM) |
 | `search_papers` | Multi-source paper search (OpenAlex / Semantic Scholar / arXiv / AIRAS DB) with normalized, de-duplicated results; no API keys required |
 | `fetch_paper_fulltext` | Fetch a paper's full text by arXiv ID, DOI, or PDF URL (legal open-access resolution only); no API keys required |
 | `retrieve_papers` | Fetch papers via arXiv and extract structured research study data |
@@ -99,6 +100,8 @@ Or add it to your project's `.mcp.json`:
 | --- | --- |
 | `upload_research_history` | Save research state to the experiment repository |
 | `download_research_history` | Restore research state to continue in a later session |
+
+Generation steps are dual-mode: run them on the backend LLM (the tools below, requires an LLM provider key) or author them yourself with the same curated prompts via `get_generation_prompt` (no key required). Currently host-authorable: `research_queries`, `experiment_analysis`, `paper_writing`.
 
 A typical flow: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **write the experiment code yourself** (see below) → `dispatch_experiment` → (poll `get_workflow_runs` for GitHub Actions, or `get_experiment_run_status` for AIXS) → `fetch_experiment_results` → `analyze_experiment` → **create figures and diagrams yourself** (see below) → `generate_bibfile` → `generate_paper` → `generate_latex` → **write the returned LaTeX to `.research/latex/{template}/main.tex` in your clone and push it with git** → **either or both of** `compile_latex` (build the PDF on GitHub Actions) / `open_in_overleaf` (hand the project to the user for editing; with `local_path`, no push needed) → `upload_research_history`.
 

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -59,7 +59,7 @@ Or add it to your project's `.mcp.json`:
 
 | Tool | Description |
 | --- | --- |
-| `get_generation_prompt` | Assemble AIRAS's curated prompts for a generation step (research_queries / experiment_analysis / paper_writing) so the MCP host can author the artifact itself; no API keys required |
+| `get_generation_prompt` | Assemble AIRAS's curated prompts for a generation step (research_queries / hypothesis / experimental_design / experiment_analysis / paper_writing / latex_conversion) so the MCP host can author the artifact itself; no API keys required |
 | `generate_research_queries` | Generate paper search queries from a research topic (backend LLM) |
 | `search_papers` | Multi-source paper search (OpenAlex / Semantic Scholar / arXiv / AIRAS DB) with normalized, de-duplicated results; no API keys required |
 | `fetch_paper_fulltext` | Fetch a paper's full text by arXiv ID, DOI, or PDF URL (legal open-access resolution only); no API keys required |
@@ -100,7 +100,7 @@ Or add it to your project's `.mcp.json`:
 | `upload_research_history` | Save research state to the experiment repository |
 | `download_research_history` | Restore research state to continue in a later session |
 
-Generation steps are dual-mode: run them on the backend LLM (the tools below, requires an LLM provider key) or author them yourself with the same curated prompts via `get_generation_prompt` (no key required). Currently host-authorable: `research_queries`, `experiment_analysis`, `paper_writing`.
+Generation steps are dual-mode: run them on the backend LLM (the tools below, requires an LLM provider key) or author them yourself with the same curated prompts via `get_generation_prompt` (no key required). Host-authorable steps: `research_queries`, `hypothesis`, `experimental_design`, `experiment_analysis`, `paper_writing`, `latex_conversion` — every prompt comes with an `output_json_schema` describing exactly the data format to produce.
 
 A typical flow: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **write the experiment code yourself** (see below) → `dispatch_experiment` → (poll `get_workflow_runs` for GitHub Actions, or `get_experiment_run_status` for AIXS) → `fetch_experiment_results` → `analyze_experiment` → **create figures and diagrams yourself** (see below) → `generate_bibfile` → `generate_paper` → `generate_latex` → **write the returned LaTeX to `.research/latex/{template}/main.tex` in your clone and push it with git** → **either or both of** `compile_latex` (build the PDF on GitHub Actions) / `open_in_overleaf` (hand the project to the user for editing; with `local_path`, no push needed) → `upload_research_history`.
 

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -66,7 +66,6 @@ Or add it to your project's `.mcp.json`:
 | `retrieve_papers` | Fetch papers via arXiv and extract structured research study data |
 | `generate_hypothesis` | Generate a novel research hypothesis from a topic and related studies |
 | `generate_experimental_design` | Design experiments to test a hypothesis |
-| `refine_experimental_design` | Refine a design based on results so far and an instruction |
 | `retrieve_models` | List curated candidate models for a subfield; no API key required |
 | `retrieve_datasets` | List curated candidate datasets for a subfield; no API key required |
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -66,7 +66,6 @@ claude mcp add airas -- uvx airas
 | `retrieve_papers` | arXiv経由で論文を取得し、構造化された研究データを抽出 |
 | `generate_hypothesis` | トピックと関連研究から新規の研究仮説を生成 |
 | `generate_experimental_design` | 仮説を検証する実験を設計 |
-| `refine_experimental_design` | これまでの結果と指示に基づき実験設計を改良 |
 | `retrieve_models` | サブ分野ごとの候補モデル一覧を取得。APIキー不要 |
 | `retrieve_datasets` | サブ分野ごとの候補データセット一覧を取得。APIキー不要 |
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -59,7 +59,8 @@ claude mcp add airas -- uvx airas
 
 | ツール | 説明 |
 | --- | --- |
-| `generate_research_queries` | 研究トピックから論文検索クエリを生成 |
+| `get_generation_prompt` | 生成ステップ（research_queries / experiment_analysis / paper_writing）のキュレート済みプロンプトを組み立てて返し、MCPホスト自身が成果物を執筆できるようにする。APIキー不要 |
+| `generate_research_queries` | 研究トピックから論文検索クエリを生成（バックエンドLLM） |
 | `search_papers` | 複数ソース（OpenAlex / Semantic Scholar / arXiv / AIRAS DB）の並列論文検索。結果は正規化・重複排除済み。APIキー不要 |
 | `fetch_paper_fulltext` | arXiv ID / DOI / PDF URL から論文全文を取得（合法なオープンアクセス解決のみ）。APIキー不要 |
 | `retrieve_papers` | arXiv経由で論文を取得し、構造化された研究データを抽出 |
@@ -99,6 +100,8 @@ claude mcp add airas -- uvx airas
 | --- | --- |
 | `upload_research_history` | 研究状態を実験リポジトリに保存 |
 | `download_research_history` | 保存した研究状態を復元し、別セッションで継続 |
+
+生成ステップは**デュアルモード**です: バックエンドLLMで実行する（下記の各ツール、LLMプロバイダーキーが必要）か、`get_generation_prompt` で同じキュレート済みプロンプトを受け取ってホスト自身が執筆する（キー不要）かを選べます。現在ホスト執筆に対応: `research_queries` / `experiment_analysis` / `paper_writing`
 
 典型的なフロー: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **実験コードを自分で書く**（下記参照）→ `dispatch_experiment` →（GitHub Actions は `get_workflow_runs`、AIXS は `get_experiment_run_status` でポーリング）→ `fetch_experiment_results` → `analyze_experiment` → **図とダイアグラムを自分で作る**（下記参照）→ `generate_bibfile` → `generate_paper` → `generate_latex` → **返された LaTeX を clone 内の `.research/latex/{テンプレート}/main.tex` に書いて git で push** → **出口は2つ（片方でも両方でも）**: `compile_latex`（GitHub ActionsでPDFをビルド）/ `open_in_overleaf`（ユーザーが編集できる形でOverleafに引き渡し。`local_path` 指定なら push 不要）→ `upload_research_history`
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -59,7 +59,7 @@ claude mcp add airas -- uvx airas
 
 | ツール | 説明 |
 | --- | --- |
-| `get_generation_prompt` | 生成ステップ（research_queries / experiment_analysis / paper_writing）のキュレート済みプロンプトを組み立てて返し、MCPホスト自身が成果物を執筆できるようにする。APIキー不要 |
+| `get_generation_prompt` | 生成ステップ（research_queries / hypothesis / experimental_design / experiment_analysis / paper_writing / latex_conversion）のキュレート済みプロンプトを組み立てて返し、MCPホスト自身が成果物を執筆できるようにする。APIキー不要 |
 | `generate_research_queries` | 研究トピックから論文検索クエリを生成（バックエンドLLM） |
 | `search_papers` | 複数ソース（OpenAlex / Semantic Scholar / arXiv / AIRAS DB）の並列論文検索。結果は正規化・重複排除済み。APIキー不要 |
 | `fetch_paper_fulltext` | arXiv ID / DOI / PDF URL から論文全文を取得（合法なオープンアクセス解決のみ）。APIキー不要 |
@@ -100,7 +100,7 @@ claude mcp add airas -- uvx airas
 | `upload_research_history` | 研究状態を実験リポジトリに保存 |
 | `download_research_history` | 保存した研究状態を復元し、別セッションで継続 |
 
-生成ステップは**デュアルモード**です: バックエンドLLMで実行する（下記の各ツール、LLMプロバイダーキーが必要）か、`get_generation_prompt` で同じキュレート済みプロンプトを受け取ってホスト自身が執筆する（キー不要）かを選べます。現在ホスト執筆に対応: `research_queries` / `experiment_analysis` / `paper_writing`
+生成ステップは**デュアルモード**です: バックエンドLLMで実行する（下記の各ツール、LLMプロバイダーキーが必要）か、`get_generation_prompt` で同じキュレート済みプロンプトを受け取ってホスト自身が執筆する（キー不要）かを選べます。ホスト執筆対応ステップ: `research_queries` / `hypothesis` / `experimental_design` / `experiment_analysis` / `paper_writing` / `latex_conversion` — 各プロンプトには**作成すべきデータ形式を正確に示す `output_json_schema`** が付属します
 
 典型的なフロー: `generate_research_queries` → `search_papers` → `retrieve_papers` → `generate_hypothesis` → `generate_experimental_design` → `prepare_repository` → **実験コードを自分で書く**（下記参照）→ `dispatch_experiment` →（GitHub Actions は `get_workflow_runs`、AIXS は `get_experiment_run_status` でポーリング）→ `fetch_experiment_results` → `analyze_experiment` → **図とダイアグラムを自分で作る**（下記参照）→ `generate_bibfile` → `generate_paper` → `generate_latex` → **返された LaTeX を clone 内の `.research/latex/{テンプレート}/main.tex` に書いて git で push** → **出口は2つ（片方でも両方でも）**: `compile_latex`（GitHub ActionsでPDFをビルド）/ `open_in_overleaf`（ユーザーが編集できる形でOverleafに引き渡し。`local_path` 指定なら push 不要）→ `upload_research_history`
 


### PR DESCRIPTION
## 概要
生成系ツールの位置付け（論点8）への対応第一弾です。生成ステップを**デュアルモード**にします:

- **バックエンドモード**（従来どおり）: `generate_research_queries` / `analyze_experiment` / `generate_paper` がバックエンドLLMを呼ぶ。LLMプロバイダーキーが必要。E2E・ダッシュボードもこちら
- **ホストモード**（新設）: 新ツール `get_generation_prompt(step, inputs)` がバックエンドノードと**同一のテンプレート・同一の入力**からプロンプトを組み立てて返し、MCPホスト（Claude Code等）が自分で執筆する。**LLM APIキー不要**

## 設計のポイント
- **単一ソース**: `mcp/prompt_registry.py` は既存の prompts/*.py テンプレートと Pydantic モデルへの薄いレンダラ。プロンプトを複製しないため両モードがドリフトしない
- **単発出力**: バックエンドの内部ループはホストモードでは再現せず、1プロンプト=1成果物。placeholder 機構は不要になり返却形式もフラット
- **入力検証**: inputs は既存の Pydantic モデルで検証（不正入力は明確なエラー）
- **フラグ方式は不採用**: 各ツールに return_prompt 引数を生やすより、プロンプト組み立てを1ツールに集約する方が保守が容易

## あわせて削除
- **`refine_experimental_design` ツールを削除**（ツール数 28 → 27）。実験履歴を踏まえた設計の差分改訂はホストエージェント自身が行えるため。サブグラフはE2E・ダッシュボード用に温存



## 対応ステップ（全生成系をカバー、すべて単発出力）
`research_queries` / `hypothesis` / `experimental_design` / `experiment_analysis` / `paper_writing` / `latex_conversion`

すべてのステップは **`{step, prompt, output_json_schema, flow}` のフラットな単一プロンプト**を返します。バックエンド内部でループする処理（仮説の生成→評価→リファイン、論文の write→refine）も、ホストモードではループを再現させず**1回の出力で完結**する指示にしています（ホストは自身の文脈で最良の成果物を一度で書く）。`latex_conversion` の flow はテンプレート埋め込み手順（`<< marker >>` 置換 → main.tex 保存）を案内します。

対象外は `retrieve_papers` のみ（ホスト実行だと論文全文でコンテキストを大量消費するため、バックエンド維持がコンテキスト隔離の利点）。

## Verification
- [x] 6ステップすべてで実レンダリング確認（write プロンプト 12k 文字、スキーマ付与、placeholder 検出）
- [x] 不正な step 名・不正な inputs が明確なエラーになること
- [x] MCPサーバーロードで27ツール（refine_experimental_design 不在確認済み）
- [x] ruff / mypy Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
