### PR TITLE
docs: document get_library_docs MCP tool

### DIFF
--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -68,6 +68,7 @@ Or add it to your project's `.mcp.json`:
 | `generate_experimental_design` | Design experiments to test a hypothesis |
 | `retrieve_models` | List curated candidate models for a subfield; no API key required |
 | `retrieve_datasets` | List curated candidate datasets for a subfield; no API key required |
+| `get_library_docs` | Look up canonical documentation endpoints (official docs / source repo / `llms.txt`) for ~165 AI research libraries, filterable by `domain` / `category`; no API key required |
 
 ### Experiment execution
 
@@ -110,8 +111,9 @@ The MCP host is expected to be a capable coding agent (Claude Code, Cursor, ...)
 
 1. Clone the experiment repository locally with git.
 2. Read its `AGENTS.md` — it defines the contract the code must satisfy (allowed files, CLI shape, `sanity` / `pilot` / `full` modes, validation verdict lines, W&B conventions).
-3. Implement the experiment, run `mode=sanity` locally until it prints `SANITY_VALIDATION: PASS`, then commit and push.
-4. Dispatch GPU-scale runs with `dispatch_experiment` and fetch errors/results with `get_experiment_run_status` / `fetch_experiment_results`.
+3. For any library the design relies on, call `get_library_docs` and fetch the returned `llms.txt` (or docs) to work from current APIs rather than memory.
+4. Implement the experiment, run `mode=sanity` locally until it prints `SANITY_VALIDATION: PASS`, then commit and push.
+5. Dispatch GPU-scale runs with `dispatch_experiment` and fetch errors/results with `get_experiment_run_status` / `fetch_experiment_results`.
 
 Headless pipelines (the built-in autonomous research workflows) still generate code remotely on GitHub Actions; that path is not exposed as an MCP tool.
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -68,6 +68,7 @@ claude mcp add airas -- uvx airas
 | `generate_experimental_design` | 仮説を検証する実験を設計 |
 | `retrieve_models` | サブ分野ごとの候補モデル一覧を取得。APIキー不要 |
 | `retrieve_datasets` | サブ分野ごとの候補データセット一覧を取得。APIキー不要 |
+| `get_library_docs` | AI研究ライブラリ約165件の公式ドキュメント / ソースリポジトリ / `llms.txt` エンドポイントを検索（`domain` / `category` で絞り込み可）。APIキー不要 |
 
 ### 実験実行
 
@@ -110,8 +111,9 @@ MCP ホストは有能なコーディングエージェント（Claude Code、Cu
 
 1. 実験リポジトリを git でローカルに clone する
 2. リポジトリ内の `AGENTS.md` を読む — コードが満たすべき規約（編集可能ファイル、CLI の形、`sanity` / `pilot` / `full` モード、検証判定行、W&B 規約）が定義されています
-3. 実験を実装し、ローカルで `mode=sanity` を実行して `SANITY_VALIDATION: PASS` が出るまで修正してから commit・push する
-4. GPU 規模の実行は `dispatch_experiment` でディスパッチし、エラーと結果は `get_experiment_run_status` / `fetch_experiment_results` で取得する
+3. 設計が依存する各ライブラリについて `get_library_docs` を呼び、返される `llms.txt`（またはドキュメント）を取得して、記憶に頼らず最新のAPIをもとに実装する
+4. 実験を実装し、ローカルで `mode=sanity` を実行して `SANITY_VALIDATION: PASS` が出るまで修正してから commit・push する
+5. GPU 規模の実行は `dispatch_experiment` でディスパッチし、エラーと結果は `get_experiment_run_status` / `fetch_experiment_results` で取得する
 
 ヘッドレスなパイプライン（組み込みの全自動研究ワークフロー）は従来どおり GitHub Actions 上でコードをリモート生成しますが、その経路は MCP ツールとしては公開していません。
 


### PR DESCRIPTION
## Summary

Documents the `get_library_docs` MCP tool, which shipped with the library docs registry (#924) but was not yet listed in the MCP docs.

- Adds `get_library_docs` to the tool table in both `docs/development/MCP.mdx` and `docs/ja/development/MCP.mdx` (next to `retrieve_models` / `retrieve_datasets`).
- Adds a step in the *Writing the experiment code* flow telling agents to fetch the returned `llms.txt` / docs for libraries the design relies on, rather than working from memory.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)