### PR TITLE
feat: add the Rikyu (OpenAI-compatible) LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ AWS_BEARER_TOKEN_BEDROCK=""
 ## Use it as llm_name="vercel_ai_gateway/<provider>/<model>",
 ## e.g. "vercel_ai_gateway/anthropic/claude-sonnet-4".
 VERCEL_AI_GATEWAY_API_KEY=""
+## RIKEN R-CCS's OpenAI-compatible API. Use it as llm_name="rikyu/<model>",
+## where <model> is an ID the endpoint reports at GET <base URL>/models.
+## The same key configures opencode.
+RIKYU_API_KEY=""
 
 
 # <Optional>

--- a/backend/src/airas/core/credentials.py
+++ b/backend/src/airas/core/credentials.py
@@ -98,6 +98,12 @@ CREDENTIAL_SPECS: tuple[CredentialSpec, ...] = (
     # the same value as AI_GATEWAY_API_KEY (mapped in the template repo's
     # workflows).
     CredentialSpec("VERCEL_AI_GATEWAY_API_KEY"),
+    # RIKEN R-CCS's OpenAI-compatible API, used as `rikyu/<model>`. Keys are
+    # issued and billed per project, so this stays under its own name rather
+    # than a shared one. opencode reads the same key in the template repo's
+    # workflows. The base URL has a default; override it by adding
+    # RIKYU_API_BASE to this file by hand.
+    CredentialSpec("RIKYU_API_KEY"),
     # Optional: raise rate limits for the paper-search sources.
     CredentialSpec("SEMANTIC_SCHOLAR_API_KEY"),
     CredentialSpec("OPENALEX_API_KEY"),

--- a/backend/src/airas/core/credentials.py
+++ b/backend/src/airas/core/credentials.py
@@ -93,16 +93,7 @@ CREDENTIAL_SPECS: tuple[CredentialSpec, ...] = (
     CredentialSpec("GEMINI_API_KEY"),
     CredentialSpec("OPENROUTER_API_KEY"),
     CredentialSpec("AWS_BEARER_TOKEN_BEDROCK"),
-    # One key for every model reachable through Vercel AI Gateway. litellm
-    # routes `vercel_ai_gateway/<provider>/<model>` with it; opencode reads
-    # the same value as AI_GATEWAY_API_KEY (mapped in the template repo's
-    # workflows).
     CredentialSpec("VERCEL_AI_GATEWAY_API_KEY"),
-    # RIKEN R-CCS's OpenAI-compatible API, used as `rikyu/<model>`. Keys are
-    # issued and billed per project, so this stays under its own name rather
-    # than a shared one. opencode reads the same key in the template repo's
-    # workflows. The base URL has a default; override it by adding
-    # RIKYU_API_BASE to this file by hand.
     CredentialSpec("RIKYU_API_KEY"),
     # Optional: raise rate limits for the paper-search sources.
     CredentialSpec("SEMANTIC_SCHOLAR_API_KEY"),

--- a/backend/src/airas/core/types/llm_provider.py
+++ b/backend/src/airas/core/types/llm_provider.py
@@ -10,7 +10,4 @@ class LLMProvider(str, Enum):
     BEDROCK = "bedrock"
     AZURE = "azure"
     VERCEL_AI_GATEWAY = "vercel_ai_gateway"
-    # OpenAI-compatible endpoints, one provider per institution so keys stay
-    # traceable to their host and billing. See OPENAI_COMPATIBLE_ENDPOINTS in
-    # infra/llm_provider_resolver.py for how they are routed.
     RIKYU = "rikyu"

--- a/backend/src/airas/core/types/llm_provider.py
+++ b/backend/src/airas/core/types/llm_provider.py
@@ -10,3 +10,7 @@ class LLMProvider(str, Enum):
     BEDROCK = "bedrock"
     AZURE = "azure"
     VERCEL_AI_GATEWAY = "vercel_ai_gateway"
+    # OpenAI-compatible endpoints, one provider per institution so keys stay
+    # traceable to their host and billing. See OPENAI_COMPATIBLE_ENDPOINTS in
+    # infra/llm_provider_resolver.py for how they are routed.
+    RIKYU = "rikyu"

--- a/backend/src/airas/infra/litellm_client.py
+++ b/backend/src/airas/infra/litellm_client.py
@@ -21,7 +21,9 @@ from litellm import get_valid_models
 
 from airas.core.types.llm_provider import LLMProvider
 from airas.infra.llm_provider_resolver import (
-    OPENAI_COMPATIBLE_ENDPOINTS,
+    RIKYU_BASE_URL_ENV,
+    RIKYU_DEFAULT_BASE_URL,
+    RIKYU_KEY_ENV,
     detect_available_providers,
     infer_provider,
 )
@@ -40,16 +42,16 @@ PROVIDER_REQUIRED_ENV_VARS: dict[LLMProvider, list[str]] = {
     LLMProvider.BEDROCK: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
     LLMProvider.AZURE: ["AZURE_API_KEY", "AZURE_API_BASE"],
     LLMProvider.VERCEL_AI_GATEWAY: ["VERCEL_AI_GATEWAY_API_KEY"],
-    # Only the key: the base URL has a default, so an endpoint counts as
-    # configured once its key is present (see OPENAI_COMPATIBLE_ENDPOINTS).
+    # Only the key: the base URL has a default (RIKYU_DEFAULT_BASE_URL), so
+    # the endpoint counts as configured once its key is present.
     LLMProvider.RIKYU: ["RIKYU_API_KEY"],
 }
 
-# litellm has no provider per institutional endpoint, so an airas name like
-# "rikyu/kimi-k3" is rewritten onto litellm's generic OpenAI-compatible route
-# and paired with an explicit api_base. `openai/` is deliberately not used:
-# with no key passed it silently falls back to OPENAI_API_KEY, which would
-# send one vendor's credential to another's host.
+# litellm has no provider for Rikyu, so "rikyu/kimi-k3" is rewritten onto
+# litellm's generic OpenAI-compatible route and paired with an explicit
+# api_base. `openai/` is deliberately not used: with no key passed it silently
+# falls back to OPENAI_API_KEY, which would send one vendor's credential to
+# another's host.
 LITELLM_OPENAI_COMPATIBLE_PREFIX = "hosted_vllm/"
 
 # TODO: Define LLMParams
@@ -75,28 +77,20 @@ class LiteLLMClient:
         """Map an airas model name to litellm's model name + connection kwargs.
 
         Every model litellm already knows how to route passes through
-        untouched. Models on an OpenAI-compatible endpoint carry a provider
-        name litellm has never heard of, so the route and the host have to be
-        supplied here.
+        untouched. Rikyu models carry a provider name litellm has never heard
+        of, so the route and the host have to be supplied here.
         """
         api_key = self._get_api_key(llm_name)
-        provider = infer_provider(llm_name)
-        endpoint = (
-            OPENAI_COMPATIBLE_ENDPOINTS.get(provider) if provider is not None else None
-        )
-        if endpoint is None:
+        if infer_provider(llm_name) is not LLMProvider.RIKYU:
             return llm_name, {"api_key": api_key}
 
-        assert provider is not None  # narrowed by the lookup above
-        model_id = llm_name.removeprefix(f"{provider.value}/")
-        api_base = (
-            os.getenv(endpoint.base_url_env, "").strip() or endpoint.default_base_url
-        )
+        model_id = llm_name.removeprefix(f"{LLMProvider.RIKYU.value}/")
+        api_base = os.getenv(RIKYU_BASE_URL_ENV, "").strip() or RIKYU_DEFAULT_BASE_URL
         return LITELLM_OPENAI_COMPATIBLE_PREFIX + model_id, {
             # Self-hosted callers build the client without a key resolver, so
             # read the env directly rather than sending an unauthenticated
             # request that the endpoint would reject.
-            "api_key": api_key or os.getenv(endpoint.key_env) or None,
+            "api_key": api_key or os.getenv(RIKYU_KEY_ENV) or None,
             "api_base": api_base.rstrip("/"),
         }
 

--- a/backend/src/airas/infra/litellm_client.py
+++ b/backend/src/airas/infra/litellm_client.py
@@ -20,7 +20,11 @@ import litellm
 from litellm import get_valid_models
 
 from airas.core.types.llm_provider import LLMProvider
-from airas.infra.llm_provider_resolver import detect_available_providers
+from airas.infra.llm_provider_resolver import (
+    OPENAI_COMPATIBLE_ENDPOINTS,
+    detect_available_providers,
+    infer_provider,
+)
 from airas.infra.retry_policy import make_llm_retry_policy
 
 logger = logging.getLogger(__name__)
@@ -36,7 +40,17 @@ PROVIDER_REQUIRED_ENV_VARS: dict[LLMProvider, list[str]] = {
     LLMProvider.BEDROCK: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
     LLMProvider.AZURE: ["AZURE_API_KEY", "AZURE_API_BASE"],
     LLMProvider.VERCEL_AI_GATEWAY: ["VERCEL_AI_GATEWAY_API_KEY"],
+    # Only the key: the base URL has a default, so an endpoint counts as
+    # configured once its key is present (see OPENAI_COMPATIBLE_ENDPOINTS).
+    LLMProvider.RIKYU: ["RIKYU_API_KEY"],
 }
+
+# litellm has no provider per institutional endpoint, so an airas name like
+# "rikyu/kimi-k3" is rewritten onto litellm's generic OpenAI-compatible route
+# and paired with an explicit api_base. `openai/` is deliberately not used:
+# with no key passed it silently falls back to OPENAI_API_KEY, which would
+# send one vendor's credential to another's host.
+LITELLM_OPENAI_COMPATIBLE_PREFIX = "hosted_vllm/"
 
 # TODO: Define LLMParams
 
@@ -56,6 +70,35 @@ class LiteLLMClient:
         litellm.drop_params = True
         if logger.isEnabledFor(logging.DEBUG):
             os.environ["LITELLM_LOG"] = "DEBUG"
+
+    def _resolve_call_target(self, llm_name: str) -> tuple[str, dict[str, Any]]:
+        """Map an airas model name to litellm's model name + connection kwargs.
+
+        Every model litellm already knows how to route passes through
+        untouched. Models on an OpenAI-compatible endpoint carry a provider
+        name litellm has never heard of, so the route and the host have to be
+        supplied here.
+        """
+        api_key = self._get_api_key(llm_name)
+        provider = infer_provider(llm_name)
+        endpoint = (
+            OPENAI_COMPATIBLE_ENDPOINTS.get(provider) if provider is not None else None
+        )
+        if endpoint is None:
+            return llm_name, {"api_key": api_key}
+
+        assert provider is not None  # narrowed by the lookup above
+        model_id = llm_name.removeprefix(f"{provider.value}/")
+        api_base = (
+            os.getenv(endpoint.base_url_env, "").strip() or endpoint.default_base_url
+        )
+        return LITELLM_OPENAI_COMPATIBLE_PREFIX + model_id, {
+            # Self-hosted callers build the client without a key resolver, so
+            # read the env directly rather than sending an unauthenticated
+            # request that the endpoint would reject.
+            "api_key": api_key or os.getenv(endpoint.key_env) or None,
+            "api_base": api_base.rstrip("/"),
+        }
 
     @_LLM_RETRY
     async def generate(
@@ -86,13 +129,13 @@ class LiteLLMClient:
                 "Proceeding without max_tokens limit."
             )
 
-        api_key = self._get_api_key(llm_name)
+        model, connection = self._resolve_call_target(llm_name)
 
         try:
             response = await litellm.acompletion(
-                model=llm_name,
+                model=model,
                 messages=messages,
-                api_key=api_key,
+                **connection,
                 **litellm_kwargs,
             )  # TODO: timeoutを延長する
             content = response.choices[0].message.content
@@ -172,14 +215,14 @@ class LiteLLMClient:
                 "Proceeding without max_tokens limit."
             )
 
-        api_key = self._get_api_key(llm_name)
+        model, connection = self._resolve_call_target(llm_name)
 
         try:
             response = await litellm.acompletion(
-                model=llm_name,
+                model=model,
                 messages=messages,
                 response_format=data_model,
-                api_key=api_key,
+                **connection,
                 **litellm_kwargs,
             )  # TODO: timeoutを延長する
 
@@ -221,11 +264,11 @@ class LiteLLMClient:
                 f"Failed to get model info for {model}: {e}. Proceeding without model metadata."
             )
 
