### PR TITLE
chore: ignore local dev artifacts in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,8 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+.pnpm-store/
+scratch/
 dist
 dist-ssr
 *.local
@@ -188,6 +190,7 @@ dist-ssr
 .serena/*
 .claude/CLAUDE.local.md
 .claude/settings.local.json
+.claude/skills/
 
 
 # Built dashboard frontend copied into the wheel by CI


### PR DESCRIPTION
## 背景と目的

ローカル開発環境で生成される成果物が `.gitignore` に登録されておらず、`git status` に未追跡ファイルとして常時表示されてしまう状態でした。ノイズによって本来レビューすべき差分が埋もれるほか、誤ってコミットしてしまうリスクもあります。

このPRは、これらのローカル専用ディレクトリを無視対象に追加し、作業ツリーをクリーンに保つことを目的とします。

## 変更内容

以下の3つのディレクトリを `.gitignore` に追加しました：

1. `.pnpm-store/` — pnpm のローカルコンテンツアドレッサブルストア
2. `scratch/` — 一時的な作業ファイル置き場
3. `.claude/skills/` — Claude Code のローカルスキル定義

実装の詳細は以下の通りです：

<details>
<summary><code>.gitignore への追加</code></summary>

**実装概要**

- **Node / フロントエンド系のブロック**（`node_modules` の直下）に追加
  - `.pnpm-store/`: フロントエンドの pnpm 移行に伴い生成されるパッケージストア。環境依存かつサイズが大きいため追跡対象外とする。
  - `scratch/`: 検証用スクリプトなどを置く一時ディレクトリ。
- **`.claude/` 系のブロック**（`CLAUDE.local.md` / `settings.local.json` の直下）に追加
  - `.claude/skills/`: 既存のローカル設定ファイル群と同じ扱いとし、開発者ごとに異なるスキル定義を共有しない。

いずれも現時点で追跡済みのファイルは存在しないため、既存の履歴やチェックアウト内容には影響しません。

</details>
