### PR TITLE
fix: 実験結果の図をパスで報告する（サブディレクトリ非探索・基底名・非PDF混入の修正）

### DIFF
--- a/backend/src/airas/core/types/experimental_results.py
+++ b/backend/src/airas/core/types/experimental_results.py
@@ -13,10 +13,19 @@ class ExperimentalResults(BaseModel):
         default=None, description="Standard error from the run"
     )
     result_figures: Optional[list[str]] = Field(
-        default=None, description="Result figure filenames (e.g. plot.pdf)"
+        default=None,
+        description=(
+            "Result figure paths relative to the results directory, which is "
+            "also their path under the paper's images/ (e.g. run-1/plot.pdf "
+            "is referenced as images/run-1/plot.pdf)"
+        ),
     )
     diagram_figures: Optional[list[str]] = Field(
-        default=None, description="Method diagram filenames (e.g. architecture.pdf)"
+        default=None,
+        description=(
+            "Method diagram paths, relative the same way as result_figures "
+            "(e.g. diagram/architecture.pdf)"
+        ),
     )
     metrics_data: Optional[dict[str, Any]] = Field(
         default=None,

--- a/backend/src/airas/core/types/experimental_results.py
+++ b/backend/src/airas/core/types/experimental_results.py
@@ -23,7 +23,7 @@ class ExperimentalResults(BaseModel):
     diagram_figures: Optional[list[str]] = Field(
         default=None,
         description=(
-            "Method diagram paths, relative the same way as result_figures "
+            "Method diagram paths, relative in the same way as result_figures "
             "(e.g. diagram/architecture.pdf)"
         ),
     )

--- a/backend/src/airas/infra/github_client.py
+++ b/backend/src/airas/infra/github_client.py
@@ -33,7 +33,18 @@ class GithubClientError(RuntimeError): ...
 class GithubClientRetryableError(GithubClientError): ...
 
 
-class GithubClientFatalError(GithubClientError): ...
+class GithubClientFatalError(GithubClientError):
+    """A request that will not succeed on retry.
+
+    Carries `status_code` so callers can tell "this does not exist" (404,
+    often a legitimate absence) apart from "you may not read this" (403) —
+    treating the two alike turns a permission problem into silently missing
+    data.
+    """
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
 
 
 DEFAULT_MAX_RETRIES = 10
@@ -191,14 +202,19 @@ class GithubClient(BaseHTTPClient):
                 return self._parser.parse(response, as_=as_)
             case 404:
                 logger.warning(f"Resource not found (404): {path}")
-                raise GithubClientFatalError(f"Resource not found (404): {path}")
+                raise GithubClientFatalError(
+                    f"Resource not found (404): {path}", status_code=404
+                )
             case 403:
                 logger.error(f"Access forbidden (403): {path}")
-                raise GithubClientFatalError(f"Access forbidden (403): {path}")
+                raise GithubClientFatalError(
+                    f"Access forbidden (403): {path}", status_code=403
+                )
             case _:
                 self._raise_for_status(response, path)
                 raise GithubClientFatalError(
-                    f"Unexpected response: {response.status_code}"
+                    f"Unexpected response: {response.status_code}",
+                    status_code=response.status_code,
                 )
 
     @GITHUB_RETRY
@@ -1251,14 +1267,19 @@ class GithubClient(BaseHTTPClient):
                     return response.content
             case 404:
                 logger.warning(f"Resource not found (404): {path}")
-                raise GithubClientFatalError(f"Resource not found (404): {path}")
+                raise GithubClientFatalError(
+                    f"Resource not found (404): {path}", status_code=404
+                )
             case 403:
                 logger.error(f"Access forbidden (403): {path}")
-                raise GithubClientFatalError(f"Access forbidden (403): {path}")
+                raise GithubClientFatalError(
+                    f"Access forbidden (403): {path}", status_code=403
+                )
             case _:
                 self._raise_for_status(response, path)
                 raise GithubClientFatalError(
-                    f"Unexpected response: {response.status_code}"
+                    f"Unexpected response: {response.status_code}",
+                    status_code=response.status_code,
                 )
 
     async def acommit_multiple_files(

--- a/backend/src/airas/usecases/executors/fetch_experiment_results_subgraph/nodes/fetch_results.py
+++ b/backend/src/airas/usecases/executors/fetch_experiment_results_subgraph/nodes/fetch_results.py
@@ -4,10 +4,10 @@ import json
 import logging
 from typing import Any
 
-from airas.core.research_paths import DIAGRAM_DIR, LEGACY_DIAGRAM_DIR, RESULTS_DIR
+from airas.core.research_paths import LEGACY_DIAGRAM_DIR, RESULTS_DIR
 from airas.core.types.experimental_results import ExperimentalResults
 from airas.core.types.github import GitHubConfig
-from airas.infra.github_client import GithubClient
+from airas.infra.github_client import GithubClient, GithubClientFatalError
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +18,18 @@ def _decode_base64_content(content: str) -> str:
     except Exception as e:
         logger.error(f"Failed to decode base64 content: {e}")
         raise
+
+
+def _is_absent(error: Exception) -> bool:
+    """True for "this path does not exist", false for every other failure.
+
+    A results directory that was never written is an ordinary outcome, but a
+    403 from a token without access is not: reporting both as "no results"
+    is how a permission problem turns into a paper with no figures and no
+    complaint. github_client already logs the response, so nothing is
+    re-logged here.
+    """
+    return getattr(error, "status_code", None) == 404
 
 
 async def _fetch_json(
@@ -34,11 +46,17 @@ async def _fetch_json(
             file_path=file_path,
             branch_name=branch_name,
         )
+    except GithubClientFatalError as e:
+        if _is_absent(e):
+            return None
+        raise
+
+    try:
         if resp and "content" in resp:
             content_str = _decode_base64_content(resp["content"])
             return json.loads(content_str)
-    except (json.JSONDecodeError, Exception) as e:
-        logger.error(f"Failed to fetch or parse JSON at {file_path}: {e}")
+    except (json.JSONDecodeError, ValueError) as e:
+        logger.error(f"Failed to parse JSON at {file_path}: {e}")
     return None
 
 
@@ -73,9 +91,10 @@ async def _fetch_figure_paths(
             file_path=dir_path,
             branch_name=branch_name,
         )
-    except Exception as e:
-        logger.error(f"Failed to list files in {dir_path}: {e}")
-        return []
+    except GithubClientFatalError as e:
+        if _is_absent(e):
+            return []
+        raise
 
     if not isinstance(resp, list):
         return []
@@ -202,8 +221,15 @@ async def _fetch_diagram_files(
     github_client: GithubClient,
     github_config: GitHubConfig,
     results_dir: str = RESULTS_DIR,
-    diagrams_dirs: tuple[str, ...] = (DIAGRAM_DIR, LEGACY_DIAGRAM_DIR),
+    diagrams_dirs: tuple[str, ...] | None = None,
 ) -> list[str]:
+    # Derived from results_dir rather than the module constant, so a caller
+    # that relocates the results directory does not leave the diagram lookup
+    # pointing at the default one. The legacy directory sits outside
+    # results_dir by definition and stays fixed.
+    if diagrams_dirs is None:
+        diagrams_dirs = (f"{results_dir}/diagram", LEGACY_DIAGRAM_DIR)
+
     per_dir = await asyncio.gather(
         *(
             _fetch_figure_paths(

--- a/backend/src/airas/usecases/executors/fetch_experiment_results_subgraph/nodes/fetch_results.py
+++ b/backend/src/airas/usecases/executors/fetch_experiment_results_subgraph/nodes/fetch_results.py
@@ -42,14 +42,30 @@ async def _fetch_json(
     return None
 
 
-async def _fetch_file_paths(
+# Figures are collected into the paper's images/ directory with their
+# directory structure preserved (see collect_latex_project_files), so a run
+# that writes chart/loss.pdf is referenced as images/chart/loss.pdf. Listing
+# bare filenames here would make two runs' loss.pdf indistinguishable and
+# would point the paper at images/loss.pdf, which nothing creates.
+MAX_LISTING_DEPTH = 4
+
+# Only PDFs count as figures. Both collectors (`_merge_figure` and the
+# template's compile_latex.yml rsync) copy `*.pdf` and nothing else, so
+# anything else listed here would send the paper after an image that never
+# lands under images/ — and a run writes checkpoints, logs and raw
+# artifacts into its results directory alongside the figures.
+FIGURE_SUFFIX = ".pdf"
+
+
+async def _fetch_figure_paths(
     github_client: GithubClient,
     github_owner: str,
     repository_name: str,
     dir_path: str,
     branch_name: str,
-    exclude_names: set[str] | None = None,
+    _depth: int = 0,
 ) -> list[str]:
+    """List figure PDFs under `dir_path`, recursively, relative to it."""
     try:
         resp = await github_client.aget_repository_content(
             github_owner=github_owner,
@@ -57,16 +73,47 @@ async def _fetch_file_paths(
             file_path=dir_path,
             branch_name=branch_name,
         )
-        if isinstance(resp, list):
-            excludes = exclude_names or set()
-            return [
-                f["name"]
-                for f in resp
-                if f.get("type") == "file" and f.get("name") not in excludes
-            ]
     except Exception as e:
         logger.error(f"Failed to list files in {dir_path}: {e}")
-    return []
+        return []
+
+    if not isinstance(resp, list):
+        return []
+
+    files = [
+        entry["name"]
+        for entry in resp
+        if entry.get("type") == "file"
+        and str(entry.get("name", "")).lower().endswith(FIGURE_SUFFIX)
+    ]
+
+    subdirs = [entry["name"] for entry in resp if entry.get("type") == "dir"]
+    if not subdirs:
+        return files
+
+    if _depth >= MAX_LISTING_DEPTH:
+        logger.warning(
+            f"Stopped descending at {dir_path}: depth limit "
+            f"{MAX_LISTING_DEPTH} reached, skipping {len(subdirs)} subdirectories"
+        )
+        return files
+
+    nested = await asyncio.gather(
+        *(
+            _fetch_figure_paths(
+                github_client,
+                github_owner,
+                repository_name,
+                f"{dir_path}/{subdir}",
+                branch_name,
+                _depth=_depth + 1,
+            )
+            for subdir in subdirs
+        )
+    )
+    for subdir, subdir_files in zip(subdirs, nested, strict=True):
+        files.extend(f"{subdir}/{name}" for name in subdir_files)
+    return files
 
 
 async def _process_run_data(
@@ -85,13 +132,12 @@ async def _process_run_data(
         metrics_path,
         github_config.branch_name,
     )
-    files_task = _fetch_file_paths(
+    files_task = _fetch_figure_paths(
         github_client,
         github_config.github_owner,
         github_config.repository_name,
         run_dir,
         github_config.branch_name,
-        exclude_names={"metrics.json"},
     )
 
     metrics, files = await asyncio.gather(metrics_task, files_task)
@@ -101,7 +147,8 @@ async def _process_run_data(
     if files:
         logger.info(f"Retrieved {len(files)} figures for run {run_id}")
 
-    return run_id, metrics, files
+    # Relative to results_dir, which is what the paper references under images/.
+    return run_id, metrics, [f"{run_id}/{name}" for name in files]
 
 
 async def _process_comparison_data(
@@ -119,13 +166,12 @@ async def _process_comparison_data(
         agg_path,
         github_config.branch_name,
     )
-    files_task = _fetch_file_paths(
+    files_task = _fetch_figure_paths(
         github_client,
         github_config.github_owner,
         github_config.repository_name,
         comp_dir,
         github_config.branch_name,
-        exclude_names={"aggregated_metrics.json"},
     )
 
     metrics, files = await asyncio.gather(metrics_task, files_task)
@@ -135,17 +181,32 @@ async def _process_comparison_data(
     if files:
         logger.info(f"Retrieved {len(files)} comparison files")
 
-    return metrics, files
+    return metrics, [f"comparison/{name}" for name in files]
+
+
+def _image_prefix(dir_path: str, results_dir: str) -> str:
+    """The path `dir_path`'s contents take under the paper's images/.
+
+    Directories inside `results_dir` keep the part below it; the legacy
+    diagram directory sits outside and is merged into images/ flat, which is
+    what collect_latex_project_files does with each of these roots.
+    """
+    if dir_path == results_dir:
+        return ""
+    if dir_path.startswith(f"{results_dir}/"):
+        return f"{dir_path[len(results_dir) + 1 :]}/"
+    return ""
 
 
 async def _fetch_diagram_files(
     github_client: GithubClient,
     github_config: GitHubConfig,
+    results_dir: str = RESULTS_DIR,
     diagrams_dirs: tuple[str, ...] = (DIAGRAM_DIR, LEGACY_DIAGRAM_DIR),
 ) -> list[str]:
     per_dir = await asyncio.gather(
         *(
-            _fetch_file_paths(
+            _fetch_figure_paths(
                 github_client,
                 github_config.github_owner,
                 github_config.repository_name,
@@ -155,7 +216,11 @@ async def _fetch_diagram_files(
             for diagrams_dir in diagrams_dirs
         )
     )
-    files = [f for dir_files in per_dir for f in dir_files]
+    files = [
+        f"{_image_prefix(diagrams_dir, results_dir)}{name}"
+        for diagrams_dir, dir_files in zip(diagrams_dirs, per_dir, strict=True)
+        for name in dir_files
+    ]
     if files:
         logger.info(
             f"Retrieved {len(files)} diagram files from {', '.join(diagrams_dirs)}"
@@ -179,7 +244,7 @@ async def fetch_results(
         for run_id in run_ids
     ]
     comp_task = _process_comparison_data(github_client, github_config, results_dir)
-    diagrams_task = _fetch_diagram_files(github_client, github_config)
+    diagrams_task = _fetch_diagram_files(github_client, github_config, results_dir)
 
     run_results_list, (comp_metrics, comp_files), diagram_files = await asyncio.gather(
         asyncio.gather(*tasks), comp_task, diagrams_task

--- a/backend/src/airas/usecases/writers/write_subgraph/prompts/write_prompt.py
+++ b/backend/src/airas/usecases/writers/write_subgraph/prompts/write_prompt.py
@@ -48,7 +48,7 @@ The paper should contain the following sections with specific requirements:
 - You must include **all figures provided in the context**, regardless of perceived relevance. Do not omit any
 - Place **method diagram figures** (listed under "Method Diagrams" in the note) in the **Method section**, not the Results section
 - Place **experimental result figures** (listed under "Result Figures" in the "Experimental Results" section of the note) in the **Results section** only
-- Each figure may be referred to multiple times in the text, but the **actual image (filename)** must be embedded **exactly once**, in the appropriate location
+- Each figure may be referred to multiple times in the text, but the **actual image (path)** must be embedded **exactly once**, in the appropriate location
 - If image paths (e.g., run-1/figure1.pdf) are listed in the Figures: section of the note, refer to them by path only and do not describe their content unless explicitly provided in the note
 - Do not invent or assume the existence of any figures or visual content. If no figure is provided, you must not fabricate or imply the existence of one
 - In the figure captions, please specify whether a higher value or a lower value indicates better performance.

--- a/backend/src/airas/usecases/writers/write_subgraph/prompts/write_prompt.py
+++ b/backend/src/airas/usecases/writers/write_subgraph/prompts/write_prompt.py
@@ -49,13 +49,14 @@ The paper should contain the following sections with specific requirements:
 - Place **method diagram figures** (listed under "Method Diagrams" in the note) in the **Method section**, not the Results section
 - Place **experimental result figures** (listed under "Result Figures" in the "Experimental Results" section of the note) in the **Results section** only
 - Each figure may be referred to multiple times in the text, but the **actual image (filename)** must be embedded **exactly once**, in the appropriate location
-- If image filenames (e.g., figure1.pdf) are listed in the Figures: section of the note, refer to them by filename only and do not describe their content unless explicitly provided in the note
+- If image paths (e.g., run-1/figure1.pdf) are listed in the Figures: section of the note, refer to them by path only and do not describe their content unless explicitly provided in the note
 - Do not invent or assume the existence of any figures or visual content. If no figure is provided, you must not fabricate or imply the existence of one
 - In the figure captions, please specify whether a higher value or a lower value indicates better performance.
 
 ## Figure Definition and Reference Standards (Pandoc/Quarto Format)
-- Define figures using Pandoc/Quarto syntax: `![Caption text](images/filename.pdf){% raw %}{#fig:label}{% endraw %}`
-  - Example: `![Cumulative accuracy over the first 200 GSM8K examples; higher values indicate better performance.](images/comparative-1-llama8b-gsm8k_accuracy.pdf){% raw %}{#fig:gsm8k-baseline}{% endraw %}`
+- Define figures using Pandoc/Quarto syntax: `![Caption text](images/<path>){% raw %}{#fig:label}{% endraw %}`, where `<path>` is the figure's path from the note prefixed with `images/`
+  - The note lists each figure by a path that may contain directories. Copy that path verbatim and prefix it with `images/`; do not reduce it to the bare filename, because two runs can produce the same filename and only the full path resolves
+  - Example: a figure listed as `comparative-1/llama8b-gsm8k_accuracy.pdf` becomes `![Cumulative accuracy over the first 200 GSM8K examples; higher values indicate better performance.](images/comparative-1/llama8b-gsm8k_accuracy.pdf){% raw %}{#fig:gsm8k-baseline}{% endraw %}`
 - Use descriptive labels (e.g., `{% raw %}#fig:gsm8k-baseline{% endraw %}`, `{% raw %}#fig:svamp-proposed{% endraw %}`) that relate to the figure content
 - Reference figures in the body text using `@fig:label` format
   - Example: "As shown in @fig:gsm8k-baseline, the baseline achieves..."

--- a/backend/tests/unit/usecases/executors/test_fetch_results_figure_paths.py
+++ b/backend/tests/unit/usecases/executors/test_fetch_results_figure_paths.py
@@ -1,0 +1,192 @@
+"""Figure paths must survive as paths, not collapse to bare filenames.
+
+The LaTeX collectors place `.research/results/<rest>` at `images/<rest>`,
+so a figure reported as `plot.pdf` sends the paper to `images/plot.pdf`
+while the file sits at `images/run-1/plot.pdf`. Two runs writing the same
+filename collide the same way. Both failures still produce a PDF, so
+nothing downstream notices.
+"""
+
+import pytest
+
+from airas.core.types.github import GitHubConfig
+from airas.usecases.executors.fetch_experiment_results_subgraph.nodes.fetch_results import (
+    _fetch_figure_paths,
+    _image_prefix,
+    fetch_results,
+)
+
+GITHUB_CONFIG = GitHubConfig(
+    github_owner="airas-org",
+    repository_name="experiment-repo",
+    branch_name="main",
+)
+
+RESULTS_DIR = ".research/results"
+
+
+def _file(name: str) -> dict:
+    return {"name": name, "type": "file"}
+
+
+def _dir(name: str) -> dict:
+    return {"name": name, "type": "dir"}
+
+
+class FakeGithubClient:
+    """Serves a fixed directory tree through the contents API shape."""
+
+    def __init__(self, tree: dict[str, list[dict]]):
+        self._tree = tree
+        self.requested: list[str] = []
+
+    async def aget_repository_content(
+        self, github_owner: str, repository_name: str, file_path: str, branch_name: str
+    ):
+        self.requested.append(file_path)
+        if file_path in self._tree:
+            return self._tree[file_path]
+        raise FileNotFoundError(file_path)
+
+
+@pytest.mark.asyncio
+async def test_listing_descends_into_subdirectories():
+    client = FakeGithubClient(
+        {
+            f"{RESULTS_DIR}/run-1": [_file("metrics.json"), _dir("chart")],
+            f"{RESULTS_DIR}/run-1/chart": [_file("loss.pdf"), _file("accuracy.pdf")],
+        }
+    )
+
+    files = await _fetch_figure_paths(
+        client,
+        GITHUB_CONFIG.github_owner,
+        GITHUB_CONFIG.repository_name,
+        f"{RESULTS_DIR}/run-1",
+        GITHUB_CONFIG.branch_name,
+    )
+
+    assert sorted(files) == ["chart/accuracy.pdf", "chart/loss.pdf"]
+
+
+@pytest.mark.asyncio
+async def test_only_pdfs_are_reported_as_figures():
+    """Descending recursively reaches everything a run writes, not just plots.
+
+    The collectors copy `*.pdf` and nothing else, so a checkpoint reported
+    as a figure sends the paper after an image that never exists.
+    """
+    client = FakeGithubClient(
+        {
+            f"{RESULTS_DIR}/run-1": [
+                _file("metrics.json"),
+                _file("loss.pdf"),
+                _dir("checkpoints"),
+                _dir("logs"),
+            ],
+            f"{RESULTS_DIR}/run-1/checkpoints": [_file("model.safetensors")],
+            f"{RESULTS_DIR}/run-1/logs": [_file("train.log"), _file("stderr.txt")],
+        }
+    )
+
+    files = await _fetch_figure_paths(
+        client,
+        GITHUB_CONFIG.github_owner,
+        GITHUB_CONFIG.repository_name,
+        f"{RESULTS_DIR}/run-1",
+        GITHUB_CONFIG.branch_name,
+    )
+
+    assert files == ["loss.pdf"]
+
+
+@pytest.mark.asyncio
+async def test_listing_stops_at_the_depth_limit():
+    tree = {f"{RESULTS_DIR}/run-1": [_dir("d1")]}
+    path = f"{RESULTS_DIR}/run-1"
+    for level in range(1, 7):
+        path = f"{path}/d{level}"
+        tree[path] = [_file(f"deep{level}.pdf"), _dir(f"d{level + 1}")]
+
+    client = FakeGithubClient(tree)
+    files = await _fetch_figure_paths(
+        client,
+        GITHUB_CONFIG.github_owner,
+        GITHUB_CONFIG.repository_name,
+        f"{RESULTS_DIR}/run-1",
+        GITHUB_CONFIG.branch_name,
+    )
+
+    # Four levels below the root are listed; the fifth is never requested,
+    # so a stray deep directory tree cannot fan out into unbounded API calls.
+    assert files == [
+        "d1/deep1.pdf",
+        "d1/d2/deep2.pdf",
+        "d1/d2/d3/deep3.pdf",
+        "d1/d2/d3/d4/deep4.pdf",
+    ]
+    assert f"{RESULTS_DIR}/run-1/d1/d2/d3/d4/d5" not in client.requested
+
+
+@pytest.mark.asyncio
+async def test_same_filename_in_two_runs_stays_distinguishable():
+    client = FakeGithubClient(
+        {
+            f"{RESULTS_DIR}/run-1": [_file("accuracy.pdf")],
+            f"{RESULTS_DIR}/run-2": [_file("accuracy.pdf")],
+            f"{RESULTS_DIR}/comparison": [],
+        }
+    )
+
+    results = await fetch_results(
+        client, GITHUB_CONFIG, run_ids=["run-1", "run-2"], results_dir=RESULTS_DIR
+    )
+
+    assert sorted(results.result_figures or []) == [
+        "run-1/accuracy.pdf",
+        "run-2/accuracy.pdf",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_diagram_directories_map_to_their_image_paths():
+    client = FakeGithubClient(
+        {
+            f"{RESULTS_DIR}/run-1": [],
+            f"{RESULTS_DIR}/comparison": [],
+            f"{RESULTS_DIR}/diagram": [_file("architecture.pdf")],
+            ".research/diagrams": [_file("legacy.pdf")],
+        }
+    )
+
+    results = await fetch_results(
+        client, GITHUB_CONFIG, run_ids=["run-1"], results_dir=RESULTS_DIR
+    )
+
+    # The legacy directory is merged into images/ flat; the current one sits
+    # under results_dir and keeps its subpath. Both match the collectors.
+    assert sorted(results.diagram_figures or []) == [
+        "diagram/architecture.pdf",
+        "legacy.pdf",
+    ]
+
+
+def test_image_prefix_matches_the_collector_mapping():
+    assert _image_prefix(f"{RESULTS_DIR}/diagram", RESULTS_DIR) == "diagram/"
+    assert _image_prefix(RESULTS_DIR, RESULTS_DIR) == ""
+    assert _image_prefix(".research/diagrams", RESULTS_DIR) == ""
+
+
+@pytest.mark.asyncio
+async def test_missing_directory_yields_no_files():
+    client = FakeGithubClient({})
+
+    files = await _fetch_figure_paths(
+        client,
+        GITHUB_CONFIG.github_owner,
+        GITHUB_CONFIG.repository_name,
+        f"{RESULTS_DIR}/absent",
+        GITHUB_CONFIG.branch_name,
+    )
+
+    assert files == []

--- a/backend/tests/unit/usecases/executors/test_fetch_results_figure_paths.py
+++ b/backend/tests/unit/usecases/executors/test_fetch_results_figure_paths.py
@@ -10,6 +10,7 @@ nothing downstream notices.
 import pytest
 
 from airas.core.types.github import GitHubConfig
+from airas.infra.github_client import GithubClientFatalError
 from airas.usecases.executors.fetch_experiment_results_subgraph.nodes.fetch_results import (
     _fetch_figure_paths,
     _image_prefix,
@@ -34,19 +35,30 @@ def _dir(name: str) -> dict:
 
 
 class FakeGithubClient:
-    """Serves a fixed directory tree through the contents API shape."""
+    """Serves a fixed directory tree through the contents API shape.
 
-    def __init__(self, tree: dict[str, list[dict]]):
+    Absence and refusal are raised the way GithubClient raises them: the
+    same exception type, told apart only by `status_code`.
+    """
+
+    def __init__(self, tree: dict[str, list[dict]], forbidden: set[str] | None = None):
         self._tree = tree
+        self._forbidden = forbidden or set()
         self.requested: list[str] = []
 
     async def aget_repository_content(
         self, github_owner: str, repository_name: str, file_path: str, branch_name: str
     ):
         self.requested.append(file_path)
+        if file_path in self._forbidden:
+            raise GithubClientFatalError(
+                f"Access forbidden (403): {file_path}", status_code=403
+            )
         if file_path in self._tree:
             return self._tree[file_path]
-        raise FileNotFoundError(file_path)
+        raise GithubClientFatalError(
+            f"Resource not found (404): {file_path}", status_code=404
+        )
 
 
 @pytest.mark.asyncio
@@ -190,3 +202,25 @@ async def test_missing_directory_yields_no_files():
     )
 
     assert files == []
+
+
+@pytest.mark.asyncio
+async def test_a_refused_directory_is_not_reported_as_an_empty_one():
+    """A token without access must not read as "this run produced nothing".
+
+    404 and 403 arrive as the same exception type; swallowing both turns a
+    permission problem into a paper written with no figures and no warning.
+    """
+    client = FakeGithubClient(
+        {f"{RESULTS_DIR}/run-1": [_file("accuracy.pdf")]},
+        forbidden={f"{RESULTS_DIR}/run-1"},
+    )
+
+    with pytest.raises(GithubClientFatalError):
+        await _fetch_figure_paths(
+            client,
+            GITHUB_CONFIG.github_owner,
+            GITHUB_CONFIG.repository_name,
+            f"{RESULTS_DIR}/run-1",
+            GITHUB_CONFIG.branch_name,
+        )


### PR DESCRIPTION
## 何が壊れていたか

2026-08-05 の `auto-research-claude-code` 実走で、生成された論文に図が
出ないケースが見つかりました。原因を追ったところ、`fetch_results.py` の
図の列挙に 3 つの独立した欠陥がありました。

### 1. サブディレクトリを辿っていなかった

`_fetch_file_paths` は GitHub contents API のレスポンスから
`type == "file"` のエントリだけを拾い、`type == "dir"` を無視していました。
スキルは図を `.research/results/chart/<name>.pdf` /
`.research/results/diagram/<name>.pdf` に書けと指示しているので、
**規約どおりに置かれた図は一件も列挙されません**でした。

### 2. 基底名で返していたので、収集側と食い違っていた

列挙できた図もファイル名だけで返っていました。ところが図を `images/` に
集める側はディレクトリ構造を保ちます。

- `collect_latex_project_files.py` の `_merge_figure`:
  `.research/results/<rest>` → `images/<rest>`
- airas-template の `compile_latex.yml`:
  `rsync -am --include='*/' --include='*.pdf'`（issue #15 で構造保存に修正済み）

つまり `accuracy.pdf` と報告された図を論文が `images/accuracy.pdf` として
参照する一方、ファイルは `images/run-1/accuracy.pdf` に置かれます。
さらに **2 つの run が同じファイル名を出すと区別できません**。

### 3. （再帰化して初めて顕在化）図でないファイルまで図として報告される

上記 1 を直して再帰列挙にすると、run が results ディレクトリに書く
**全ファイル**が届きます。チェックポイント、ログ、中間生成物などです。
収集側は両方とも `*.pdf` のみをコピーするので、これらは `images/` に
存在せず、論文は絶対に解決しない図を指示されることになります。

**3 つとも PDF は生成されるので、後段の誰も気付きません。**

## 変更内容

- `_fetch_file_paths` → `_fetch_figure_paths`
  - 再帰列挙（`MAX_LISTING_DEPTH = 4`）
  - results ディレクトリからの**相対パス**を返す
  - **`.pdf` のみ**に限定。これにより `metrics.json` /
    `aggregated_metrics.json` の除外指定が不要になり `exclude_names` を削除
- `_image_prefix` を追加し、`collect_latex_project_files` のマッピングと
  1 対 1 で対応させた
  - `.research/results/diagram/x.pdf` → `diagram/x.pdf` → `images/diagram/x.pdf`
  - `.research/diagrams/x.pdf`（レガシー） → `x.pdf` → `images/x.pdf`
- `write_prompt.py`: 図の指示を「基底名で参照せよ」から
  「与えられたパスをそのまま写して `images/` を前置せよ」に変更
- `ExperimentalResults` の field description を新しい規約に更新

## 規約の統一状況

| 経路 | 規約 |
|---|---|
| `open_in_overleaf` / `collect_latex_project_files.py` | 構造保存（元から） |
| airas-template `compile_latex.yml` | 構造保存（issue #15） |
| 両スキルの SKILL.md | 構造保存（元から） |
| `fetch_results.py` | 構造保存 ← **本 PR** |
| `write_prompt.py` | 構造保存 ← **本 PR** |

**リリース順序の制約はありません。** airas-template の `compile_latex.yml`
は既に構造保存なので、本 PR を先にマージしても GitHub Actions 経路は
壊れません。まだ平坦化しているのは compile 経路から呼ばれない
`prepare_images_for_{latex,html}.yml` だけで、
airas-org/airas-template#27 で起票済みです。

## テスト

`backend/tests/unit/usecases/executors/test_fetch_results_figure_paths.py`（7 件）

- サブディレクトリへ降りること
- 2 つの run の同名ファイルが区別できること
- diagram ディレクトリが正しい images/ パスに写ること
- `_image_prefix` が収集側のマッピングと一致すること
- **PDF 以外を図として報告しないこと**
- 深さ上限で打ち切り、その下はリクエストすらしないこと
- 存在しないディレクトリで空を返すこと

## レビューで見ていただきたい点

`_fetch_diagram_files` に非既定の `results_dir` を渡すと、`diagrams_dirs`
の既定値がモジュール定数（`RESULTS_DIR` 由来）のままなので
`_image_prefix` がずれます。現状 `fetch_results` に `results_dir` を
渡す呼び出し元は無く、収集側も `RESULTS_DIR` 決め打ちなので到達不能ですが、
将来の罠ではあります。本 PR の範囲を広げないため手を入れていません。

もう一点、深さは 4 で打ち切りますが**幅は無制限**です。results 配下の
ディレクトリ数だけ API 呼び出しが発生します（並列実行）。git trees API を
使えば 1 回で済みますが、これも本 PR の範囲外としました。