-        api_key = self._get_api_key(model)
+        litellm_model, connection = self._resolve_call_target(model)
 
         try:
             response = await litellm.aembedding(
-                model=model, input=texts, api_key=api_key
+                model=litellm_model, input=texts, **connection
             )
             data = getattr(response, "data", None)
             if not data:
@@ -291,6 +334,9 @@ if __name__ == "__main__":
         "openrouter",
         "azure",
         "vercel_ai_gateway",
+        # litellm's route for OpenAI-compatible endpoints; airas addresses
+        # those per endpoint, e.g. "rikyu/<model>".
+        "hosted_vllm",
     ]
 
     for provider_name in provider_names:

--- a/backend/src/airas/infra/llm_provider_resolver.py
+++ b/backend/src/airas/infra/llm_provider_resolver.py
@@ -5,8 +5,40 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 
 from airas.core.types.llm_provider import LLMProvider
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible endpoints
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class OpenAICompatibleEndpoint:
+    """An OpenAI-compatible API that airas addresses under its own name.
+
+    Each endpoint gets a named provider rather than sharing one generic pair
+    of env vars: a generic pair is effectively a singleton and collides as
+    soon as a second such endpoint exists, and a credential named
+    ``RIKYU_API_KEY`` says which host it reaches and which project is billed
+    — which a generic name cannot. The implementation stays generic: adding
+    the next endpoint is one entry here plus its prefix below.
+    """
+
+    key_env: str
+    base_url_env: str
+    # Used when *base_url_env* is unset, so only the key has to be configured.
+    default_base_url: str
+
+
+OPENAI_COMPATIBLE_ENDPOINTS: dict[LLMProvider, OpenAICompatibleEndpoint] = {
+    LLMProvider.RIKYU: OpenAICompatibleEndpoint(
+        key_env="RIKYU_API_KEY",
+        base_url_env="RIKYU_API_BASE",
+        default_base_url="https://api.rikyu.r-ccs.riken.jp/v1",
+    ),
+}
+
 
 # ---------------------------------------------------------------------------
 # Provider -> primary API-key env-var name
