### PR TITLE
Fix AIXS client base URL and extend it for BYO compute runs

### DIFF
--- a/backend/src/airas/core/credentials.py
+++ b/backend/src/airas/core/credentials.py
@@ -103,6 +103,8 @@ CREDENTIAL_SPECS: tuple[CredentialSpec, ...] = (
     # Optional: run experiments on the AIXS compute platform.
     CredentialSpec("AIXS_API_KEY"),
     CredentialSpec("AIXS_BASE_URL", is_secret=False),
+    # Default cluster for dispatch_experiment(backend="aixs"), as "byo:<uuid>".
+    CredentialSpec("AIXS_COMPUTE_ID", is_secret=False),
 )
 
 KNOWN_CREDENTIAL_NAMES = frozenset(spec.name for spec in CREDENTIAL_SPECS)

--- a/backend/src/airas/infra/aixs_client.py
+++ b/backend/src/airas/infra/aixs_client.py
@@ -12,7 +12,11 @@ logger = getLogger(__name__)
 
 AIXS_RETRY = make_retry_policy()
 
-DEFAULT_AIXS_BASE_URL = "https://api.aixs.dev"
+# AIXS deploys `develop` to the dev environment and `main` to production
+# (api.airas.io). The endpoints this client uses are only on the dev
+# deployment until AIXS releases them to main.
+# TODO(aixs-prod): switch to "https://api.airas.io" once AIXS main ships them.
+DEFAULT_AIXS_BASE_URL = "https://api.dev.airas.io"
 
 
 class AixsClient(BaseHTTPClient):
@@ -74,14 +78,55 @@ class AixsClient(BaseHTTPClient):
     # --- analyses ---
 
     async def astart_analysis(
-        self, repository_id: str, commit_hash: str, branch: str | None = None
+        self, repository_id: str, commit_hash: str, branch: str
     ) -> dict[str, Any]:
-        """Create an analysis record for a commit (required before starting runs)."""
+        """Create an analysis record for a commit (required before starting runs).
+
+        The response carries no record id, so pin a run to this analysis by
+        resolving the id with `alist_analyses`.
+        """
         path = f"v1/repositories/{repository_id}/analysis/{commit_hash}"
