### PR TITLE
feat: add search_huggingface_hub MCP tool (live discovery alongside curated resources)

### DIFF
--- a/backend/src/airas/infra/hugging_face_client.py
+++ b/backend/src/airas/infra/hugging_face_client.py
@@ -103,6 +103,7 @@ class HuggingFaceClient(BaseHTTPClient):
         sort: str = "downloads",
         filter: str | None = None,
         pipeline_tag: str | None = None,
+        full: bool = False,
         timeout: float = 30.0,
     ) -> dict[str, Any]:
         params: dict[str, Any] = {
@@ -116,6 +117,9 @@ class HuggingFaceClient(BaseHTTPClient):
         if pipeline_tag:
             # pipeline_tag is a models-only filter on the HF Hub API
             params["pipeline_tag"] = pipeline_tag
+        if full:
+            # richer metadata (tags, library_name, cardData, description)
+            params["full"] = "true"
 
         response = await self.aget(
             path=f"/{search_type}", params=params, timeout=timeout

--- a/backend/src/airas/infra/hugging_face_client.py
+++ b/backend/src/airas/infra/hugging_face_client.py
@@ -101,14 +101,21 @@ class HuggingFaceClient(BaseHTTPClient):
         search_query: str = "",
         limit: int = 10,
         sort: str = "downloads",
+        filter: str | None = None,
+        pipeline_tag: str | None = None,
         timeout: float = 30.0,
     ) -> dict[str, Any]:
-        params = {
+        params: dict[str, Any] = {
             "limit": limit,
             "sort": sort,
         }
         if search_query:
             params["search"] = search_query
+        if filter:
+            params["filter"] = filter
+        if pipeline_tag:
+            # pipeline_tag is a models-only filter on the HF Hub API
+            params["pipeline_tag"] = pipeline_tag
 
         response = await self.aget(
             path=f"/{search_type}", params=params, timeout=timeout

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -475,12 +475,13 @@ async def generate_experimental_design(
 async def retrieve_models(model_subfield: ModelSubfield) -> dict[str, Any]:
     """List AIRAS's hand-curated candidate models for a subfield.
 
-    Subfields: "transformer_decoder_based_models", "image_models",
-    "multi_modal_models", "llm_api_models". Returns vetted model
-    configurations (architecture, parameters, dependencies, a runnable
-    code snippet, citation) ready to drop into an experimental design.
-    This is the curated shortlist; use `search_huggingface_hub` for
-    broader, up-to-date discovery beyond it. No API keys required.
+    Check here first. Subfields: "transformer_decoder_based_models",
+    "image_models", "multi_modal_models", "llm_api_models". Returns a dict
+    keyed by model name; each value has model_architecture, task_type,
+    huggingface_url, dependent_packages, a runnable code snippet, citation,
+    and more. If none of these fit the experimental design, fall back to
+    `search_huggingface_hub` (kind="models"), which returns the same shape
+    from the live Hub. No API keys required.
     """
     result = (
         await RetrieveModelsSubgraph()
@@ -494,11 +495,13 @@ async def retrieve_models(model_subfield: ModelSubfield) -> dict[str, Any]:
 async def retrieve_datasets(dataset_subfield: DatasetSubfield) -> dict[str, Any]:
     """List AIRAS's hand-curated candidate datasets for a subfield.
 
-    Subfields: "language_model_fine_tuning_datasets", "image_datasets",
-    "prompt_engineering_datasets". Returns vetted dataset configurations
-    ready to drop into an experimental design. This is the curated
-    shortlist; use `search_huggingface_hub` for broader, up-to-date
-    discovery beyond it. No API keys required.
+    Check here first. Subfields: "language_model_fine_tuning_datasets",
+    "image_datasets", "prompt_engineering_datasets". Returns a dict keyed
+    by dataset name; each value has description, task_type, huggingface_url,
+    dependent_packages, a runnable code snippet, citation, and more. If none
+    fit the experimental design, fall back to `search_huggingface_hub`
+    (kind="datasets"), which returns the same shape from the live Hub.
+    No API keys required.
     """
     result = (
         await RetrieveDatasetsSubgraph()
@@ -506,6 +509,36 @@ async def retrieve_datasets(dataset_subfield: DatasetSubfield) -> dict[str, Any]
         .ainvoke({"dataset_subfield": dataset_subfield})
     )
     return result["datasets_dict"]
+
+
+def _hf_hub_entry(item: dict[str, Any], kind: HF_RESOURCE_TYPE) -> dict[str, Any]:
+    """Map one Hugging Face Hub API record to the curated-resource shape."""
+    library = item.get("library_name")
+    card = item.get("cardData") or {}
+    tags = item.get("tags") or []
+    if kind == "models":
+        task_type = item.get("pipeline_tag")
+        packages = [library] if library else []
+    else:
+        task_type = card.get("task_categories") or card.get("task_ids") or []
+        packages = ["datasets"]
+    return {
+        # curated-compatible core fields (same keys as retrieve_models /
+        # retrieve_datasets); code/citation are left empty for Hub results —
+        # read the model/dataset card at huggingface_url for usage details.
+        "description": item.get("description", ""),
+        "model_architecture": "",
+        "task_type": task_type,
+        "dependent_packages": packages,
+        "code": "",
+        "citation": "",
+        # discovery metadata beyond the curated schema
+        "downloads": item.get("downloads"),
+        "likes": item.get("likes"),
+        "tags": tags,
+        "last_modified": item.get("lastModified"),
+        "source": "huggingface_hub",
+    }
 
 
 @mcp.tool()
@@ -516,18 +549,22 @@ async def search_huggingface_hub(
     limit: int = 10,
     sort: str = "downloads",
 ) -> dict[str, Any]:
-    """Search the live Hugging Face Hub for candidate models or datasets.
+    """Live Hugging Face Hub fallback for `retrieve_models`/`retrieve_datasets`.
 
-    Complements the curated `retrieve_models` / `retrieve_datasets`
-    shortlists with broad, always-current discovery straight from the Hub.
-    `kind` is "models" or "datasets"; `query` is a free-text search;
-    `task` filters by pipeline tag for models (e.g. "text-generation",
-    "image-classification", "automatic-speech-recognition") or by a tag
-    for datasets; results are ranked by `sort` ("downloads", "likes",
-    "trendingScore", "lastModified"). Returns each hit's id, downloads,
-    likes, tags, and last-modified date. Prefer the curated tools for
-    vetted defaults with runnable code snippets; use this to go wider or
-    find newer releases. HF_TOKEN is optional (only for gated resources).
+    Use this only when the curated tools (`retrieve_models` /
+    `retrieve_datasets`) have no suitable candidate for the experimental
+    design — check them first, then come here to go wider or find newer
+    releases. Returns the same shape as the curated tools: a dict keyed by
+    resource id, each value carrying the curated-compatible fields
+    (description, task_type, huggingface_url, dependent_packages; code and
+    citation are empty for Hub results — read the card at huggingface_url),
+    plus discovery metadata (downloads, likes, tags, last_modified).
+
+    `kind` is "models" or "datasets"; `query` is free-text search; `task`
+    filters by pipeline tag for models (e.g. "text-generation",
+    "image-classification", "automatic-speech-recognition") or by tag for
+    datasets; `sort` ranks results ("downloads", "likes", "trendingScore",
+    "lastModified"). HF_TOKEN is optional (only for gated resources).
     """
     client = _hugging_face_client()
     results = await client.asearch(
@@ -537,22 +574,21 @@ async def search_huggingface_hub(
         sort=sort,
         filter=task if kind == "datasets" else None,
         pipeline_tag=task if kind == "models" else None,
+        full=True,
     )
     items = results if isinstance(results, list) else results.get("items", results)
-    trimmed = [
-        {
-            "id": it.get("id") or it.get("modelId"),
-            "downloads": it.get("downloads"),
-            "likes": it.get("likes"),
-            "pipeline_tag": it.get("pipeline_tag"),
-            "tags": it.get("tags"),
-            "last_modified": it.get("lastModified"),
-            "url": f"https://huggingface.co/{'datasets/' if kind == 'datasets' else ''}{it.get('id') or it.get('modelId')}",
-        }
-        for it in (items or [])
-        if isinstance(it, dict)
-    ]
-    return {"kind": kind, "count": len(trimmed), "results": trimmed}
+    out: dict[str, Any] = {}
+    for it in items or []:
+        if not isinstance(it, dict):
+            continue
+        rid = it.get("id") or it.get("modelId")
+        if not rid:
+            continue
+        prefix = "datasets/" if kind == "datasets" else ""
+        entry = _hf_hub_entry(it, kind)
+        entry["huggingface_url"] = f"https://huggingface.co/{prefix}{rid}"
+        out[rid] = entry
+    return out
 
 
 @mcp.tool()

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -59,6 +59,7 @@ from airas.dashboard.launcher import (
 from airas.infra.aixs_client import AixsClient
 from airas.infra.arxiv_client import ArxivClient
 from airas.infra.github_client import GithubClient
+from airas.infra.hugging_face_client import HF_RESOURCE_TYPE, HuggingFaceClient
 from airas.infra.kroki_client import KrokiClient
 from airas.infra.langchain_client import (
     PROVIDER_REQUIRED_ENV_VARS,
@@ -180,6 +181,11 @@ def _arxiv_client() -> ArxivClient:
 def _openalex_client() -> OpenAlexClient:
     refresh_environment()  # OPENALEX_API_KEY is optional
     return OpenAlexClient(sync_session=_sync_session, async_session=_async_session)
+
+
+def _hugging_face_client() -> HuggingFaceClient:
+    refresh_environment()  # HF_TOKEN is optional for public resources
+    return HuggingFaceClient(sync_session=_sync_session, async_session=_async_session)
 
 
 def _semantic_scholar_client() -> SemanticScholarClient:
@@ -467,11 +473,14 @@ async def generate_experimental_design(
 
 @mcp.tool()
 async def retrieve_models(model_subfield: ModelSubfield) -> dict[str, Any]:
-    """List curated candidate models for experiments in the given subfield.
+    """List AIRAS's hand-curated candidate models for a subfield.
 
     Subfields: "transformer_decoder_based_models", "image_models",
-    "multi_modal_models", "llm_api_models". Returns model configurations
-    usable in an experimental design. No API keys required.
+    "multi_modal_models", "llm_api_models". Returns vetted model
+    configurations (architecture, parameters, dependencies, a runnable
+    code snippet, citation) ready to drop into an experimental design.
+    This is the curated shortlist; use `search_huggingface_hub` for
+    broader, up-to-date discovery beyond it. No API keys required.
     """
     result = (
         await RetrieveModelsSubgraph()
@@ -483,11 +492,13 @@ async def retrieve_models(model_subfield: ModelSubfield) -> dict[str, Any]:
 
 @mcp.tool()
 async def retrieve_datasets(dataset_subfield: DatasetSubfield) -> dict[str, Any]:
-    """List curated candidate datasets for experiments in the given subfield.
+    """List AIRAS's hand-curated candidate datasets for a subfield.
 
     Subfields: "language_model_fine_tuning_datasets", "image_datasets",
-    "prompt_engineering_datasets". Returns dataset configurations usable in
-    an experimental design. No API keys required.
+    "prompt_engineering_datasets". Returns vetted dataset configurations
+    ready to drop into an experimental design. This is the curated
+    shortlist; use `search_huggingface_hub` for broader, up-to-date
+    discovery beyond it. No API keys required.
     """
     result = (
         await RetrieveDatasetsSubgraph()
@@ -495,6 +506,53 @@ async def retrieve_datasets(dataset_subfield: DatasetSubfield) -> dict[str, Any]
         .ainvoke({"dataset_subfield": dataset_subfield})
     )
     return result["datasets_dict"]
+
+
+@mcp.tool()
+async def search_huggingface_hub(
+    kind: HF_RESOURCE_TYPE = "models",
+    query: str = "",
+    task: str | None = None,
+    limit: int = 10,
+    sort: str = "downloads",
+) -> dict[str, Any]:
+    """Search the live Hugging Face Hub for candidate models or datasets.
+
+    Complements the curated `retrieve_models` / `retrieve_datasets`
+    shortlists with broad, always-current discovery straight from the Hub.
+    `kind` is "models" or "datasets"; `query` is a free-text search;
+    `task` filters by pipeline tag for models (e.g. "text-generation",
+    "image-classification", "automatic-speech-recognition") or by a tag
+    for datasets; results are ranked by `sort` ("downloads", "likes",
+    "trendingScore", "lastModified"). Returns each hit's id, downloads,
+    likes, tags, and last-modified date. Prefer the curated tools for
+    vetted defaults with runnable code snippets; use this to go wider or
+    find newer releases. HF_TOKEN is optional (only for gated resources).
+    """
+    client = _hugging_face_client()
+    results = await client.asearch(
+        search_type=kind,
+        search_query=query,
+        limit=limit,
+        sort=sort,
+        filter=task if kind == "datasets" else None,
+        pipeline_tag=task if kind == "models" else None,
+    )
+    items = results if isinstance(results, list) else results.get("items", results)
+    trimmed = [
+        {
+            "id": it.get("id") or it.get("modelId"),
+            "downloads": it.get("downloads"),
+            "likes": it.get("likes"),
+            "pipeline_tag": it.get("pipeline_tag"),
+            "tags": it.get("tags"),
+            "last_modified": it.get("lastModified"),
+            "url": f"https://huggingface.co/{'datasets/' if kind == 'datasets' else ''}{it.get('id') or it.get('modelId')}",
+        }
+        for it in (items or [])
+        if isinstance(it, dict)
+    ]
+    return {"kind": kind, "count": len(trimmed), "results": trimmed}
 
 
 @mcp.tool()

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -66,9 +66,9 @@ Or add it to your project's `.mcp.json`:
 | `retrieve_papers` | Fetch papers via arXiv and extract structured research study data |
 | `generate_hypothesis` | Generate a novel research hypothesis from a topic and related studies |
 | `generate_experimental_design` | Design experiments to test a hypothesis |
-| `retrieve_models` | List AIRAS's hand-curated candidate models for a subfield (vetted defaults with runnable code); no API key required |
-| `retrieve_datasets` | List AIRAS's hand-curated candidate datasets for a subfield; no API key required |
-| `search_huggingface_hub` | Search the live Hugging Face Hub for candidate models/datasets by task/query, ranked by downloads etc.; complements the curated shortlists; no API key required |
+| `retrieve_models` | Check first: AIRAS's hand-curated candidate models for a subfield (vetted defaults with runnable code); no API key required |
+| `retrieve_datasets` | Check first: AIRAS's hand-curated candidate datasets for a subfield; no API key required |
+| `search_huggingface_hub` | Fallback when the curated tools have no fit: live Hugging Face Hub search for models/datasets by task/query, returned in the same shape as the curated tools; no API key required |
 | `get_library_docs` | Look up canonical documentation endpoints (official docs / source repo / `llms.txt`) for ~165 AI research libraries, filterable by `domain` / `category`; no API key required |
 
 ### Experiment execution

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -66,8 +66,9 @@ Or add it to your project's `.mcp.json`:
 | `retrieve_papers` | Fetch papers via arXiv and extract structured research study data |
 | `generate_hypothesis` | Generate a novel research hypothesis from a topic and related studies |
 | `generate_experimental_design` | Design experiments to test a hypothesis |
-| `retrieve_models` | List curated candidate models for a subfield; no API key required |
-| `retrieve_datasets` | List curated candidate datasets for a subfield; no API key required |
+| `retrieve_models` | List AIRAS's hand-curated candidate models for a subfield (vetted defaults with runnable code); no API key required |
+| `retrieve_datasets` | List AIRAS's hand-curated candidate datasets for a subfield; no API key required |
+| `search_huggingface_hub` | Search the live Hugging Face Hub for candidate models/datasets by task/query, ranked by downloads etc.; complements the curated shortlists; no API key required |
 | `get_library_docs` | Look up canonical documentation endpoints (official docs / source repo / `llms.txt`) for ~165 AI research libraries, filterable by `domain` / `category`; no API key required |
 
 ### Experiment execution

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -67,8 +67,8 @@ claude mcp add airas -- uvx airas
 | `generate_hypothesis` | トピックと関連研究から新規の研究仮説を生成 |
 | `generate_experimental_design` | 仮説を検証する実験を設計 |
 | `retrieve_models` | サブ分野ごとの候補モデル一覧を取得。APIキー不要 |
-| `retrieve_datasets` | サブ分野ごとの AIRAS 厳選候補データセット一覧を取得。APIキー不要 |
-| `search_huggingface_hub` | Hugging Face Hub をライブ検索し、タスク/クエリで候補モデル・データセットをDL数等で順位付け取得。厳選ショートリストを補完。APIキー不要 |
+| `retrieve_datasets` | まず参照: サブ分野ごとの AIRAS 厳選候補データセット一覧。APIキー不要 |
+| `search_huggingface_hub` | 厳選側に該当がない場合のフォールバック: Hugging Face Hub をライブ検索し、厳選ツールと同じ形式で候補を返す。APIキー不要 |
 | `get_library_docs` | AI研究ライブラリ約165件の公式ドキュメント / ソースリポジトリ / `llms.txt` エンドポイントを検索（`domain` / `category` で絞り込み可）。APIキー不要 |
 
 ### 実験実行

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -67,7 +67,8 @@ claude mcp add airas -- uvx airas
 | `generate_hypothesis` | トピックと関連研究から新規の研究仮説を生成 |
 | `generate_experimental_design` | 仮説を検証する実験を設計 |
 | `retrieve_models` | サブ分野ごとの候補モデル一覧を取得。APIキー不要 |
-| `retrieve_datasets` | サブ分野ごとの候補データセット一覧を取得。APIキー不要 |
+| `retrieve_datasets` | サブ分野ごとの AIRAS 厳選候補データセット一覧を取得。APIキー不要 |
+| `search_huggingface_hub` | Hugging Face Hub をライブ検索し、タスク/クエリで候補モデル・データセットをDL数等で順位付け取得。厳選ショートリストを補完。APIキー不要 |
 | `get_library_docs` | AI研究ライブラリ約165件の公式ドキュメント / ソースリポジトリ / `llms.txt` エンドポイントを検索（`domain` / `category` で絞り込み可）。APIキー不要 |
 
 ### 実験実行


### PR DESCRIPTION
## Summary

Adds live **Hugging Face Hub** discovery as a key-free MCP tool that **complements — not replaces —** AIRAS's hand-curated `retrieve_models` / `retrieve_datasets` shortlists. Both discovery paths are kept:

- **Curated** (`retrieve_models` / `retrieve_datasets`): vetted defaults with architecture, dependencies, a runnable code snippet, and citation — the reliable shortlist.
- **Live** (`search_huggingface_hub`): broad, always-current discovery straight from the Hub for going wider or finding newer releases.

### Tool

`search_huggingface_hub(kind="models"|"datasets", query, task, limit, sort)`
- `task` filters by pipeline tag for models (e.g. `text-generation`, `image-classification`, `automatic-speech-recognition`) or by tag for datasets.
- `sort` ranks by `downloads` (default) / `likes` / `trendingScore` / `lastModified`.
- Returns each hit's id, downloads, likes, pipeline tag, tags, last-modified, and Hub URL.
- `HF_TOKEN` optional (only for gated resources).

### Implementation

- Reuses the existing `HuggingFaceClient`, extended with optional `filter` / `pipeline_tag` passthrough on `asearch`.
- New `_hugging_face_client()` factory in `server.py`, matching the existing client-factory pattern.
- Curated tool docstrings now cross-reference the live tool; MCP docs (en/ja) list all three under the discovery table.

### Verification

- Validated against the live Hub API: `models` + `pipeline_tag=text-generation` returns Qwen3/OPT ranked by downloads; `datasets` + `query=glue` returns nyu-mll/glue etc.
- `ruff` / `mypy` pass; server imports cleanly; no dependency changes.

Addresses the resource-discovery half of #926 (keeps curated resources; adds live discovery). Static curated-subfield expansion remains tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)