### PR TITLE
feat: one-click secrets sync to experiment repos from the API Keys page

### DIFF
--- a/backend/src/airas/dashboard/api/routes/v1/github_actions.py
+++ b/backend/src/airas/dashboard/api/routes/v1/github_actions.py
@@ -70,7 +70,10 @@ async def set_github_actions_secrets(
     config = {"callbacks": [handler]} if handler else {}
 
     result = (
-        await SetGithubActionsSecretsSubgraph(github_client=github_client)
+        await SetGithubActionsSecretsSubgraph(
+            github_client=github_client,
+            secret_names=request.secret_names,
+        )
         .build_graph()
         .ainvoke(request, config=config)
     )

--- a/backend/src/airas/dashboard/api/schemas/github_actions.py
+++ b/backend/src/airas/dashboard/api/schemas/github_actions.py
@@ -16,6 +16,8 @@ class PollGithubActionsResponseBody(BaseModel):
 
 class SetGithubActionsSecretsRequestBody(BaseModel):
     github_config: GitHubConfig
+    # None syncs the default credential set; a list restricts to those names.
+    secret_names: list[str] | None = None
 
 
 class SetGithubActionsSecretsResponseBody(BaseModel):

--- a/backend/src/airas/usecases/github/set_github_actions_secrets_subgraph/set_github_actions_secrets_subgraph.py
+++ b/backend/src/airas/usecases/github/set_github_actions_secrets_subgraph/set_github_actions_secrets_subgraph.py
@@ -37,7 +37,7 @@ class SetGithubActionsSecretsSubgraph:
         self,
         github_client: GithubClient,
         secret_names: list[str]
-        | None = None,  # TODO: no caller passes a custom list; consider removing
+        | None = None,  # None syncs the default set; the dashboard passes one name
     ):
         self.secret_names = secret_names or [
             "OPENAI_API_KEY",

--- a/frontend/src/components/pages/settings/api-keys.tsx
+++ b/frontend/src/components/pages/settings/api-keys.tsx
@@ -45,8 +45,8 @@ export function ApiKeysPage() {
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [syncRepo, setSyncRepo] = useState("");
-  const [syncing, setSyncing] = useState(false);
-  const [syncResult, setSyncResult] = useState<"success" | "error" | null>(null);
+  const [syncingName, setSyncingName] = useState<string | null>(null);
+  const [syncResults, setSyncResults] = useState<Record<string, "success" | "error">>({});
 
   useEffect(() => {
     CredentialsService.listCredentialsAirasV1CredentialsGet()
@@ -89,6 +89,17 @@ export function ApiKeysPage() {
       : credential.is_set
         ? `${t("credentials.configured")}${credential.preview ? ` (${credential.preview})` : ""} — ${t("credentials.replacePlaceholder")}`
         : `${t("credentials.notConfigured")} — ${t("credentials.placeholder")}`;
+    // GH_PERSONAL_ACCESS_TOKEN is the gate for syncing, not a syncable
+    // secret itself (the experiment workflows use the runner's own token).
+    const syncable = credential.is_secret && credential.name !== "GH_PERSONAL_ACCESS_TOKEN";
+    const syncDisabledReason = !githubTokenSet
+      ? t("credentials.sync.requiresToken")
+      : parsedSync.repo === "" || parsedSync.owner === ""
+        ? t("credentials.sync.requiresRepo")
+        : !credential.is_set
+          ? t("credentials.sync.requiresValue")
+          : undefined;
+    const syncResult = syncResults[credential.name];
     return (
       <div key={credential.name} className="flex items-center gap-3">
         <span className="w-72 shrink-0 text-caption-bold font-caption-bold text-default-font break-all">
@@ -113,6 +124,32 @@ export function ApiKeysPage() {
             </Button>
           )}
         </div>
+        {syncable && (
+          <div className="w-40 shrink-0 flex items-center gap-2" title={syncDisabledReason}>
+            <Button
+              variant="neutral-secondary"
+              size="small"
+              disabled={syncDisabledReason !== undefined || syncingName !== null}
+              onClick={() => handleSyncSecret(credential.name)}
+            >
+              {syncingName === credential.name
+                ? t("credentials.sync.syncing")
+                : t("credentials.sync.rowButton")}
+            </Button>
+            {syncResult === "success" && (
+              <FeatherCheckCircle
+                className="text-success-600"
+                aria-label={t("credentials.sync.rowSynced")}
+              />
+            )}
+            {syncResult === "error" && (
+              <FeatherAlertTriangle
+                className="text-error-600"
+                aria-label={t("credentials.sync.rowError")}
+              />
+            )}
+          </div>
+        )}
       </div>
     );
   };
@@ -134,9 +171,13 @@ export function ApiKeysPage() {
     ? { owner: syncRepo.split("/")[0].trim(), repo: syncRepo.split("/")[1].trim() }
     : { owner: githubOwner?.preview ?? "", repo: syncRepo.trim() };
 
-  const handleSyncSecrets = async () => {
-    setSyncing(true);
-    setSyncResult(null);
+  const handleSyncSecret = async (name: string) => {
+    setSyncingName(name);
+    setSyncResults((prev) => {
+      const next = { ...prev };
+      delete next[name];
+      return next;
+    });
     try {
       const res = await GithubActionsService.setGithubActionsSecretsAirasV1GithubActionsSecretsPost(
         {
@@ -145,13 +186,14 @@ export function ApiKeysPage() {
             repository_name: parsedSync.repo,
             branch_name: "main",
           },
+          secret_names: [name],
         },
       );
-      setSyncResult(res.secrets_set ? "success" : "error");
+      setSyncResults((prev) => ({ ...prev, [name]: res.secrets_set ? "success" : "error" }));
     } catch {
-      setSyncResult("error");
+      setSyncResults((prev) => ({ ...prev, [name]: "error" }));
     } finally {
-      setSyncing(false);
+      setSyncingName(null);
     }
   };
 
@@ -198,7 +240,35 @@ export function ApiKeysPage() {
             </h2>
             <div className="mt-2 rounded-lg border border-border bg-card p-6 flex flex-col gap-5">
               {section.items.map(renderCredential)}
+              {section.key === "github" && (
+                <div className="flex items-center gap-3 border-t border-border pt-4">
+                  <span className="w-72 shrink-0 text-caption-bold font-caption-bold text-default-font">
+                    {t("credentials.sync.targetLabel")}
+                  </span>
+                  <TextField className="flex-1" error={false}>
+                    <TextField.Input
+                      type="text"
+                      placeholder={
+                        githubOwner?.preview
+                          ? t("credentials.sync.repoPlaceholderWithOwner", {
+                              owner: githubOwner.preview,
+                            })
+                          : t("credentials.sync.repoPlaceholder")
+                      }
+                      value={syncRepo}
+                      onChange={(e) => setSyncRepo(e.target.value)}
+                      disabled={!githubTokenSet}
+                    />
+                  </TextField>
+                  <div className="w-16 shrink-0" />
+                </div>
+              )}
             </div>
+            {section.key === "github" && (
+              <p className="text-caption font-caption text-subtext-color mt-2">
+                {githubTokenSet ? t("credentials.sync.hint") : t("credentials.sync.requiresToken")}
+              </p>
+            )}
           </div>
         ))}
 
@@ -209,64 +279,6 @@ export function ApiKeysPage() {
           <Button onClick={handleSave} disabled={saving || Object.keys(edits).length === 0}>
             {saving ? t("credentials.saving") : t("credentials.save")}
           </Button>
-        </div>
-
-        <div className="mt-8">
-          <h2 className="text-heading-3 font-heading-3 text-default-font">
-            {t("credentials.sync.title")}
-          </h2>
-          <p className="text-caption font-caption text-subtext-color mt-1">
-            {t("credentials.sync.subtitle")}
-          </p>
-          <div className="mt-2 rounded-lg border border-border bg-card p-6 flex flex-col gap-4">
-            <div className="flex items-center gap-3">
-              <TextField className="flex-1" error={false}>
-                <TextField.Input
-                  type="text"
-                  placeholder={
-                    githubOwner?.preview
-                      ? t("credentials.sync.repoPlaceholderWithOwner", {
-                          owner: githubOwner.preview,
-                        })
-                      : t("credentials.sync.repoPlaceholder")
-                  }
-                  value={syncRepo}
-                  onChange={(e) => {
-                    setSyncResult(null);
-                    setSyncRepo(e.target.value);
-                  }}
-                  disabled={!githubTokenSet}
-                />
-              </TextField>
-              <Button
-                onClick={handleSyncSecrets}
-                disabled={!githubTokenSet || syncing || !parsedSync.owner || !parsedSync.repo}
-              >
-                {syncing ? t("credentials.sync.syncing") : t("credentials.sync.button")}
-              </Button>
-            </div>
-            {!githubTokenSet && (
-              <p className="text-caption font-caption text-subtext-color">
-                {t("credentials.sync.requiresToken")}
-              </p>
-            )}
-            {syncResult === "success" && (
-              <Alert
-                variant="success"
-                icon={<FeatherCheckCircle />}
-                title={t("credentials.sync.successTitle", {
-                  repo: `${parsedSync.owner}/${parsedSync.repo}`,
-                })}
-              />
-            )}
-            {syncResult === "error" && (
-              <Alert
-                variant="error"
-                icon={<FeatherAlertTriangle />}
-                title={t("credentials.sync.errorTitle")}
-              />
-            )}
-          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/pages/settings/api-keys.tsx
+++ b/frontend/src/components/pages/settings/api-keys.tsx
@@ -1,13 +1,28 @@
 import { FeatherAlertTriangle, FeatherCheckCircle } from "@subframe/core";
+import type { TFunction } from "i18next";
 import { Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { ApiError } from "@/lib/api/core/ApiError";
 import type { CredentialStatus } from "@/lib/api/models/CredentialStatus";
 import { CredentialsService } from "@/lib/api/services/CredentialsService";
 import { GithubActionsService } from "@/lib/api/services/GithubActionsService";
 import { Alert } from "@/ui/components/Alert";
 import { Button } from "@/ui/components/Button";
 import { TextField } from "@/ui/components/TextField";
+
+// Turn a caught request failure into a short " (reason)" suffix so the user
+// sees why a save failed instead of a generic message.
+function describeApiError(error: unknown, t: TFunction): string {
+  if (error instanceof ApiError) {
+    const detail = (error.body as { detail?: unknown } | undefined)?.detail;
+    if (typeof detail === "string" && detail) return `: ${detail}`;
+    if (error.status) return `: ${error.status} ${error.statusText}`.trimEnd();
+    return "";
+  }
+  // No HTTP response at all — the dashboard API is unreachable.
+  return `: ${t("credentials.networkError")}`;
+}
 
 const CATEGORIES: { key: string; names: string[] }[] = [
   { key: "github", names: ["GH_PERSONAL_ACCESS_TOKEN", "GITHUB_OWNER"] },
@@ -72,8 +87,8 @@ export function ApiKeysPage() {
       setCredentials(res.credentials);
       setEdits({});
       setSaved(true);
-    } catch {
-      setError(t("credentials.saveError"));
+    } catch (e) {
+      setError(`${t("credentials.saveError")}${describeApiError(e, t)}`);
     } finally {
       setSaving(false);
     }

--- a/frontend/src/components/pages/settings/api-keys.tsx
+++ b/frontend/src/components/pages/settings/api-keys.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { CredentialStatus } from "@/lib/api/models/CredentialStatus";
 import { CredentialsService } from "@/lib/api/services/CredentialsService";
+import { GithubActionsService } from "@/lib/api/services/GithubActionsService";
 import { Alert } from "@/ui/components/Alert";
 import { Button } from "@/ui/components/Button";
 import { TextField } from "@/ui/components/TextField";
@@ -43,6 +44,9 @@ export function ApiKeysPage() {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [syncRepo, setSyncRepo] = useState("");
+  const [syncing, setSyncing] = useState(false);
+  const [syncResult, setSyncResult] = useState<"success" | "error" | null>(null);
 
   useEffect(() => {
     CredentialsService.listCredentialsAirasV1CredentialsGet()
@@ -122,6 +126,35 @@ export function ApiKeysPage() {
   }
 
   const all = credentials ?? [];
+  const isSet = (name: string) => all.some((c) => c.name === name && c.is_set);
+  const githubTokenSet = isSet("GH_PERSONAL_ACCESS_TOKEN");
+  const githubOwner = all.find((c) => c.name === "GITHUB_OWNER");
+  // "owner/repo" also works; a bare name falls back to the GITHUB_OWNER credential.
+  const parsedSync = syncRepo.includes("/")
+    ? { owner: syncRepo.split("/")[0].trim(), repo: syncRepo.split("/")[1].trim() }
+    : { owner: githubOwner?.preview ?? "", repo: syncRepo.trim() };
+
+  const handleSyncSecrets = async () => {
+    setSyncing(true);
+    setSyncResult(null);
+    try {
+      const res = await GithubActionsService.setGithubActionsSecretsAirasV1GithubActionsSecretsPost(
+        {
+          github_config: {
+            github_owner: parsedSync.owner,
+            repository_name: parsedSync.repo,
+            branch_name: "main",
+          },
+        },
+      );
+      setSyncResult(res.secrets_set ? "success" : "error");
+    } catch {
+      setSyncResult("error");
+    } finally {
+      setSyncing(false);
+    }
+  };
+
   const categorizedNames = new Set(CATEGORIES.flatMap((c) => c.names));
   const sections = [
     ...CATEGORIES.map((category) => ({
@@ -176,6 +209,64 @@ export function ApiKeysPage() {
           <Button onClick={handleSave} disabled={saving || Object.keys(edits).length === 0}>
             {saving ? t("credentials.saving") : t("credentials.save")}
           </Button>
+        </div>
+
+        <div className="mt-8">
+          <h2 className="text-heading-3 font-heading-3 text-default-font">
+            {t("credentials.sync.title")}
+          </h2>
+          <p className="text-caption font-caption text-subtext-color mt-1">
+            {t("credentials.sync.subtitle")}
+          </p>
+          <div className="mt-2 rounded-lg border border-border bg-card p-6 flex flex-col gap-4">
+            <div className="flex items-center gap-3">
+              <TextField className="flex-1" error={false}>
+                <TextField.Input
+                  type="text"
+                  placeholder={
+                    githubOwner?.preview
+                      ? t("credentials.sync.repoPlaceholderWithOwner", {
+                          owner: githubOwner.preview,
+                        })
+                      : t("credentials.sync.repoPlaceholder")
+                  }
+                  value={syncRepo}
+                  onChange={(e) => {
+                    setSyncResult(null);
+                    setSyncRepo(e.target.value);
+                  }}
+                  disabled={!githubTokenSet}
+                />
+              </TextField>
+              <Button
+                onClick={handleSyncSecrets}
+                disabled={!githubTokenSet || syncing || !parsedSync.owner || !parsedSync.repo}
+              >
+                {syncing ? t("credentials.sync.syncing") : t("credentials.sync.button")}
+              </Button>
+            </div>
+            {!githubTokenSet && (
+              <p className="text-caption font-caption text-subtext-color">
+                {t("credentials.sync.requiresToken")}
+              </p>
+            )}
+            {syncResult === "success" && (
+              <Alert
+                variant="success"
+                icon={<FeatherCheckCircle />}
+                title={t("credentials.sync.successTitle", {
+                  repo: `${parsedSync.owner}/${parsedSync.repo}`,
+                })}
+              />
+            )}
+            {syncResult === "error" && (
+              <Alert
+                variant="error"
+                icon={<FeatherAlertTriangle />}
+                title={t("credentials.sync.errorTitle")}
+              />
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/lib/api/models/SetGithubActionsSecretsRequestBody.ts
+++ b/frontend/src/lib/api/models/SetGithubActionsSecretsRequestBody.ts
@@ -5,5 +5,6 @@
 import type { GitHubConfig } from './GitHubConfig';
 export type SetGithubActionsSecretsRequestBody = {
     github_config: GitHubConfig;
+    secret_names?: (Array<string> | null);
 };
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -854,15 +854,17 @@
       "other": "Other"
     },
     "sync": {
-      "title": "Sync secrets to an experiment repository",
-      "subtitle": "Copies the credentials above to a GitHub repository's Actions secrets so experiment and LaTeX workflows can use them.",
+      "targetLabel": "Sync target repository",
       "repoPlaceholder": "owner/repository",
       "repoPlaceholderWithOwner": "repository (or owner/repository — defaults to {{owner}})",
-      "button": "Sync to GitHub",
+      "rowButton": "Sync to GitHub",
       "syncing": "Syncing...",
-      "requiresToken": "Set GH_PERSONAL_ACCESS_TOKEN above (and save) to enable syncing.",
-      "successTitle": "Secrets synced to {{repo}}",
-      "errorTitle": "Failed to sync secrets. Check the repository name and token permissions."
+      "rowSynced": "Synced",
+      "rowError": "Sync failed",
+      "requiresToken": "Set GH_PERSONAL_ACCESS_TOKEN (and save) to enable syncing secrets to a repository.",
+      "requiresRepo": "Enter the sync target repository (owner/repository) in the GitHub section.",
+      "requiresValue": "Save a value for this credential first.",
+      "hint": "Each saved secret below can be copied to this repository's Actions secrets with its \"Sync to GitHub\" button."
     }
   },
   "paperSearch": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -852,6 +852,17 @@
       "compute": "Compute (AIXS)",
       "integrations": "Optional Integrations",
       "other": "Other"
+    },
+    "sync": {
+      "title": "Sync secrets to an experiment repository",
+      "subtitle": "Copies the credentials above to a GitHub repository's Actions secrets so experiment and LaTeX workflows can use them.",
+      "repoPlaceholder": "owner/repository",
+      "repoPlaceholderWithOwner": "repository (or owner/repository — defaults to {{owner}})",
+      "button": "Sync to GitHub",
+      "syncing": "Syncing...",
+      "requiresToken": "Set GH_PERSONAL_ACCESS_TOKEN above (and save) to enable syncing.",
+      "successTitle": "Secrets synced to {{repo}}",
+      "errorTitle": "Failed to sync secrets. Check the repository name and token permissions."
     }
   },
   "paperSearch": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -865,7 +865,8 @@
       "requiresRepo": "Enter the sync target repository (owner/repository) in the GitHub section.",
       "requiresValue": "Save a value for this credential first.",
       "hint": "Each saved secret below can be copied to this repository's Actions secrets with its \"Sync to GitHub\" button."
-    }
+    },
+    "networkError": "the dashboard API is unreachable"
   },
   "paperSearch": {
     "pageTitle": "Paper Search",

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -851,6 +851,17 @@
       "compute": "計算基盤 (AIXS)",
       "integrations": "オプション連携",
       "other": "その他"
+    },
+    "sync": {
+      "title": "実験リポジトリへのシークレット同期",
+      "subtitle": "上記の認証情報をGitHubリポジトリのActionsシークレットにコピーします。実験やLaTeXのワークフローがこれらを利用できるようになります。",
+      "repoPlaceholder": "owner/リポジトリ名",
+      "repoPlaceholderWithOwner": "リポジトリ名（owner/リポジトリ名 も可 — 省略時は {{owner}}）",
+      "button": "GitHubに同期",
+      "syncing": "同期中...",
+      "requiresToken": "同期するには上の GH_PERSONAL_ACCESS_TOKEN を設定して保存してください。",
+      "successTitle": "{{repo}} にシークレットを同期しました",
+      "errorTitle": "シークレットの同期に失敗しました。リポジトリ名とトークンの権限を確認してください。"
     }
   },
   "paperSearch": {

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -864,7 +864,8 @@
       "requiresRepo": "GitHubセクションの同期先リポジトリ（owner/リポジトリ名）を入力してください。",
       "requiresValue": "先にこの認証情報の値を保存してください。",
       "hint": "保存済みの各シークレットは「GitHubに同期」ボタンでこのリポジトリのActionsシークレットにコピーできます。"
-    }
+    },
+    "networkError": "ダッシュボードAPIに接続できません"
   },
   "paperSearch": {
     "pageTitle": "論文検索",

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -853,15 +853,17 @@
       "other": "その他"
     },
     "sync": {
-      "title": "実験リポジトリへのシークレット同期",
-      "subtitle": "上記の認証情報をGitHubリポジトリのActionsシークレットにコピーします。実験やLaTeXのワークフローがこれらを利用できるようになります。",
+      "targetLabel": "同期先リポジトリ",
       "repoPlaceholder": "owner/リポジトリ名",
       "repoPlaceholderWithOwner": "リポジトリ名（owner/リポジトリ名 も可 — 省略時は {{owner}}）",
-      "button": "GitHubに同期",
+      "rowButton": "GitHubに同期",
       "syncing": "同期中...",
-      "requiresToken": "同期するには上の GH_PERSONAL_ACCESS_TOKEN を設定して保存してください。",
-      "successTitle": "{{repo}} にシークレットを同期しました",
-      "errorTitle": "シークレットの同期に失敗しました。リポジトリ名とトークンの権限を確認してください。"
+      "rowSynced": "同期済み",
+      "rowError": "同期失敗",
+      "requiresToken": "各シークレットをリポジトリに同期するには GH_PERSONAL_ACCESS_TOKEN を設定して保存してください。",
+      "requiresRepo": "GitHubセクションの同期先リポジトリ（owner/リポジトリ名）を入力してください。",
+      "requiresValue": "先にこの認証情報の値を保存してください。",
+      "hint": "保存済みの各シークレットは「GitHubに同期」ボタンでこのリポジトリのActionsシークレットにコピーできます。"
     }
   },
   "paperSearch": {

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -4824,6 +4824,13 @@ components:
       properties:
         github_config:
           $ref: '#/components/schemas/GitHubConfig'
+        secret_names:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Secret Names
       type: object
       required:
       - github_config


### PR DESCRIPTION
## 概要
ダッシュボードの API Keys ページから、保存済みの認証情報を実験リポジトリの GitHub Actions Secrets に同期できるようにします。

## UI仕様（per-シークレット方式）
- **GH_PERSONAL_ACCESS_TOKEN は同期のゲートとなる特別な項目**。それ自身には同期ボタンを付けない
- **各シークレット行の入力欄の右に「GitHubに同期」ボタン**を配置
  - GH_PERSONAL_ACCESS_TOKEN 未設定 → 全ボタン無効（tooltip で理由表示）。設定・保存すると有効化
  - 同期先リポジトリ未入力、またはそのシークレットの値が未保存 → その行のボタンは無効（理由も行単位で表示）
- **同期先リポジトリ入力は GitHub セクション内**。`owner/repo` 形式または `repo` のみ（省略時は GITHUB_OWNER にフォールバック、プレースホルダに明示）
- 実行結果は行ごとに成功/失敗アイコンで表示

## バックエンド
- `SetGithubActionsSecretsRequestBody` に `secret_names: list[str] | null` を追加（null は従来どおり既定セット全体、リスト指定でそのシークレットのみ同期）
- `openapi.yaml` とフロントAPIクライアントを再生成

## Verification（Playwright で実施、HOME 隔離）
- [x] トークン未設定: 全行の同期ボタン無効 + 同期先入力も無効 + 案内文
- [x] トークン・owner 保存後: 同期先入力が有効化、プレースホルダに owner 反映
- [x] 値を保存した行（WANDB_API_KEY）だけボタン有効、未保存の行（OPENAI_API_KEY）は「先に値を保存」理由で無効のまま
- [x] 同期実行: `secret_names: ["WANDB_API_KEY"]` でAPI呼び出し → GitHub API まで到達（ダミートークンで401）→ 行に失敗アイコン表示
- [x] ruff / mypy / biome / pnpm build Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)