-        resp = await self.apost(
+        resp = await self.apost(path=path, json={"branch": branch}, timeout=30.0)
+        raise_for_status(resp, path=path)
+        return self._parser.parse(resp, as_="json")
+
+    @AIXS_RETRY
+    async def alist_analyses(
+        self, repository_id: str, branch: str | None = None
+    ) -> list[dict[str, Any]]:
+        """List analysis records, newest first. Each entry has an `analysis_id`."""
+        path = f"v1/repositories/{repository_id}/analysis"
+        resp = await self.aget(
             path=path,
-            json={"branch": branch} if branch else {},
+            params={"branch": branch} if branch else None,
             timeout=30.0,
+        )
+        raise_for_status(resp, path=path)
+        return self._parser.parse(resp, as_="json")
+
+    # --- computes ---
+
+    @AIXS_RETRY
+    async def aget_byo_compute_status(
+        self, compute_id: str, refresh: bool = False
+    ) -> dict[str, Any]:
+        """Observe a registered cluster's node congestion and storage usage.
+
+        Indicative only — for the authoritative "would a job start now?"
+        answer, ask the cluster's own scheduler through AIXS's availability
+        check. Partial failures are not errors: whatever could not be read
+        is explained in `warnings`.
+
+        Results are cached server-side; `refresh=True` requests a fresh
+        observation but is rate-limited to protect the cluster's login node,
+        and `cached` in the response says which you got.
+        """
+        byo_uuid = compute_id.removeprefix("byo:")
+        path = f"v1/byo-computes/{byo_uuid}/credential/status"
+        resp = await self.aget(
+            path=path,
+            params={"refresh": "true"} if refresh else None,
+            timeout=120.0,
         )
         raise_for_status(resp, path=path)
         return self._parser.parse(resp, as_="json")
@@ -96,9 +141,28 @@ class AixsClient(BaseHTTPClient):
         compute_type: str = "cpu-general",
         compute_id: str | None = None,
         analysis_id: str | None = None,
+        inputs_from_runs: list[str] | None = None,
+        time_limit: str | None = None,
+        resource_count: int | None = None,
     ) -> dict[str, Any]:
         """Start a code-execution run. Not retried: a duplicate submission
-        would double the compute cost."""
+        would double the compute cost.
+
+        `compute_id` selects the machine (`"byo:<uuid>"` for a registered
+        cluster); `compute_type` still applies on top of it, because a
+        registered cluster resolves it to the resources the job asks for.
+
+        `inputs_from_runs` restores earlier runs' outputs into this run's
+        working directory at their original relative paths, so a run can
+        read what a previous one wrote (measurement run -> visualization
+        run, or comparing several runs). Only completed runs of the same
+        repository qualify; on a path collision the last id listed wins.
+
+        `time_limit` (e.g. "24:00:00") and `resource_count` are per-run
+        requests honoured by registered clusters — the accepted values come
+        from that cluster's `run_profile` in the compute catalog. Managed
+        compute takes neither, since `compute_type` fixes its shape.
+        """
         path = f"v1/repositories/{repository_id}/{commit_hash}/runs"
         body: dict[str, Any] = {
             "analyzed_experiment": analyzed_experiment,
@@ -108,6 +172,14 @@ class AixsClient(BaseHTTPClient):
             body["compute_id"] = compute_id
         if analysis_id is not None:
             body["analysis_id"] = analysis_id
+        # AIXS rejects an empty list, and "no inputs" is expressed by
+        # omitting the field entirely.
+        if inputs_from_runs:
+            body["inputs_from_runs"] = inputs_from_runs
+        if time_limit is not None:
+            body["time_limit"] = time_limit
+        if resource_count is not None:
+            body["resource_count"] = resource_count
         resp = await self.apost(path=path, json=body, timeout=60.0)
         raise_for_status(resp, path=path)
         return self._parser.parse(resp, as_="json")
@@ -119,6 +191,35 @@ class AixsClient(BaseHTTPClient):
         raise_for_status(resp, path=path)
         return self._parser.parse(resp, as_="json")
 
+    @AIXS_RETRY
+    async def aget_run_outputs(self, run_id: str) -> dict[str, Any]:
+        """Get a run's output files, each with a ready-to-use `download_url`.
+
+        Paths are relative to the run's working directory, so an experiment
+        following the airas-template contract exposes its results under
+        `.research/results`. `truncated` is true when the run wrote more
+        files than AIXS lists. Available wherever the run executed.
+        """
+        path = f"v1/runs/{run_id}/outputs"
+        resp = await self.aget(path=path, timeout=60.0)
+        raise_for_status(resp, path=path)
+        return self._parser.parse(resp, as_="json")
+
+    @AIXS_RETRY
+    async def adownload(self, url: str) -> bytes:
+        """Download a URL handed out by AIXS: an output file's `download_url`,
+        or the `stdout_url` / `stderr_url` of a finished run.
+
+        These URLs are pre-authorized and expire, so the API key is
+        deliberately not attached. Fetch them soon after receiving them.
+        """
+        resp = await self.async_session.get(url, timeout=120.0, follow_redirects=True)
+        raise_for_status(resp, path=url.split("?", 1)[0])
+        return resp.content
+
+    # AIXS has these two endpoints slated for removal in favour of the
+    # `stdout_url` / `stderr_url` it returns for a finished run. They stay
+    # because they also serve runs that have no such URL yet.
     @AIXS_RETRY
     async def aget_run_stdout(self, run_id: str) -> str:
         path = f"v1/runs/{run_id}/stdout"

--- a/backend/src/airas/infra/aixs_client.py
+++ b/backend/src/airas/infra/aixs_client.py
@@ -121,8 +121,12 @@ class AixsClient(BaseHTTPClient):
         observation but is rate-limited to protect the cluster's login node,
         and `cached` in the response says which you got.
         """
