### PR TITLE
feat: register bionemo-recipes in the bioinformatics library index

### DIFF
--- a/backend/src/airas/resources/libraries/science/bioinformatics.py
+++ b/backend/src/airas/resources/libraries/science/bioinformatics.py
@@ -39,4 +39,13 @@ BIOINFORMATICS_LIBRARIES: dict[str, dict[str, str | None]] = {
         "llms_txt": None,
         "llms_full_txt": None,
     },
+    "bionemo-recipes": {
+        "description": "TransformerEngine-optimized checkpoints and FSDP training recipes for biomolecular models (protein, single-cell, genome); works with HF Accelerate, PyTorch Lightning, and vanilla PyTorch. Note: the PyPI package `bionemo` is an unrelated deprecated service client",
+        "domain": "science",
+        "category": "bioinformatics",
+        "official_docs": "https://nvidia-bionemo.github.io/bionemo-recipes/",
+        "github": "https://github.com/NVIDIA-BioNeMo/bionemo-recipes",
+        "llms_txt": None,
+        "llms_full_txt": None,
+    },
 }


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

- Closes #973
- Adds one entry, `bionemo-recipes`, to `BIOINFORMATICS_LIBRARIES` in `backend/src/airas/resources/libraries/science/bioinformatics.py`. No other files change — `library_docs.py` and the `get_library_docs` MCP tool pick up entries in existing categories automatically.

The entry is keyed on the current upstream name rather than the old `bionemo-framework`: that repository was moved and renamed, and upstream now ships model checkpoints and training recipes instead of a batteries-included framework. `official_docs` points at `https://nvidia-bionemo.github.io/bionemo-recipes/`, which the repository declares as its homepage, rather than the `docs.nvidia.com/bionemo-framework/` snapshot that predates the rename and whose version banner redirects in a loop. The description notes that the PyPI package `bionemo` is an unrelated deprecated service client, since the seven-field entry has nowhere else to record an install caveat.

Verification:

- `LIBRARY_DOCS` imports cleanly (168 libraries, so the global-uniqueness `ValueError` did not fire) and `get_library_docs(library="bionemo-recipes")` returns the entry; it also appears under the `domain="science"` / `category="bioinformatics"` filters.
- `ruff check` and `ruff format --check` pass on the changed file.
- `backend/scripts/check_library_docs_urls.py` could not be run meaningfully here — this environment's egress policy returns 403 for nearly every host in the registry, including `github.com`, so the pre-existing entries fail too. The GitHub repo URL was confirmed reachable through an allowed path; the docs URL is the homepage that repo declares. Please let the `check_library_docs_urls` workflow be the real check on this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSEFTt1GYAJiRjwNpn13Ys)_