@@ -18,6 +50,7 @@ PROVIDER_PRIMARY_KEY: dict[LLMProvider, str] = {
     LLMProvider.OPENROUTER: "OPENROUTER_API_KEY",
     LLMProvider.AZURE: "AZURE_API_KEY",
     LLMProvider.VERCEL_AI_GATEWAY: "VERCEL_AI_GATEWAY_API_KEY",
+    LLMProvider.RIKYU: "RIKYU_API_KEY",
 }
 
 
@@ -35,6 +68,11 @@ _MODEL_PREFIX_TO_PROVIDER: list[tuple[str, LLMProvider]] = [
     # segment (e.g. "vercel_ai_gateway/anthropic/claude-sonnet-4"), so this
     # entry must be matched before the vendor-prefix rules further down.
     ("vercel_ai_gateway/", LLMProvider.VERCEL_AI_GATEWAY),
+    # OpenAI-compatible endpoints (see OPENAI_COMPATIBLE_ENDPOINTS). What
+    # follows the prefix is the model ID the endpoint itself reports via
+    # GET /v1/models, so it can be a bare name ("rikyu/kimi-k3") or carry a
+    # vendor path; either way this must win over the vendor rules below.
+    ("rikyu/", LLMProvider.RIKYU),
     # Bare model names (no prefix)
     ("gemini-", LLMProvider.GOOGLE),
     ("gemini-embedding-", LLMProvider.GOOGLE),

--- a/backend/src/airas/infra/llm_provider_resolver.py
+++ b/backend/src/airas/infra/llm_provider_resolver.py
@@ -1,43 +1,21 @@
-# TODO: Expose a guard/eligibility check (e.g. check_model_available(provider, available_providers))
-#       so that the backend can reject unsupported model requests early and the frontend
-#       can filter the model selector based on the user's available providers.
-
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
 
 from airas.core.types.llm_provider import LLMProvider
 
-
 # ---------------------------------------------------------------------------
-# OpenAI-compatible endpoints
+# Rikyu (RIKEN R-CCS) — an OpenAI-compatible endpoint, addressed as
+# "rikyu/<model>". It gets its own provider name and env vars rather than a
+# generic OPENAI_COMPATIBLE_* pair: a generic pair is effectively a singleton,
+# and a credential named RIKYU_API_KEY says which host it reaches and which
+# project is billed. Should a second such endpoint appear, generalize these
+# into a table then.
 # ---------------------------------------------------------------------------
-@dataclass(frozen=True)
-class OpenAICompatibleEndpoint:
-    """An OpenAI-compatible API that airas addresses under its own name.
-
-    Each endpoint gets a named provider rather than sharing one generic pair
-    of env vars: a generic pair is effectively a singleton and collides as
-    soon as a second such endpoint exists, and a credential named
-    ``RIKYU_API_KEY`` says which host it reaches and which project is billed
-    — which a generic name cannot. The implementation stays generic: adding
-    the next endpoint is one entry here plus its prefix below.
-    """
-
-    key_env: str
-    base_url_env: str
-    # Used when *base_url_env* is unset, so only the key has to be configured.
-    default_base_url: str
-
-
-OPENAI_COMPATIBLE_ENDPOINTS: dict[LLMProvider, OpenAICompatibleEndpoint] = {
-    LLMProvider.RIKYU: OpenAICompatibleEndpoint(
-        key_env="RIKYU_API_KEY",
-        base_url_env="RIKYU_API_BASE",
-        default_base_url="https://api.rikyu.r-ccs.riken.jp/v1",
-    ),
-}
+RIKYU_KEY_ENV = "RIKYU_API_KEY"
+RIKYU_BASE_URL_ENV = "RIKYU_API_BASE"
+# Used when RIKYU_API_BASE is unset, so only the key has to be configured.
+RIKYU_DEFAULT_BASE_URL = "https://api.rikyu.r-ccs.riken.jp/v1"
 
 
 # ---------------------------------------------------------------------------
@@ -68,10 +46,10 @@ _MODEL_PREFIX_TO_PROVIDER: list[tuple[str, LLMProvider]] = [
     # segment (e.g. "vercel_ai_gateway/anthropic/claude-sonnet-4"), so this
     # entry must be matched before the vendor-prefix rules further down.
     ("vercel_ai_gateway/", LLMProvider.VERCEL_AI_GATEWAY),
-    # OpenAI-compatible endpoints (see OPENAI_COMPATIBLE_ENDPOINTS). What
-    # follows the prefix is the model ID the endpoint itself reports via
-    # GET /v1/models, so it can be a bare name ("rikyu/kimi-k3") or carry a
-    # vendor path; either way this must win over the vendor rules below.
+    # Rikyu (OpenAI-compatible endpoint). What follows the prefix is the
+    # model ID the endpoint itself reports via GET /v1/models, so it can be
+    # a bare name ("rikyu/kimi-k3") or carry a vendor path; either way this
+    # must win over the vendor rules below.
     ("rikyu/", LLMProvider.RIKYU),
     # Bare model names (no prefix)
     ("gemini-", LLMProvider.GOOGLE),

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -75,7 +75,8 @@ from airas.infra.litellm_client import (
     LiteLLMClient,
 )
 from airas.infra.llm_provider_resolver import (
-    OPENAI_COMPATIBLE_ENDPOINTS,
+    RIKYU_BASE_URL_ENV,
+    RIKYU_DEFAULT_BASE_URL,
     detect_available_providers,
 )
 from airas.infra.openalex_client import OpenAlexClient
@@ -230,13 +231,12 @@ def _litellm_client() -> LiteLLMClient:
 
 
 # airas's LLMProvider enum value -> litellm's ``custom_llm_provider`` name.
-# Only GOOGLE and the OpenAI-compatible endpoints diverge (airas "google" vs
-# litellm "gemini"; endpoints such as "rikyu" are airas names for litellm's
-# generic OpenAI-compatible route); every other provider's enum value already
-# matches litellm, so we fall back to it.
+# Only GOOGLE and RIKYU diverge (airas "google" vs litellm "gemini"; "rikyu"
+# is an airas name for litellm's generic OpenAI-compatible route); every
+# other provider's enum value already matches litellm, so we fall back to it.
 _LITELLM_PROVIDER_NAME: dict[LLMProvider, str] = {
     LLMProvider.GOOGLE: "gemini",
-    **{provider: "hosted_vllm" for provider in OPENAI_COMPATIBLE_ENDPOINTS},
+    LLMProvider.RIKYU: "hosted_vllm",
 }
 
 
@@ -293,13 +293,29 @@ def get_available_llms(include_models: bool = False) -> dict[str, Any]:
             "missing_env_vars": [name for name in required if not os.getenv(name)],
         }
         if configured and include_models:
-            litellm_name = _LITELLM_PROVIDER_NAME.get(provider, provider.value)
-            try:
-                models = sorted(LiteLLMClient.get_valid_models(provider=litellm_name))
-                entry["model_count"] = len(models)
-                entry["models"] = models
-            except Exception as exc:  # never let catalog lookup fail the tool
-                entry["models_error"] = str(exc)
+            if provider is LLMProvider.RIKYU:
+                # litellm's catalog has no entries for this endpoint, so an
+                # empty list here would read as "configured but no models".
+                # Refuse explicitly and point at the endpoint's own listing.
+                base_url = (
+                    os.getenv(RIKYU_BASE_URL_ENV, "").strip() or RIKYU_DEFAULT_BASE_URL
+                ).rstrip("/")
+                entry["models_error"] = (
+                    f"litellm's catalog cannot list '{provider.value}' models. "
+                    f"Query the endpoint itself — GET {base_url}/models with "
+                    "'Authorization: Bearer $RIKYU_API_KEY' — and pass a "
+                    f"model as '{provider.value}/<model ID>'."
+                )
+            else:
+                litellm_name = _LITELLM_PROVIDER_NAME.get(provider, provider.value)
+                try:
+                    models = sorted(
+                        LiteLLMClient.get_valid_models(provider=litellm_name)
+                    )
+                    entry["model_count"] = len(models)
+                    entry["models"] = models
+                except Exception as exc:  # never let catalog lookup fail the tool
+                    entry["models_error"] = str(exc)
         providers.append(entry)
 
     return {

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -5,7 +5,8 @@ such as Claude Code and Claude Desktop.
 
 Credentials are read from ~/.airas/credentials.json (see credentials.py):
 - LLM providers: OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY /
-  OPENROUTER_API_KEY / VERCEL_AI_GATEWAY_API_KEY (at least one)
+  OPENROUTER_API_KEY / VERCEL_AI_GATEWAY_API_KEY / RIKYU_API_KEY
+  (at least one)
 - GitHub (repository/experiment tools): GH_PERSONAL_ACCESS_TOKEN
 
 The file is re-read on every tool call, so keys can be added or rotated
@@ -73,7 +74,10 @@ from airas.infra.litellm_client import (
 from airas.infra.litellm_client import (
     LiteLLMClient,
 )
-from airas.infra.llm_provider_resolver import detect_available_providers
+from airas.infra.llm_provider_resolver import (
+    OPENAI_COMPATIBLE_ENDPOINTS,
+    detect_available_providers,
+)
 from airas.infra.openalex_client import OpenAlexClient
 from airas.infra.retry_policy import HTTPClientFatalError, HTTPClientRetryableError
 from airas.infra.semantic_scholar_client import SemanticScholarClient
@@ -226,10 +230,13 @@ def _litellm_client() -> LiteLLMClient:
 
 
 # airas's LLMProvider enum value -> litellm's ``custom_llm_provider`` name.
-# Only GOOGLE diverges (airas "google" vs litellm "gemini"); every other
-# provider's enum value already matches litellm, so we fall back to it.
+# Only GOOGLE and the OpenAI-compatible endpoints diverge (airas "google" vs
+# litellm "gemini"; endpoints such as "rikyu" are airas names for litellm's
+# generic OpenAI-compatible route); every other provider's enum value already
+# matches litellm, so we fall back to it.
 _LITELLM_PROVIDER_NAME: dict[LLMProvider, str] = {
     LLMProvider.GOOGLE: "gemini",
+    **{provider: "hosted_vllm" for provider in OPENAI_COMPATIBLE_ENDPOINTS},
 }
 
 

--- a/backend/src/airas/usecases/github/push_code_subgraph/push_code_subgraph.py
+++ b/backend/src/airas/usecases/github/push_code_subgraph/push_code_subgraph.py
@@ -48,6 +48,7 @@ class PushCodeSubgraph:
             "GEMINI_API_KEY",
             "ANTHROPIC_API_KEY",
             "OPENROUTER_API_KEY",
+            "RIKYU_API_KEY",
             "AWS_BEARER_TOKEN_BEDROCK",
             "WANDB_API_KEY",
             "HF_TOKEN",

--- a/backend/src/airas/usecases/github/set_github_actions_secrets_subgraph/set_github_actions_secrets_subgraph.py
+++ b/backend/src/airas/usecases/github/set_github_actions_secrets_subgraph/set_github_actions_secrets_subgraph.py
@@ -45,6 +45,7 @@ class SetGithubActionsSecretsSubgraph:
             "ANTHROPIC_API_KEY",
             "OPENROUTER_API_KEY",
             "VERCEL_AI_GATEWAY_API_KEY",
+            "RIKYU_API_KEY",
             "AWS_BEARER_TOKEN_BEDROCK",
             "WANDB_API_KEY",
             "HF_TOKEN",

--- a/backend/tests/unit/test_litellm_client_openai_compatible.py
+++ b/backend/tests/unit/test_litellm_client_openai_compatible.py
@@ -1,19 +1,20 @@
-"""How OpenAI-compatible endpoints (e.g. `rikyu/<model>`) reach litellm.
+"""How the Rikyu endpoint (`rikyu/<model>`) reaches litellm.
 
-litellm has no provider per institutional endpoint, so the client rewrites
-the model name and supplies the host itself. These tests pin that mapping,
-since getting it wrong sends research traffic to the wrong host — or to a
-vendor default with the wrong key.
+litellm has no provider for Rikyu, so the client rewrites the model name
+onto litellm's generic OpenAI-compatible route and supplies the host itself.
+These tests pin that mapping, since getting it wrong sends research traffic
+to the wrong host — or to a vendor default with the wrong key.
 """
 
-from airas.core.types.llm_provider import LLMProvider
 from airas.infra.litellm_client import (
     LITELLM_OPENAI_COMPATIBLE_PREFIX,
     LiteLLMClient,
 )
-from airas.infra.llm_provider_resolver import OPENAI_COMPATIBLE_ENDPOINTS
-
-RIKYU = OPENAI_COMPATIBLE_ENDPOINTS[LLMProvider.RIKYU]
+from airas.infra.llm_provider_resolver import (
+    RIKYU_BASE_URL_ENV,
+    RIKYU_DEFAULT_BASE_URL,
+    RIKYU_KEY_ENV,
+)
 
 
 def test_vendor_models_pass_through_untouched() -> None:
@@ -26,7 +27,7 @@ def test_vendor_models_pass_through_untouched() -> None:
 
 
 def test_endpoint_model_is_routed_to_its_default_base_url(monkeypatch) -> None:
-    monkeypatch.delenv(RIKYU.base_url_env, raising=False)
+    monkeypatch.delenv(RIKYU_BASE_URL_ENV, raising=False)
     client = LiteLLMClient(
         get_api_key=lambda _: "sk-endpoint", available_providers=set()
     )
@@ -37,12 +38,12 @@ def test_endpoint_model_is_routed_to_its_default_base_url(monkeypatch) -> None:
     assert model == f"{LITELLM_OPENAI_COMPATIBLE_PREFIX}kimi-k3"
     assert connection == {
         "api_key": "sk-endpoint",
-        "api_base": RIKYU.default_base_url,
+        "api_base": RIKYU_DEFAULT_BASE_URL,
     }
 
 
 def test_base_url_env_overrides_the_default(monkeypatch) -> None:
-    monkeypatch.setenv(RIKYU.base_url_env, "https://staging.example.org/v1/")
+    monkeypatch.setenv(RIKYU_BASE_URL_ENV, "https://staging.example.org/v1/")
     client = LiteLLMClient(
         get_api_key=lambda _: "sk-endpoint", available_providers=set()
     )
@@ -55,7 +56,7 @@ def test_base_url_env_overrides_the_default(monkeypatch) -> None:
 
 def test_key_falls_back_to_the_environment(monkeypatch) -> None:
     """Self-hosted callers construct the client without a key resolver."""
-    monkeypatch.setenv(RIKYU.key_env, "sk-from-env")
+    monkeypatch.setenv(RIKYU_KEY_ENV, "sk-from-env")
     client = LiteLLMClient(available_providers=set())
 
     _, connection = client._resolve_call_target("rikyu/kimi-k3")

--- a/backend/tests/unit/test_litellm_client_openai_compatible.py
+++ b/backend/tests/unit/test_litellm_client_openai_compatible.py
@@ -1,0 +1,63 @@
+"""How OpenAI-compatible endpoints (e.g. `rikyu/<model>`) reach litellm.
+
+litellm has no provider per institutional endpoint, so the client rewrites
+the model name and supplies the host itself. These tests pin that mapping,
+since getting it wrong sends research traffic to the wrong host — or to a
+vendor default with the wrong key.
+"""
+
+from airas.core.types.llm_provider import LLMProvider
+from airas.infra.litellm_client import (
+    LITELLM_OPENAI_COMPATIBLE_PREFIX,
+    LiteLLMClient,
+)
+from airas.infra.llm_provider_resolver import OPENAI_COMPATIBLE_ENDPOINTS
+
+RIKYU = OPENAI_COMPATIBLE_ENDPOINTS[LLMProvider.RIKYU]
+
+
+def test_vendor_models_pass_through_untouched() -> None:
+    client = LiteLLMClient(get_api_key=lambda _: "sk-vendor", available_providers=set())
+
+    model, connection = client._resolve_call_target("openrouter/openai/gpt-5-nano")
+
+    assert model == "openrouter/openai/gpt-5-nano"
+    assert connection == {"api_key": "sk-vendor"}
+
+
+def test_endpoint_model_is_routed_to_its_default_base_url(monkeypatch) -> None:
+    monkeypatch.delenv(RIKYU.base_url_env, raising=False)
+    client = LiteLLMClient(
+        get_api_key=lambda _: "sk-endpoint", available_providers=set()
+    )
+
+    model, connection = client._resolve_call_target("rikyu/kimi-k3")
+
+    # Only the model ID survives the rewrite; the provider name is airas's.
+    assert model == f"{LITELLM_OPENAI_COMPATIBLE_PREFIX}kimi-k3"
+    assert connection == {
+        "api_key": "sk-endpoint",
+        "api_base": RIKYU.default_base_url,
+    }
+
+
+def test_base_url_env_overrides_the_default(monkeypatch) -> None:
+    monkeypatch.setenv(RIKYU.base_url_env, "https://staging.example.org/v1/")
+    client = LiteLLMClient(
+        get_api_key=lambda _: "sk-endpoint", available_providers=set()
+    )
+
+    _, connection = client._resolve_call_target("rikyu/kimi-k3")
+
+    # The trailing slash is dropped so litellm does not build "//chat/...".
+    assert connection["api_base"] == "https://staging.example.org/v1"
+
+
+def test_key_falls_back_to_the_environment(monkeypatch) -> None:
+    """Self-hosted callers construct the client without a key resolver."""
+    monkeypatch.setenv(RIKYU.key_env, "sk-from-env")
+    client = LiteLLMClient(available_providers=set())
+
+    _, connection = client._resolve_call_target("rikyu/kimi-k3")
+
+    assert connection["api_key"] == "sk-from-env"

--- a/backend/tests/unit/test_llm_provider_resolver.py
+++ b/backend/tests/unit/test_llm_provider_resolver.py
@@ -3,6 +3,7 @@ import pytest
 from airas.core.types.llm_provider import LLMProvider
 from airas.infra.litellm_client import PROVIDER_REQUIRED_ENV_VARS
 from airas.infra.llm_provider_resolver import (
+    OPENAI_COMPATIBLE_ENDPOINTS,
     PROVIDER_PRIMARY_KEY,
     detect_available_providers,
     infer_provider,
@@ -19,6 +20,11 @@ from airas.infra.llm_provider_resolver import (
         ("vercel_ai_gateway/openai/gpt-5", LLMProvider.VERCEL_AI_GATEWAY),
         ("vercel_ai_gateway/google/gemini-2.5-pro", LLMProvider.VERCEL_AI_GATEWAY),
         ("vercel_ai_gateway/moonshotai/kimi-k2", LLMProvider.VERCEL_AI_GATEWAY),
+        # OpenAI-compatible endpoints: what follows the prefix is the
+        # endpoint's own model ID, which may itself look like a vendor path.
+        ("rikyu/kimi-k3", LLMProvider.RIKYU),
+        ("rikyu/moonshotai/kimi-k3", LLMProvider.RIKYU),
+        ("rikyu/gpt-oss-120b", LLMProvider.RIKYU),
         # Other explicit litellm-style prefixes stay unaffected.
         ("gemini/gemini-2.5-pro", LLMProvider.GOOGLE),
         ("openrouter/openai/gpt-5-nano", LLMProvider.OPENROUTER),
@@ -48,6 +54,28 @@ def test_vercel_gateway_is_available_when_its_key_is_set() -> None:
         PROVIDER_REQUIRED_ENV_VARS, {"VERCEL_AI_GATEWAY_API_KEY": "vck-test"}
     )
     assert available == {LLMProvider.VERCEL_AI_GATEWAY}
+
+
+def test_openai_compatible_endpoint_needs_only_its_key() -> None:
+    """The base URL has a default, so the key alone configures the endpoint."""
+    available = detect_available_providers(
+        PROVIDER_REQUIRED_ENV_VARS, {"RIKYU_API_KEY": "sk-test"}
+    )
+    assert available == {LLMProvider.RIKYU}
+
+
+def test_openai_compatible_endpoints_are_wired_consistently() -> None:
+    """Each endpoint's key must be the one the rest of the code looks up.
+
+    The table, the availability check and the dashboard's key resolution are
+    three separate maps; a drift between them routes requests to an endpoint
+    with no credential.
+    """
+    for provider, endpoint in OPENAI_COMPATIBLE_ENDPOINTS.items():
+        assert PROVIDER_PRIMARY_KEY[provider] == endpoint.key_env
+        assert PROVIDER_REQUIRED_ENV_VARS[provider] == [endpoint.key_env]
+        assert infer_provider(f"{provider.value}/some-model") is provider
+        assert endpoint.default_base_url.startswith("https://")
 
 
 def test_primary_keys_are_declared_as_required() -> None:

--- a/backend/tests/unit/test_llm_provider_resolver.py
+++ b/backend/tests/unit/test_llm_provider_resolver.py
@@ -3,8 +3,9 @@ import pytest
 from airas.core.types.llm_provider import LLMProvider
 from airas.infra.litellm_client import PROVIDER_REQUIRED_ENV_VARS
 from airas.infra.llm_provider_resolver import (
-    OPENAI_COMPATIBLE_ENDPOINTS,
     PROVIDER_PRIMARY_KEY,
+    RIKYU_DEFAULT_BASE_URL,
+    RIKYU_KEY_ENV,
     detect_available_providers,
     infer_provider,
 )
@@ -64,18 +65,17 @@ def test_openai_compatible_endpoint_needs_only_its_key() -> None:
     assert available == {LLMProvider.RIKYU}
 
 
-def test_openai_compatible_endpoints_are_wired_consistently() -> None:
-    """Each endpoint's key must be the one the rest of the code looks up.
+def test_rikyu_is_wired_consistently() -> None:
+    """Rikyu's key must be the one the rest of the code looks up.
 
-    The table, the availability check and the dashboard's key resolution are
-    three separate maps; a drift between them routes requests to an endpoint
-    with no credential.
+    The routing constants, the availability check and the dashboard's key
+    resolution are separate maps; a drift between them routes requests to
+    the endpoint with no credential.
     """
-    for provider, endpoint in OPENAI_COMPATIBLE_ENDPOINTS.items():
-        assert PROVIDER_PRIMARY_KEY[provider] == endpoint.key_env
-        assert PROVIDER_REQUIRED_ENV_VARS[provider] == [endpoint.key_env]
-        assert infer_provider(f"{provider.value}/some-model") is provider
-        assert endpoint.default_base_url.startswith("https://")
+    assert PROVIDER_PRIMARY_KEY[LLMProvider.RIKYU] == RIKYU_KEY_ENV
+    assert PROVIDER_REQUIRED_ENV_VARS[LLMProvider.RIKYU] == [RIKYU_KEY_ENV]
+    assert infer_provider("rikyu/some-model") is LLMProvider.RIKYU
+    assert RIKYU_DEFAULT_BASE_URL.startswith("https://")
 
 
 def test_primary_keys_are_declared_as_required() -> None:

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -51,7 +51,7 @@ curl -H "Authorization: Bearer $RIKYU_API_KEY" \
   https://api.rikyu.r-ccs.riken.jp/v1/models
 ```
 
-The base URL defaults to `https://api.rikyu.r-ccs.riken.jp/v1`; add `RIKYU_API_BASE` to the credentials file by hand to point at a different host. Other OpenAI-compatible endpoints get their own provider name and key the same way — one entry in `OPENAI_COMPATIBLE_ENDPOINTS` (`backend/src/airas/infra/llm_provider_resolver.py`) — so a key always says which host it reaches and which project is billed.
+The base URL defaults to `https://api.rikyu.r-ccs.riken.jp/v1`; add `RIKYU_API_BASE` to the credentials file by hand to point at a different host. A future OpenAI-compatible endpoint would get its own provider name and key the same way (see the `RIKYU_*` wiring in `backend/src/airas/infra/llm_provider_resolver.py`), so a key always says which host it reaches and which project is billed.
 
 The same key reaches the coding agent. To use the endpoint from a local [opencode](https://opencode.ai), declare it as a custom provider in `~/.config/opencode/opencode.json` (the experiment repository ships the equivalent block in `.opencode/opencode.jsonc`, and its workflows pass the key through from repository secrets):
 

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -29,10 +29,51 @@ chmod 600 ~/.airas/credentials.json
 
 | Key | Required | Purpose |
 | --- | --- | --- |
-| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `OPENROUTER_API_KEY` / `VERCEL_AI_GATEWAY_API_KEY` | At least one | LLM calls (query generation, paper extraction, hypothesis generation, paper writing) |
+| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `OPENROUTER_API_KEY` / `VERCEL_AI_GATEWAY_API_KEY` / `RIKYU_API_KEY` | At least one | LLM calls (query generation, paper extraction, hypothesis generation, paper writing) |
 | `GH_PERSONAL_ACCESS_TOKEN` | For repository / experiment / publication tools | GitHub API access (`repo` + `workflow` scopes) |
 
 If a tool is called before its credential is configured, it returns an error pointing at this file.
+
+### OpenAI-compatible endpoints (Rikyu)
+
+RIKEN R-CCS's Rikyu API speaks the OpenAI API, and is reached with one credential:
+
+```json
+{
+  "RIKYU_API_KEY": "..."
+}
+```
+
+Address its models as `rikyu/<model>`, where `<model>` is an ID the endpoint itself reports:
+
+```bash
+curl -H "Authorization: Bearer $RIKYU_API_KEY" \
+  https://api.rikyu.r-ccs.riken.jp/v1/models
+```
+
+The base URL defaults to `https://api.rikyu.r-ccs.riken.jp/v1`; add `RIKYU_API_BASE` to the credentials file by hand to point at a different host. Other OpenAI-compatible endpoints get their own provider name and key the same way — one entry in `OPENAI_COMPATIBLE_ENDPOINTS` (`backend/src/airas/infra/llm_provider_resolver.py`) — so a key always says which host it reaches and which project is billed.
+
+The same key reaches the coding agent. To use the endpoint from a local [opencode](https://opencode.ai), declare it as a custom provider in `~/.config/opencode/opencode.json` (the experiment repository ships the equivalent block in `.opencode/opencode.jsonc`, and its workflows pass the key through from repository secrets):
+
+```json
+{
+  "provider": {
+    "rikyu": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Rikyu (RIKEN R-CCS)",
+      "options": {
+        "baseURL": "https://api.rikyu.r-ccs.riken.jp/v1",
+        "apiKey": "{env:RIKYU_API_KEY}"
+      },
+      "models": {
+        "kimi-k3": { "name": "Kimi K3" }
+      }
+    }
+  }
+}
+```
+
+Register one entry under `models` per model ID you want to select, then run `opencode run --model rikyu/<model>` — the same name the node LLMs use. Coding-agent use requires the endpoint to serve tool calls (on vLLM, a tool-call parser must be enabled); a model that only handles plain completions still works for node LLM calls.
 
 ### 2. Register the server (Claude Code)
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -29,10 +29,51 @@ chmod 600 ~/.airas/credentials.json
 
 | キー | 必須 | 用途 |
 | --- | --- | --- |
-| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `OPENROUTER_API_KEY` / `VERCEL_AI_GATEWAY_API_KEY` | いずれか1つ | LLM呼び出し（クエリ生成・論文抽出・仮説生成・論文執筆） |
+| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `OPENROUTER_API_KEY` / `VERCEL_AI_GATEWAY_API_KEY` / `RIKYU_API_KEY` | いずれか1つ | LLM呼び出し（クエリ生成・論文抽出・仮説生成・論文執筆） |
 | `GH_PERSONAL_ACCESS_TOKEN` | リポジトリ・実験・出版系ツール使用時 | GitHub APIアクセス（`repo` + `workflow` スコープ） |
 
 認証情報が未設定のままツールを呼ぶと、このファイルを案内するエラーが返ります。
+
+### OpenAI互換エンドポイント（理究）
+
+理研R-CCSの理究APIはOpenAI互換で、認証情報は1つだけです：
+
+```json
+{
+  "RIKYU_API_KEY": "..."
+}
+```
+
+モデル名は `rikyu/<model>` の形式で指定します。`<model>` はエンドポイント自身が返すモデルIDです：
+
+```bash
+curl -H "Authorization: Bearer $RIKYU_API_KEY" \
+  https://api.rikyu.r-ccs.riken.jp/v1/models
+```
+
+base URLは `https://api.rikyu.r-ccs.riken.jp/v1` がデフォルトです。別のホストを指す場合は、認証情報ファイルに `RIKYU_API_BASE` を手動で追加してください。他のOpenAI互換エンドポイントも同様に、固有のプロバイダー名とキーを与えて追加します（`backend/src/airas/infra/llm_provider_resolver.py` の `OPENAI_COMPATIBLE_ENDPOINTS` に1エントリ）。こうすることで、キー名から接続先と課金先が常に辿れます。
+
+同じキーでコーディングエージェントからも利用できます。ローカルの [opencode](https://opencode.ai) から使う場合は、`~/.config/opencode/opencode.json` にカスタムプロバイダーとして宣言します（実験リポジトリ側には同等の設定が `.opencode/opencode.jsonc` に含まれており、ワークフローがリポジトリシークレットからキーを渡します）：
+
+```json
+{
+  "provider": {
+    "rikyu": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Rikyu (RIKEN R-CCS)",
+      "options": {
+        "baseURL": "https://api.rikyu.r-ccs.riken.jp/v1",
+        "apiKey": "{env:RIKYU_API_KEY}"
+      },
+      "models": {
+        "kimi-k3": { "name": "Kimi K3" }
+      }
+    }
+  }
+}
+```
+
+選択したいモデルIDごとに `models` へ1エントリを追加し、`opencode run --model rikyu/<model>` で実行します（ノード内LLMと同じ名前です）。コーディングエージェント用途ではエンドポイント側がツールコールに対応している必要があります（vLLMの場合はツールコールパーサーの有効化が必要）。対応していないモデルでも、ノード内LLMとしては利用できます。
 
 ### 2. サーバーの登録（Claude Code）
 

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -51,7 +51,7 @@ curl -H "Authorization: Bearer $RIKYU_API_KEY" \
   https://api.rikyu.r-ccs.riken.jp/v1/models
 ```
 
-base URLは `https://api.rikyu.r-ccs.riken.jp/v1` がデフォルトです。別のホストを指す場合は、認証情報ファイルに `RIKYU_API_BASE` を手動で追加してください。他のOpenAI互換エンドポイントも同様に、固有のプロバイダー名とキーを与えて追加します（`backend/src/airas/infra/llm_provider_resolver.py` の `OPENAI_COMPATIBLE_ENDPOINTS` に1エントリ）。こうすることで、キー名から接続先と課金先が常に辿れます。
+base URLは `https://api.rikyu.r-ccs.riken.jp/v1` がデフォルトです。別のホストを指す場合は、認証情報ファイルに `RIKYU_API_BASE` を手動で追加してください。将来別のOpenAI互換エンドポイントを追加する場合も同様に、固有のプロバイダー名とキーを与えます（`backend/src/airas/infra/llm_provider_resolver.py` の `RIKYU_*` の配線を参照）。こうすることで、キー名から接続先と課金先が常に辿れます。
 
 同じキーでコーディングエージェントからも利用できます。ローカルの [opencode](https://opencode.ai) から使う場合は、`~/.config/opencode/opencode.json` にカスタムプロバイダーとして宣言します（実験リポジトリ側には同等の設定が `.opencode/opencode.jsonc` に含まれており、ワークフローがリポジトリシークレットからキーを渡します）：
 

--- a/frontend/src/components/pages/settings/api-keys.tsx
+++ b/frontend/src/components/pages/settings/api-keys.tsx
@@ -34,6 +34,7 @@ const CATEGORIES: { key: string; names: string[] }[] = [
       "GEMINI_API_KEY",
       "OPENROUTER_API_KEY",
       "VERCEL_AI_GATEWAY_API_KEY",
+      "RIKYU_API_KEY",
       "AWS_BEARER_TOKEN_BEDROCK",
     ],
   },


### PR DESCRIPTION
## 背景と目的

理研 R-CCS の理究 LLM API（OpenAI 互換、キーは課題ごとに発行・課金）を研究サイクルから利用できるようにします。ノード内 LLM（LiteLLM 経由の仮説生成・分析など）とコーディングエージェント（opencode）の両層で同じモデル名 `rikyu/<model>` を通すことが目標ですが、AIRAS 側にはプロバイダ定義・認証情報・シークレット伝搬の配管が存在しないため、本 PR で追加します。

命名は理究固有（`RIKYU_API_KEY`）とします。汎用の `OPENAI_COMPATIBLE_*` にすると env ペアが実質シングルトンとなり 2 つ目の互換エンドポイントと衝突するうえ、キー名から接続先・課金先が辿れなくなるためです。

親Issue・関連PR:
- https://github.com/airas-org/airas/issues/969
- https://github.com/airas-org/airas-template/pull/22
  - 実験リポジトリ側の対応（`.opencode/opencode.jsonc` の `rikyu` プロバイダ定義・ワークフローへのキー注入）。本 PR とペアで機能します

## 変更内容

以下の機能が変更されました：
1. `rikyu` プロバイダの追加: `rikyu/<model>` を litellm の OpenAI 互換ルート（`hosted_vllm/`）へ書き換えて理究の base URL に接続
2. 認証情報の配管: `RIKYU_API_KEY` を credentials・ダッシュボード・実験リポジトリの Actions Secrets 同期に追加
3. `get_available_llms` の対応: 理究のモデル一覧は litellm カタログでは列挙できないため、明示エラーでエンドポイント自身の `GET /models` を案内
4. ドキュメント整備: 認証情報の設定方法とローカル opencode のプロバイダ設定例を追記（EN + JA）

実装の詳細は以下の通りです：

<details>
<summary><code>1. rikyu プロバイダの追加（litellm へのルーティング）</code></summary>

**実装概要**

- `backend/src/airas/core/types/llm_provider.py`: `LLMProvider.RIKYU = "rikyu"` を追加
- `backend/src/airas/infra/llm_provider_resolver.py`:
  - ルーティング定数を追加: `RIKYU_KEY_ENV` / `RIKYU_BASE_URL_ENV` / `RIKYU_DEFAULT_BASE_URL`（`https://api.rikyu.r-ccs.riken.jp/v1`）
    - base URL はデフォルトを持つため、設定が必要なのはキーのみ。`RIKYU_API_BASE` で上書き可能
    - インスタンスが 1 つのため抽象化（endpoint テーブル）は導入せず、2 つ目の互換エンドポイントが現れた時点でテーブル化する方針をコメントに明記
  - `_MODEL_PREFIX_TO_PROVIDER` に `rikyu/` プレフィックスを追加（ベンダー規則より先にマッチ）
- `backend/src/airas/infra/litellm_client.py`:
  - `_resolve_call_target()` を追加: litellm が知らない `rikyu/<model>` を `hosted_vllm/<model>` + 明示 `api_base` に書き換え、`generate` / `structured_output` / `embedding` の全経路で使用
    - `openai/` ルートは不採用。キー未指定時に `OPENAI_API_KEY` へ暗黙フォールバックし、別ベンダーのキーを理究に送ってしまうため
    - キーはリゾルバ → env（`RIKYU_API_KEY`）の順でフォールバックし、キーレスの自己ホスト構成でも動作
  - `PROVIDER_REQUIRED_ENV_VARS` に `RIKYU: ["RIKYU_API_KEY"]` を追加

</details>

<details>
<summary><code>2. 認証情報の配管とシークレット伝搬</code></summary>

**実装概要**

- `backend/src/airas/core/credentials.py`: `CREDENTIAL_SPECS` に `RIKYU_API_KEY` を追加（`~/.airas/credentials.json` とダッシュボード設定画面から管理可能に）
- `backend/src/airas/usecases/github/push_code_subgraph/push_code_subgraph.py` / `set_github_actions_secrets_subgraph.py`: `secret_names` に `RIKYU_API_KEY` を追加
  - 実験リポジトリの Actions Secrets に同期され、ランナー上の opencode が同じキーを読める
- `frontend/src/components/pages/settings/api-keys.tsx`: 設定画面の LLM カテゴリに `RIKYU_API_KEY` を追加
- `.env.example`: `RIKYU_API_KEY` と使い方（`rikyu/<model>` 形式）を追記

</details>

<details>
<summary><code>3. get_available_llms のモデル一覧対応</code></summary>

**実装概要**

- `backend/src/airas/mcp/server.py`:
  - `_LITELLM_PROVIDER_NAME` に `RIKYU: "hosted_vllm"` を追加
  - `get_available_llms(include_models=true)` で `rikyu` の場合は `models_error` を返すように変更
    - litellm カタログには `hosted_vllm` の実体エントリがなく、空リストを返すと「設定済みだが使えるモデルなし」と誤読させるため、明示エラーでエンドポイント自身の `GET <base URL>/models`（`Authorization: Bearer $RIKYU_API_KEY`）と `rikyu/<model ID>` 形式を案内

</details>

<details>
<summary><code>4. テストとドキュメント</code></summary>

**実装概要**

- `backend/tests/unit/test_litellm_client_openai_compatible.py`（新規）:
  - ベンダーモデルが無変更で通ること、`rikyu/<model>` がデフォルト base URL へ書き換わること、`RIKYU_API_BASE` による上書き、env キーへのフォールバックを検証
- `backend/tests/unit/test_llm_provider_resolver.py`:
  - `rikyu/` プレフィックス解決と、キー名がルーティング定数・可用性チェック・キー解決の間でドリフトしないことの整合性テストを追加
- `docs/development/MCP.mdx` / `docs/ja/development/MCP.mdx`:
  - 認証情報の設定、モデル ID の確認方法（`GET /v1/models`）、ローカル opencode のカスタムプロバイダ設定例を追記

</details>

## 動作確認

- `pytest tests/unit` パス、`ruff check` / `mypy` クリーン
- 実エンドポイントでの検証（`GET /v1/models` によるモデル ID 確認・ツールコール可否・サブグラフ 1 周）は未実施です
  - キーは課題ごとに発行されリポジトリに置けないため、キー入手後に親 Issue のチェックボックスとして手動実施します
  - docs・airas-template 側の `kimi-k3` という ID は Issue 時点の想定値であり、実 ID が異なる場合は各 1 行の修正で追従できます