-        byo_uuid = compute_id.removeprefix("byo:")
-        path = f"v1/byo-computes/{byo_uuid}/credential/status"
+if not compute_id.startswith("byo:"):
+    raise ValueError('compute_id must start with "byo:" (e.g. "byo:<uuid>")')
+byo_uuid = compute_id.removeprefix("byo:")
+if not byo_uuid or "/" in byo_uuid:
+    raise ValueError(f"Invalid BYO compute_id: {compute_id!r}")
+path = f"v1/byo-computes/{byo_uuid}/credential/status"
         resp = await self.aget(
             path=path,
             params={"refresh": "true"} if refresh else None,

--- a/backend/src/airas/infra/aixs_client.py
+++ b/backend/src/airas/infra/aixs_client.py
@@ -180,10 +180,14 @@ path = f"v1/byo-computes/{byo_uuid}/credential/status"
         # omitting the field entirely.
         if inputs_from_runs:
             body["inputs_from_runs"] = inputs_from_runs
-        if time_limit is not None:
-            body["time_limit"] = time_limit
-        if resource_count is not None:
-            body["resource_count"] = resource_count
+if (time_limit is not None or resource_count is not None) and not (
+    compute_id and compute_id.startswith("byo:")
+):
+    raise ValueError('time_limit/resource_count require compute_id="byo:<uuid>"')
+if time_limit is not None:
+    body["time_limit"] = time_limit
+if resource_count is not None:
+    body["resource_count"] = resource_count
         resp = await self.apost(path=path, json=body, timeout=60.0)
         raise_for_status(resp, path=path)
         return self._parser.parse(resp, as_="json")

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -797,6 +797,10 @@ async def dispatch_experiment(
     runner_label: list[str] | None = None,
     backend: Literal["github_actions", "aixs"] = "github_actions",
     compute_type: str = "gpu-a10",
+    compute_id: str | None = None,
+    inputs_from_runs: list[str] | None = None,
+    time_limit: str | None = None,
+    resource_count: int | None = None,
 ) -> dict[str, Any]:
     """Start an experiment run (asynchronous). The code must already be pushed.
 
@@ -810,9 +814,20 @@ async def dispatch_experiment(
       `get_workflow_runs` and collect outputs with `fetch_experiment_results`.
       Requires GH_PERSONAL_ACCESS_TOKEN.
     - "aixs": executes on the AIXS compute platform (GPU without GitHub
-      Actions limits). `compute_type` picks the machine (e.g. "cpu-general",
-      "gpu-a10"). Requires AIXS_API_KEY, and W&B API keys must be registered
-      as env vars on the AIXS side.
+      Actions limits). `compute_id` picks the machine — normally a cluster
+      you registered, "byo:<uuid>" from the AIXS MCP server's
+      `list_computes`; it defaults to AIXS_COMPUTE_ID, and without either the
+      run goes to AIXS-managed compute. `compute_type` sets the resource
+      request in both cases (e.g. "cpu-general", "gpu-a10"). The W&B API key
+      must be registered as an env var on the AIXS side.
+
+    `inputs_from_runs`, `time_limit` and `resource_count` apply to "aixs"
+    only. `inputs_from_runs` takes `execution_id`s of earlier completed runs
+    and restores their outputs into this run's working directory at the paths
+    they were written to, so a run can consume what a previous one produced.
+    `time_limit` (e.g. "24:00:00") and `resource_count` request per-run
+    resources from a registered cluster; accepted values are in its
+    `run_profile` from `list_computes`.
 
     Track progress and fetch execution errors with
     `get_experiment_run_status`. For "aixs" the returned `execution_id` is
@@ -821,11 +836,19 @@ async def dispatch_experiment(
     """
     if backend == "aixs":
         run_stage = RunStage.SANITY if workflow == "sanity_check" else RunStage.FULL
+        # Resolve the client first: it is what loads the stored credentials
+        # into the environment that AIXS_COMPUTE_ID is read from.
+        client = _aixs_client()
+        resolved_compute_id = compute_id or os.getenv("AIXS_COMPUTE_ID") or None
         aixs_result = (
             await DispatchExperimentOnAixsSubgraph(
-                aixs_client=_aixs_client(),
+                aixs_client=client,
+                compute_id=resolved_compute_id,
                 run_stage=run_stage,
                 compute_type=compute_type,
+                inputs_from_runs=inputs_from_runs,
+                time_limit=time_limit,
+                resource_count=resource_count,
             )
             .build_graph()
             .ainvoke(
@@ -842,6 +865,7 @@ async def dispatch_experiment(
         return {
             "dispatched": aixs_result["dispatched"],
             "backend": "aixs",
+            "compute_id": resolved_compute_id,
             "execution_id": aixs_result["aixs_run_id"],
             "execution_url": aixs_result["aixs_run_url"],
         }

--- a/backend/src/airas/usecases/executors/dispatch_experiment_on_aixs_subgraph/dispatch_experiment_on_aixs_subgraph.py
+++ b/backend/src/airas/usecases/executors/dispatch_experiment_on_aixs_subgraph/dispatch_experiment_on_aixs_subgraph.py
@@ -53,20 +53,54 @@ class DispatchExperimentOnAixsSubgraph:
     def __init__(
         self,
         aixs_client: AixsClient,
+        compute_id: str | None = None,
         run_stage: RunStage | None = None,
         compute_type: str = "gpu-a10",
-        compute_id: str | None = None,
         required_env_vars: list[str] | None = None,
+        inputs_from_runs: list[str] | None = None,
+        time_limit: str | None = None,
+        resource_count: int | None = None,
     ):
         self.aixs_client = aixs_client
         self.run_stage = run_stage or RunStage.SANITY
+        # compute_id ("byo:<uuid>") picks a registered cluster; without one
+        # AIXS falls back to its own managed compute. compute_type applies
+        # either way — a registered cluster resolves it to the resources the
+        # job asks for.
         self.compute_type = compute_type
         self.compute_id = compute_id
+        # Earlier runs whose outputs this run reads (e.g. a measurement run
+        # feeding a visualization run), and per-run resource requests a
+        # registered cluster honours.
+        self.inputs_from_runs = inputs_from_runs
+        self.time_limit = time_limit
+        self.resource_count = resource_count
         # W&B logging is part of the experiment-code contract, so runs need
         # the key registered on the AIXS side by default.
         self.required_env_vars = (
             required_env_vars if required_env_vars is not None else ["WANDB_API_KEY"]
         )
+
+    async def _resolve_analysis_id(
+        self, repository_id: str, commit_hash: str, branch: str
+    ) -> str | None:
+        """Find the analysis just created for `commit_hash`.
+
+        Starting an analysis returns no record id, so the id has to be looked
+        up separately. The listing is newest-first, so the first entry for the
+        commit is the one we created. Returning None is safe: AIXS then binds
+        the run to the newest analysis for that commit itself.
+        """
+        analyses = await self.aixs_client.alist_analyses(repository_id, branch=branch)
+        for analysis in analyses:
+            if analysis.get("commit_hash") == commit_hash:
+                return analysis.get("analysis_id")
+
+        logger.warning(
+            f"No analysis found for commit {commit_hash[:12]} on branch "
+            f"'{branch}'; letting AIXS pick the latest one for the commit."
+        )
+        return None
 
     @record_execution_time
     async def _dispatch_experiment_on_aixs(
@@ -96,10 +130,14 @@ class DispatchExperimentOnAixsSubgraph:
                 f"Branch '{github_config.branch_name}' not found in {git_url}. "
                 "Push the experiment code before dispatching."
             )
+
         commit_hash = branch["commit_hash"]
 
-        analysis = await self.aixs_client.astart_analysis(
+        await self.aixs_client.astart_analysis(
             repository_id, commit_hash, branch=github_config.branch_name
+        )
+        analysis_id = await self._resolve_analysis_id(
+            repository_id, commit_hash, github_config.branch_name
         )
 
         mode = self.run_stage.value
@@ -119,7 +157,8 @@ class DispatchExperimentOnAixsSubgraph:
 
         logger.info(
             f"Starting AIXS run for run_id={run_id} (mode={mode}, "
-            f"compute_type={self.compute_type}) at commit {commit_hash[:12]}"
+            f"compute_id={self.compute_id}, compute_type={self.compute_type}) "
+            f"at commit {commit_hash[:12]}"
         )
         run = await self.aixs_client.astart_run(
             repository_id,
@@ -127,7 +166,10 @@ class DispatchExperimentOnAixsSubgraph:
             analyzed_experiment,
             compute_type=self.compute_type,
             compute_id=self.compute_id,
-            analysis_id=analysis.get("id"),
+            analysis_id=analysis_id,
+            inputs_from_runs=self.inputs_from_runs,
+            time_limit=self.time_limit,
+            resource_count=self.resource_count,
         )
 
         return {


### PR DESCRIPTION
## 背景と目的

AIRAS から AIXS 計算基盤を呼び出す経路（`AixsClient` / `DispatchExperimentOnAixsSubgraph` / `dispatch_experiment(backend="aixs")`）は既に存在しますが、実際に AIXS の実装と突き合わせたところ、次の問題がありました。

- **接続先が誤っていた**: デフォルトの base URL が `https://api.aixs.dev` を指していました。これは AIXS とは無関係のホストで、`/health` に 200（プレーンテキストの `OK`）を返すため、`AIXS_BASE_URL` を明示していない利用者は「即座に失敗」ではなく分かりにくい失敗の仕方をしていました。AIXS の実配信元は `api.dev.airas.io` / `api.airas.io` です。
- **run が analysis に紐付いていなかった**: analysis 開始のレスポンスはレコード id を含まないため、`analysis.get("id")` は常に `None` で、`analysis_id` が送られていませんでした。AIXS 側のフォールバック（同一 commit の最新 analysis）で動いてはいたものの、コードは analysis を固定しているように読める状態でした。
- **登録済み計算機（BYO）での実行に必要な機能が無かった**: 計算機の指定、過去 run の成果物の引き継ぎ、run ごとのリソース要求、結果ファイル・ログの取得手段がクライアントにありませんでした。ワークフロー（LangGraph）は MCP を呼べないため、これらは Python クライアント側に必要です。

## 変更内容

以下の機能が変更されました：

1. AIXS の接続先 URL の修正
2. run を直前に作成した analysis に紐付ける修正
3. 登録済み計算機（BYO）での実行に必要なパラメータの追加
4. 実行結果・ログ・クラスタ状態を取得するクライアントメソッドの追加

実装の詳細は以下の通りです：

<details>
<summary><code>1. AIXS の接続先 URL の修正</code></summary>

**実装概要**

`backend/src/airas/infra/aixs_client.py`

- `DEFAULT_AIXS_BASE_URL` を `https://api.aixs.dev` から `https://api.dev.airas.io` に変更
- AIXS は `develop` を dev 環境、`main` を production（`api.airas.io`）にデプロイしており、本クライアントが利用するエンドポイント群は現時点では dev デプロイでのみ提供されているため、dev を既定とする
- production への切り替えは `TODO(aixs-prod)` としてコメントで残す

</details>

<details>
<summary><code>2. run を直前に作成した analysis に紐付ける修正</code></summary>

**実装概要**

- `AixsClient.alist_analyses(repository_id, branch)` を追加
  - analysis 開始のレスポンスには id が含まれないため、一覧側（各エントリが `analysis_id` を持つ）から引き直す
- `DispatchExperimentOnAixsSubgraph._resolve_analysis_id()` を追加
  - 一覧は新しい順なので、対象 commit の先頭エントリが直前に作成したもの
  - 見つからない場合は `None` を渡し、AIXS 側の「同一 commit の最新 analysis」フォールバックに委ねる（安全側）
- `AixsClient.astart_analysis()` の `branch` を必須引数に変更
  - AIXS 側のリクエストスキーマで必須のため、`None` を渡せる余地を無くして 422 を未然に防ぐ

</details>

<details>
<summary><code>3. 登録済み計算機（BYO）での実行に必要なパラメータの追加</code></summary>

**実装概要**

`AixsClient.astart_run()` / `DispatchExperimentOnAixsSubgraph` / `dispatch_experiment` に以下を追加：

- **`compute_id`**: 実行先の計算機を指定（登録済みクラスタは `"byo:<uuid>"`）
  - `dispatch_experiment` では省略時に環境変数 `AIXS_COMPUTE_ID` を参照し、いずれも無ければ AIXS のマネージド計算機で実行する
  - `AIXS_COMPUTE_ID` を `CREDENTIAL_SPECS` に追加（非シークレット）
  - `compute_type` は `compute_id` を指定した場合も有効。登録済みクラスタ側で job の要求リソースに解決されるため
- **`inputs_from_runs`**: 過去の完了 run の成果物を、書き出された相対パスのまま今回の run の作業ディレクトリへ復元する
  - 計測 run → 可視化 run のようなパイプラインや、複数 run の比較に使う
  - AIXS 側が空配列を弾くため、空なら送らない（「入力なし」はフィールド省略で表す）
- **`time_limit` / `resource_count`**: run ごとの実行時間・リソース数の要求
  - 受け付けられる値は計算機カタログの `run_profile` に依存する

</details>

<details>
<summary><code>4. 実行結果・ログ・クラスタ状態を取得するクライアントメソッドの追加</code></summary>

**実装概要**

`backend/src/airas/infra/aixs_client.py`

- **`aget_run_outputs(run_id)`**: run の成果物一覧を取得（各エントリは run 相対パス・サイズ・ダウンロード URL を持つ）
  - airas-template の規約に従う実験なら `.research/results` 配下に結果が出る
- **`adownload(url)`**: AIXS が発行した URL（成果物、完了 run の `stdout_url` / `stderr_url`）を取得
  - これらの URL は事前認可済みで期限があるため、API キーは付与しない
- **`aget_byo_compute_status(compute_id, refresh=False)`**: 登録済みクラスタの混雑状況・ストレージ使用量を取得
  - 長時間の run を投入する前の判断材料。あくまで観測値で、スケジューラによる保証ではない
  - サーバ側キャッシュがあり `refresh=True` にはレート下限があるため、レスポンスの `cached` で実際にどちらが返ったか判別する

</details>

5. その他:
   - `dispatch_experiment` の docstring を整理し、AIXS の内部実装への言及と、実行時エラーで案内される内容の重複（`AIXS_API_KEY` 未設定など）を削除。W&B の API キーを AIXS 側に env var 登録する必要がある点のみ残した（未登録だと dispatch 途中で 400 が返り、実験コードのバグと誤解されやすいため）
   - 計算機一覧・空き確認・クラスタ状態の参照などセットアップ・調査系の操作は AIXS の MCP サーバー側に任せ、AIRAS の MCP tool は airas-template の実験コントラクトを知っている必要があるもの（`dispatch_experiment` / `get_experiment_run_status`）に限定した
