### PR TITLE
fix: never let an extra paper identifier produce a worse full-text result

### DIFF
--- a/backend/src/airas/dashboard/api/routes/v1/papers.py
+++ b/backend/src/airas/dashboard/api/routes/v1/papers.py
@@ -170,6 +170,7 @@ async def fetch_paper_fulltext(
                 "arxiv_id": request.arxiv_id,
                 "doi": request.doi,
                 "pdf_url": request.pdf_url,
+                "max_chars": request.max_chars,
             }
         )
     )
@@ -177,6 +178,8 @@ async def fetch_paper_fulltext(
         text=result["text"],
         status=result["status"],
         resolved_from=result["resolved_from"],
+        total_chars=result["total_chars"],
+        truncated=result["truncated"],
         execution_time=result["execution_time"],
     )
 

--- a/backend/src/airas/dashboard/api/schemas/papers.py
+++ b/backend/src/airas/dashboard/api/schemas/papers.py
@@ -70,16 +70,23 @@ class SearchPapersResponseBody(BaseModel):
 
 
 class FetchPaperFulltextRequestBody(BaseModel):
-    # Exactly one identifier is enough; they are tried in this order.
+    # One identifier is enough. They are tried arxiv_id, pdf_url, doi, and
+    # supplying both a doi and a pdf_url is worthwhile: the pdf_url is the
+    # fallback when the doi resolves to no open-access PDF.
     arxiv_id: str | None = None
     doi: str | None = None
     pdf_url: str | None = None
+    # Uncapped by default, unlike the MCP tool: that cap exists to protect a
+    # model's context window, and nothing here is feeding one.
+    max_chars: int | None = None
 
 
 class FetchPaperFulltextResponseBody(BaseModel):
     text: str
     status: Literal["fulltext", "abstract_only", "not_found"]
     resolved_from: str | None
+    total_chars: int
+    truncated: bool
     execution_time: dict[str, list[float]]
 
 

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -471,14 +471,26 @@ async def fetch_paper_fulltext(
     arxiv_id: str | None = None,
     doi: str | None = None,
     pdf_url: str | None = None,
+    max_chars: int | None = 40000,
 ) -> dict[str, Any]:
     """Fetch the full text of a paper by arXiv ID, DOI, or direct PDF URL.
 
-    Provide one identifier (tried in that order). arXiv IDs are fetched from
-    arXiv; DOIs are resolved to an open-access PDF via Semantic Scholar.
+    Identifiers are tried in the order arXiv ID, then PDF URL, then DOI, and
+    passing several is useful rather than wasteful: arXiv IDs are fetched
+    straight from arXiv, DOIs are resolved to an open-access PDF through
+    Semantic Scholar, and a DOI that resolves to nothing falls back to the
+    `pdf_url` you supplied. Pass both whenever `search_papers` gave you both
+    — a DOI alone returns only the abstract for any paper Semantic Scholar's
+    open-access index does not cover, bioRxiv among them.
+
     Returns the extracted text with `status`: "fulltext", "abstract_only"
-    (no legal open-access PDF found, abstract returned instead), or
-    "not_found". No API keys required.
+    (no open-access PDF found, abstract returned instead), or "not_found".
+
+    A paper can run to 80k+ characters, so the text is capped at `max_chars`
+    (default 40000) and `total_chars` reports the full length with
+    `truncated` saying whether anything was cut. Raise the cap deliberately;
+    reading a few uncapped papers is enough to exhaust a context window.
+    No API keys required.
     """
     if not (arxiv_id or doi or pdf_url):
         raise ValueError("One of arxiv_id, doi, or pdf_url must be provided.")
@@ -488,12 +500,21 @@ async def fetch_paper_fulltext(
             semantic_scholar_client=_semantic_scholar_client(),
         )
         .build_graph()
-        .ainvoke({"arxiv_id": arxiv_id, "doi": doi, "pdf_url": pdf_url})
+        .ainvoke(
+            {
+                "arxiv_id": arxiv_id,
+                "doi": doi,
+                "pdf_url": pdf_url,
+                "max_chars": max_chars,
+            }
+        )
     )
     return {
         "text": result["text"],
         "status": result["status"],
         "resolved_from": result["resolved_from"],
+        "total_chars": result["total_chars"],
+        "truncated": result["truncated"],
     }
 
 

--- a/backend/src/airas/usecases/retrieve/fetch_paper_fulltext_subgraph/fetch_paper_fulltext_subgraph.py
+++ b/backend/src/airas/usecases/retrieve/fetch_paper_fulltext_subgraph/fetch_paper_fulltext_subgraph.py
@@ -21,16 +21,32 @@ record_execution_time = lambda f: time_node(subgraph_name)(f)  # noqa: E731
 FulltextStatus = Literal["fulltext", "abstract_only", "not_found"]
 
 
+def _truncate(text: str, max_chars: Optional[int]) -> dict:
+    """Cap `text`, reporting the full length so the caller can page on."""
+    total_chars = len(text)
+    if max_chars is None or max_chars <= 0 or total_chars <= max_chars:
+        return {"text": text, "total_chars": total_chars, "truncated": False}
+    logger.info(f"Truncating extracted text from {total_chars} to {max_chars} chars")
+    return {
+        "text": text[:max_chars],
+        "total_chars": total_chars,
+        "truncated": True,
+    }
+
+
 class FetchPaperFulltextSubgraphInputState(TypedDict):
     arxiv_id: Optional[str]
     doi: Optional[str]
     pdf_url: Optional[str]
+    max_chars: Optional[int]
 
 
 class FetchPaperFulltextSubgraphOutputState(ExecutionTimeState):
     text: str
     status: FulltextStatus
     resolved_from: Optional[str]
+    total_chars: int
+    truncated: bool
 
 
 class FetchPaperFulltextSubgraphState(
@@ -47,6 +63,12 @@ class FetchPaperFulltextSubgraph:
     via Semantic Scholar by DOI. When no PDF can be fetched, the abstract
     (when the DOI lookup provided one) is returned with status
     `abstract_only`, or `not_found` when nothing is available.
+
+    A DOI that Semantic Scholar cannot resolve to an open-access PDF falls
+    back to an explicitly supplied `pdf_url` before giving up on the
+    abstract: sources such as bioRxiv host their own PDF and are absent from
+    Semantic Scholar's open-access index, so the same paper that returns
+    `abstract_only` by DOI returns full text by URL.
     """
 
     def __init__(self, semantic_scholar_client: SemanticScholarClient):
@@ -105,19 +127,43 @@ class FetchPaperFulltextSubgraph:
         self, state: FetchPaperFulltextSubgraphState
     ) -> dict:
         resolved_pdf_url = state.get("resolved_pdf_url")
+        supplied_pdf_url = (state.get("pdf_url") or "").strip()
 
-        if resolved_pdf_url:
-            text = await download_pdf_text(resolved_pdf_url)
+        attempts = [(resolved_pdf_url, state.get("resolved_from"))]
+        if supplied_pdf_url and supplied_pdf_url != resolved_pdf_url:
+            attempts.append((supplied_pdf_url, "pdf_url"))
+
+        for candidate_url, resolved_from in attempts:
+            if not candidate_url:
+                continue
+            text = await download_pdf_text(candidate_url)
             if text:
-                return {"text": text, "status": "fulltext"}
+                return self._as_fulltext(text, resolved_from, state)
+            logger.info(f"No text extracted from {candidate_url}")
 
         if fallback_abstract := state.get("fallback_abstract"):
             return {
-                "text": fallback_abstract,
+                **_truncate(fallback_abstract, state.get("max_chars")),
                 "status": "abstract_only",
                 "resolved_from": "semantic_scholar_abstract",
             }
-        return {"text": "", "status": "not_found", "resolved_from": None}
+        return {
+            "text": "",
+            "status": "not_found",
+            "resolved_from": None,
+            "total_chars": 0,
+            "truncated": False,
+        }
+
+    @staticmethod
+    def _as_fulltext(
+        text: str, resolved_from: Optional[str], state: FetchPaperFulltextSubgraphState
+    ) -> dict:
+        return {
+            **_truncate(text, state.get("max_chars")),
+            "status": "fulltext",
+            "resolved_from": resolved_from,
+        }
 
     def build_graph(self):
         graph_builder = StateGraph(

--- a/backend/src/airas/usecases/retrieve/fetch_paper_fulltext_subgraph/fetch_paper_fulltext_subgraph.py
+++ b/backend/src/airas/usecases/retrieve/fetch_paper_fulltext_subgraph/fetch_paper_fulltext_subgraph.py
@@ -49,99 +49,136 @@ class FetchPaperFulltextSubgraphOutputState(ExecutionTimeState):
     truncated: bool
 
 
+# (url, resolved_from) pairs, in the order they should be downloaded.
+PdfCandidates = list[tuple[str, str]]
+
+
 class FetchPaperFulltextSubgraphState(
     FetchPaperFulltextSubgraphInputState, FetchPaperFulltextSubgraphOutputState
 ):
-    resolved_pdf_url: Optional[str]
+    pdf_candidates: PdfCandidates
     fallback_abstract: Optional[str]
+    doi_lookup_done: bool
 
 
 class FetchPaperFulltextSubgraph:
     """Resolve a paper identifier to a PDF, download it, and extract the text.
 
-    Resolution order: arXiv ID → explicit PDF URL → open-access PDF located
-    via Semantic Scholar by DOI. When no PDF can be fetched, the abstract
-    (when the DOI lookup provided one) is returned with status
-    `abstract_only`, or `not_found` when nothing is available.
+    Candidates are tried in order: the arXiv PDF (from an arXiv ID or an
+    arXiv-minted DOI), then an explicitly supplied `pdf_url`, then whatever
+    a Semantic Scholar DOI lookup turns up. The abstract is the last resort
+    (`abstract_only`), and `not_found` means there was nothing at all.
 
-    A DOI that Semantic Scholar cannot resolve to an open-access PDF falls
-    back to an explicitly supplied `pdf_url` before giving up on the
-    abstract: sources such as bioRxiv host their own PDF and are absent from
-    Semantic Scholar's open-access index, so the same paper that returns
-    `abstract_only` by DOI returns full text by URL.
+    **Supplying more identifiers never produces a worse result.** That is not
+    free: the DOI lookup is what provides the abstract to fall back on, and
+    also finds arXiv URLs for papers that only announce them there. So the
+    lookup runs whenever the direct candidates come up empty — even if a
+    `pdf_url` was supplied — rather than being skipped because a URL was
+    already on hand. It stays lazy because Semantic Scholar rate-limits
+    hard, so a request that never needs the fallback never pays for it.
     """
 
     def __init__(self, semantic_scholar_client: SemanticScholarClient):
         self.semantic_scholar_client = semantic_scholar_client
 
+    @staticmethod
+    def _arxiv_pdf_url(arxiv_id: str) -> str:
+        return f"https://arxiv.org/pdf/{arxiv_id.split('v')[0]}"
+
     @record_execution_time
     async def _resolve_pdf_url(self, state: FetchPaperFulltextSubgraphState) -> dict:
+        """Collect the candidates reachable without a network lookup."""
         arxiv_id = (state.get("arxiv_id") or "").strip()
         pdf_url = (state.get("pdf_url") or "").strip()
         doi = (state.get("doi") or "").strip()
 
+        candidates: PdfCandidates = []
         if arxiv_id:
-            bare_id = arxiv_id.split("v")[0]
-            return {
-                "resolved_pdf_url": f"https://arxiv.org/pdf/{bare_id}",
-                "resolved_from": "arxiv",
-            }
-        if pdf_url:
-            return {"resolved_pdf_url": pdf_url, "resolved_from": "pdf_url"}
+            candidates.append((self._arxiv_pdf_url(arxiv_id), "arxiv"))
         # arXiv-minted DOIs (10.48550/arxiv.<id>) map directly to arXiv and
         # are not resolvable through Semantic Scholar.
-        if doi and doi.lower().startswith("10.48550/arxiv."):
-            bare_id = doi[len("10.48550/arxiv.") :].split("v")[0]
-            return {
-                "resolved_pdf_url": f"https://arxiv.org/pdf/{bare_id}",
-                "resolved_from": "arxiv",
-            }
-        if doi:
-            try:
-                paper = await asyncio.to_thread(
-                    self.semantic_scholar_client.get_paper_by_doi, doi
-                )
-            except Exception as e:
-                logger.warning(f"Semantic Scholar DOI lookup failed for {doi}: {e}")
-                return {"resolved_pdf_url": None, "resolved_from": None}
+        if doi.lower().startswith("10.48550/arxiv."):
+            candidates.append(
+                (self._arxiv_pdf_url(doi[len("10.48550/arxiv.") :]), "arxiv")
+            )
+        if pdf_url:
+            candidates.append((pdf_url, "pdf_url"))
 
-            open_access_pdf = (paper.get("openAccessPdf") or {}).get("url")
-            external = paper.get("externalIds") or {}
-            resolved: dict = {"fallback_abstract": paper.get("abstract")}
-            if resolved_arxiv_id := external.get("ArXiv"):
-                resolved["resolved_pdf_url"] = (
-                    f"https://arxiv.org/pdf/{resolved_arxiv_id}"
-                )
-                resolved["resolved_from"] = "arxiv"
-            elif open_access_pdf:
-                resolved["resolved_pdf_url"] = open_access_pdf
-                resolved["resolved_from"] = "open_access_pdf"
-            else:
-                resolved["resolved_pdf_url"] = None
-                resolved["resolved_from"] = None
-            return resolved
-        return {"resolved_pdf_url": None, "resolved_from": None}
+        if candidates:
+            return {"pdf_candidates": candidates, "doi_lookup_done": False}
+
+        # Nothing to try without asking, so ask now rather than in the
+        # download node — there is no download to attempt first.
+        return await self._lookup_doi(doi)
+
+    async def _lookup_doi(self, doi: str) -> dict:
+        """Ask Semantic Scholar for more candidates, and for the abstract."""
+        if not doi:
+            return {"pdf_candidates": [], "doi_lookup_done": True}
+        try:
+            paper = await asyncio.to_thread(
+                self.semantic_scholar_client.get_paper_by_doi, doi
+            )
+        except Exception as e:
+            logger.warning(f"Semantic Scholar DOI lookup failed for {doi}: {e}")
+            return {"pdf_candidates": [], "doi_lookup_done": True}
+
+        candidates: PdfCandidates = []
+        external = paper.get("externalIds") or {}
+        if resolved_arxiv_id := external.get("ArXiv"):
+            candidates.append((self._arxiv_pdf_url(resolved_arxiv_id), "arxiv"))
+        if open_access_pdf := (paper.get("openAccessPdf") or {}).get("url"):
+            candidates.append((open_access_pdf, "open_access_pdf"))
+        return {
+            "pdf_candidates": candidates,
+            "fallback_abstract": paper.get("abstract"),
+            "doi_lookup_done": True,
+        }
+
+    async def _try_candidates(
+        self,
+        candidates: PdfCandidates,
+        already_tried: set[str],
+        state: FetchPaperFulltextSubgraphState,
+    ) -> Optional[dict]:
+        for url, resolved_from in candidates:
+            if not url or url in already_tried:
+                continue
+            already_tried.add(url)
+            text = await download_pdf_text(url)
+            if text:
+                return self._as_fulltext(text, resolved_from, state)
+            logger.info(f"No text extracted from {url}")
+        return None
 
     @record_execution_time
     async def _download_and_extract(
         self, state: FetchPaperFulltextSubgraphState
     ) -> dict:
-        resolved_pdf_url = state.get("resolved_pdf_url")
-        supplied_pdf_url = (state.get("pdf_url") or "").strip()
+        tried: set[str] = set()
+        fallback_abstract = state.get("fallback_abstract")
 
-        attempts = [(resolved_pdf_url, state.get("resolved_from"))]
-        if supplied_pdf_url and supplied_pdf_url != resolved_pdf_url:
-            attempts.append((supplied_pdf_url, "pdf_url"))
+        result = await self._try_candidates(
+            state.get("pdf_candidates") or [], tried, state
+        )
+        if result:
+            return result
 
-        for candidate_url, resolved_from in attempts:
-            if not candidate_url:
-                continue
-            text = await download_pdf_text(candidate_url)
-            if text:
-                return self._as_fulltext(text, resolved_from, state)
-            logger.info(f"No text extracted from {candidate_url}")
+        # The direct candidates are exhausted. A DOI still has two things to
+        # give: URLs that were never announced anywhere else (arXiv mirrors,
+        # open-access copies) and the abstract to fall back on. Skipping this
+        # because a pdf_url happened to be supplied is what made passing more
+        # identifiers produce a worse answer than passing fewer.
+        if not state.get("doi_lookup_done"):
+            looked_up = await self._lookup_doi((state.get("doi") or "").strip())
+            fallback_abstract = looked_up.get("fallback_abstract")
+            result = await self._try_candidates(
+                looked_up["pdf_candidates"], tried, state
+            )
+            if result:
+                return result
 
-        if fallback_abstract := state.get("fallback_abstract"):
+        if fallback_abstract:
             return {
                 **_truncate(fallback_abstract, state.get("max_chars")),
                 "status": "abstract_only",

--- a/backend/tests/unit/usecases/retrieve/test_fetch_paper_fulltext.py
+++ b/backend/tests/unit/usecases/retrieve/test_fetch_paper_fulltext.py
@@ -1,0 +1,117 @@
+"""A DOI that resolves to nothing must still try the PDF URL it was given.
+
+bioRxiv hosts its own PDFs and is absent from Semantic Scholar's
+open-access index, so the same paper returns `abstract_only` by DOI and
+full text by URL. Passing both and getting the abstract is how a paper
+nobody read ends up cited as if it had been.
+
+The length cap is here for the other half of the problem: one paper ran to
+84k characters, which is enough to crowd out the rest of a session.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from airas.usecases.retrieve.fetch_paper_fulltext_subgraph.fetch_paper_fulltext_subgraph import (
+    FetchPaperFulltextSubgraph,
+    _truncate,
+)
+
+DOI_PDF = "https://example.org/oa/paper.pdf"
+SUPPLIED_PDF = "https://www.biorxiv.org/content/10.1101/2024.01.01.000000v1.full.pdf"
+
+_MODULE = (
+    "airas.usecases.retrieve.fetch_paper_fulltext_subgraph"
+    ".fetch_paper_fulltext_subgraph.download_pdf_text"
+)
+
+
+def _subgraph() -> FetchPaperFulltextSubgraph:
+    return FetchPaperFulltextSubgraph(semantic_scholar_client=object())
+
+
+@pytest.mark.asyncio
+async def test_supplied_pdf_url_is_tried_when_the_resolved_one_yields_nothing():
+    state = {
+        "resolved_pdf_url": DOI_PDF,
+        "resolved_from": "open_access_pdf",
+        "pdf_url": SUPPLIED_PDF,
+        "fallback_abstract": "An abstract nobody should settle for.",
+    }
+
+    with patch(_MODULE, new=AsyncMock(side_effect=["", "The full text."])) as download:
+        result = await _subgraph()._download_and_extract(state)
+
+    assert [call.args[0] for call in download.await_args_list] == [
+        DOI_PDF,
+        SUPPLIED_PDF,
+    ]
+    assert result["status"] == "fulltext"
+    assert result["resolved_from"] == "pdf_url"
+    assert result["text"] == "The full text."
+
+
+@pytest.mark.asyncio
+async def test_the_abstract_is_the_last_resort_not_the_second():
+    state = {
+        "resolved_pdf_url": DOI_PDF,
+        "resolved_from": "open_access_pdf",
+        "pdf_url": SUPPLIED_PDF,
+        "fallback_abstract": "An abstract.",
+    }
+
+    with patch(_MODULE, new=AsyncMock(return_value="")):
+        result = await _subgraph()._download_and_extract(state)
+
+    assert result["status"] == "abstract_only"
+    assert result["resolved_from"] == "semantic_scholar_abstract"
+
+
+@pytest.mark.asyncio
+async def test_the_same_url_is_not_downloaded_twice():
+    state = {
+        "resolved_pdf_url": SUPPLIED_PDF,
+        "resolved_from": "pdf_url",
+        "pdf_url": SUPPLIED_PDF,
+    }
+
+    with patch(_MODULE, new=AsyncMock(return_value="")) as download:
+        result = await _subgraph()._download_and_extract(state)
+
+    assert download.await_count == 1
+    assert result["status"] == "not_found"
+    assert result["total_chars"] == 0
+
+
+@pytest.mark.asyncio
+async def test_full_text_is_capped_and_reports_the_full_length():
+    state = {
+        "resolved_pdf_url": DOI_PDF,
+        "resolved_from": "arxiv",
+        "max_chars": 10,
+    }
+
+    with patch(_MODULE, new=AsyncMock(return_value="x" * 84198)):
+        result = await _subgraph()._download_and_extract(state)
+
+    assert result["text"] == "x" * 10
+    assert result["total_chars"] == 84198
+    assert result["truncated"] is True
+
+
+def test_truncation_boundaries():
+    assert _truncate("abcdef", None) == {
+        "text": "abcdef",
+        "total_chars": 6,
+        "truncated": False,
+    }
+    # Exactly at the cap is not truncation.
+    assert _truncate("abcdef", 6)["truncated"] is False
+    assert _truncate("abcdef", 5) == {
+        "text": "abcde",
+        "total_chars": 6,
+        "truncated": True,
+    }
+    # A nonsensical cap is treated as no cap rather than an empty result.
+    assert _truncate("abcdef", 0)["text"] == "abcdef"

--- a/backend/tests/unit/usecases/retrieve/test_fetch_paper_fulltext.py
+++ b/backend/tests/unit/usecases/retrieve/test_fetch_paper_fulltext.py
@@ -1,12 +1,15 @@
-"""A DOI that resolves to nothing must still try the PDF URL it was given.
+"""Supplying more identifiers must never produce a worse answer.
 
-bioRxiv hosts its own PDFs and is absent from Semantic Scholar's
-open-access index, so the same paper returns `abstract_only` by DOI and
-full text by URL. Passing both and getting the abstract is how a paper
-nobody read ends up cited as if it had been.
+That property was broken in both directions. A DOI outside Semantic
+Scholar's open-access index returned `abstract_only` even when the caller
+also held a working `pdf_url` — bioRxiv hosts its own PDFs and is absent
+from that index. And supplying that `pdf_url` alongside the DOI skipped the
+DOI lookup entirely, so a dead URL returned `not_found` where the DOI alone
+would at least have returned the abstract.
 
 The length cap is here for the other half of the problem: one paper ran to
-84k characters, which is enough to crowd out the rest of a session.
+84,198 characters, overshot the MCP token ceiling and was spilled to a file
+instead of returned.
 """
 
 from unittest.mock import AsyncMock, patch
@@ -18,82 +21,183 @@ from airas.usecases.retrieve.fetch_paper_fulltext_subgraph.fetch_paper_fulltext_
     _truncate,
 )
 
-DOI_PDF = "https://example.org/oa/paper.pdf"
+ARXIV_ID = "2210.03629"
+ARXIV_PDF = f"https://arxiv.org/pdf/{ARXIV_ID}"
+DOI = "10.1101/2024.01.01.000000"
+OA_PDF = "https://example.org/oa/paper.pdf"
 SUPPLIED_PDF = "https://www.biorxiv.org/content/10.1101/2024.01.01.000000v1.full.pdf"
+ABSTRACT = "An abstract nobody should settle for."
 
-_MODULE = (
+_DOWNLOAD = (
     "airas.usecases.retrieve.fetch_paper_fulltext_subgraph"
     ".fetch_paper_fulltext_subgraph.download_pdf_text"
 )
 
 
-def _subgraph() -> FetchPaperFulltextSubgraph:
-    return FetchPaperFulltextSubgraph(semantic_scholar_client=object())
+class FakeSemanticScholar:
+    """Returns a fixed record, and counts how often it was asked."""
+
+    def __init__(self, paper: dict | None = None, fails: bool = False):
+        self._paper = paper if paper is not None else {}
+        self._fails = fails
+        self.calls: list[str] = []
+
+    def get_paper_by_doi(self, doi: str) -> dict:
+        self.calls.append(doi)
+        if self._fails:
+            raise RuntimeError("429 Too Many Requests")
+        return self._paper
+
+
+def _paper(arxiv: str | None = None, oa: str | None = None, abstract=ABSTRACT) -> dict:
+    return {
+        "externalIds": {"ArXiv": arxiv} if arxiv else {},
+        "openAccessPdf": {"url": oa} if oa else None,
+        "abstract": abstract,
+    }
+
+
+async def _run(client, downloads, **inputs) -> tuple[dict, list[str]]:
+    """Drive both nodes the way the compiled graph does."""
+    subgraph = FetchPaperFulltextSubgraph(semantic_scholar_client=client)
+    state = {"arxiv_id": None, "doi": None, "pdf_url": None, **inputs}
+    with patch(_DOWNLOAD, new=AsyncMock(side_effect=downloads)) as download:
+        state.update(await subgraph._resolve_pdf_url(state))
+        result = await subgraph._download_and_extract(state)
+    return result, [call.args[0] for call in download.await_args_list]
 
 
 @pytest.mark.asyncio
-async def test_supplied_pdf_url_is_tried_when_the_resolved_one_yields_nothing():
-    state = {
-        "resolved_pdf_url": DOI_PDF,
-        "resolved_from": "open_access_pdf",
-        "pdf_url": SUPPLIED_PDF,
-        "fallback_abstract": "An abstract nobody should settle for.",
-    }
+async def test_a_doi_that_resolves_to_nothing_still_tries_the_supplied_url():
+    client = FakeSemanticScholar(_paper())
 
-    with patch(_MODULE, new=AsyncMock(side_effect=["", "The full text."])) as download:
-        result = await _subgraph()._download_and_extract(state)
+    result, requested = await _run(
+        client, ["The full text."], doi=DOI, pdf_url=SUPPLIED_PDF
+    )
 
-    assert [call.args[0] for call in download.await_args_list] == [
-        DOI_PDF,
-        SUPPLIED_PDF,
-    ]
+    assert requested == [SUPPLIED_PDF]
     assert result["status"] == "fulltext"
     assert result["resolved_from"] == "pdf_url"
-    assert result["text"] == "The full text."
+    # The supplied URL worked, so nothing had to be asked of a rate-limited API.
+    assert client.calls == []
 
 
 @pytest.mark.asyncio
-async def test_the_abstract_is_the_last_resort_not_the_second():
-    state = {
-        "resolved_pdf_url": DOI_PDF,
-        "resolved_from": "open_access_pdf",
-        "pdf_url": SUPPLIED_PDF,
-        "fallback_abstract": "An abstract.",
-    }
+async def test_a_dead_supplied_url_does_not_cost_the_abstract():
+    """The regression that made passing both identifiers worse than one.
 
-    with patch(_MODULE, new=AsyncMock(return_value="")):
-        result = await _subgraph()._download_and_extract(state)
+    The supplied URL short-circuited the DOI lookup, so a URL that returned
+    nothing produced `not_found` — while the DOI alone produced the abstract.
+    """
+    client = FakeSemanticScholar(_paper())
 
+    result, requested = await _run(client, [""], doi=DOI, pdf_url=SUPPLIED_PDF)
+
+    assert requested == [SUPPLIED_PDF]
+    assert client.calls == [DOI]
     assert result["status"] == "abstract_only"
-    assert result["resolved_from"] == "semantic_scholar_abstract"
+    assert result["text"] == ABSTRACT
 
 
 @pytest.mark.asyncio
-async def test_the_same_url_is_not_downloaded_twice():
-    state = {
-        "resolved_pdf_url": SUPPLIED_PDF,
-        "resolved_from": "pdf_url",
-        "pdf_url": SUPPLIED_PDF,
-    }
+async def test_a_dead_supplied_url_falls_through_to_urls_only_the_doi_knows():
+    """An abstract is not good enough if the DOI can still reach full text."""
+    client = FakeSemanticScholar(_paper(arxiv=ARXIV_ID))
 
-    with patch(_MODULE, new=AsyncMock(return_value="")) as download:
-        result = await _subgraph()._download_and_extract(state)
+    result, requested = await _run(
+        client, ["", "The full text."], doi=DOI, pdf_url=SUPPLIED_PDF
+    )
 
-    assert download.await_count == 1
+    assert requested == [SUPPLIED_PDF, ARXIV_PDF]
+    assert result["status"] == "fulltext"
+    assert result["resolved_from"] == "arxiv"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("paper", "downloads", "expected"),
+    [
+        (_paper(arxiv=ARXIV_ID), ["", "text"], "fulltext"),
+        (_paper(oa=OA_PDF), ["", "text"], "fulltext"),
+        (_paper(), [""], "abstract_only"),
+        (_paper(abstract=None), [""], "not_found"),
+    ],
+)
+async def test_adding_a_pdf_url_never_downgrades_the_outcome(
+    paper, downloads, expected
+):
+    """The property, stated directly: extra identifiers only ever help."""
+    doi_only, _ = await _run(FakeSemanticScholar(paper), downloads[1:] or [""], doi=DOI)
+    with_url, _ = await _run(
+        FakeSemanticScholar(paper), downloads, doi=DOI, pdf_url=SUPPLIED_PDF
+    )
+
+    assert doi_only["status"] == expected
+    assert with_url["status"] == expected
+
+
+@pytest.mark.asyncio
+async def test_a_rate_limited_lookup_leaves_the_direct_candidates_intact():
+    """Semantic Scholar 429s constantly; that must not lose a working URL."""
+    client = FakeSemanticScholar(fails=True)
+
+    result, requested = await _run(
+        client, ["The full text."], doi=DOI, pdf_url=SUPPLIED_PDF
+    )
+
+    assert result["status"] == "fulltext"
+    assert requested == [SUPPLIED_PDF]
+
+
+@pytest.mark.asyncio
+async def test_a_rate_limited_lookup_reports_not_found_rather_than_raising():
+    client = FakeSemanticScholar(fails=True)
+
+    result, _ = await _run(client, [""], doi=DOI, pdf_url=SUPPLIED_PDF)
+
     assert result["status"] == "not_found"
-    assert result["total_chars"] == 0
+    assert client.calls == [DOI]
+
+
+@pytest.mark.asyncio
+async def test_the_same_url_is_never_downloaded_twice():
+    client = FakeSemanticScholar(_paper(oa=SUPPLIED_PDF))
+
+    _, requested = await _run(client, ["", ""], doi=DOI, pdf_url=SUPPLIED_PDF)
+
+    assert requested == [SUPPLIED_PDF]
+
+
+@pytest.mark.asyncio
+async def test_an_arxiv_id_is_tried_before_a_supplied_url():
+    client = FakeSemanticScholar(_paper())
+
+    result, requested = await _run(
+        client, ["The full text."], arxiv_id=ARXIV_ID, pdf_url=SUPPLIED_PDF
+    )
+
+    assert requested == [ARXIV_PDF]
+    assert result["resolved_from"] == "arxiv"
+
+
+@pytest.mark.asyncio
+async def test_an_arxiv_minted_doi_needs_no_lookup():
+    client = FakeSemanticScholar(_paper())
+
+    result, requested = await _run(
+        client, ["The full text."], doi=f"10.48550/arXiv.{ARXIV_ID}"
+    )
+
+    assert requested == [ARXIV_PDF]
+    assert result["status"] == "fulltext"
+    assert client.calls == []
 
 
 @pytest.mark.asyncio
 async def test_full_text_is_capped_and_reports_the_full_length():
-    state = {
-        "resolved_pdf_url": DOI_PDF,
-        "resolved_from": "arxiv",
-        "max_chars": 10,
-    }
+    client = FakeSemanticScholar(_paper())
 
-    with patch(_MODULE, new=AsyncMock(return_value="x" * 84198)):
-        result = await _subgraph()._download_and_extract(state)
+    result, _ = await _run(client, ["x" * 84198], arxiv_id=ARXIV_ID, max_chars=10)
 
     assert result["text"] == "x" * 10
     assert result["total_chars"] == 84198

--- a/frontend/src/lib/api/models/ExperimentalResults.ts
+++ b/frontend/src/lib/api/models/ExperimentalResults.ts
@@ -12,11 +12,11 @@ export type ExperimentalResults = {
      */
     stderr?: (string | null);
     /**
-     * Result figure filenames (e.g. plot.pdf)
+     * Result figure paths relative to the results directory, which is also their path under the paper's images/ (e.g. run-1/plot.pdf is referenced as images/run-1/plot.pdf)
      */
     result_figures?: (Array<string> | null);
     /**
-     * Method diagram filenames (e.g. architecture.pdf)
+     * Method diagram paths, relative in the same way as result_figures (e.g. diagram/architecture.pdf)
      */
     diagram_figures?: (Array<string> | null);
     /**

--- a/frontend/src/lib/api/models/FetchPaperFulltextRequestBody.ts
+++ b/frontend/src/lib/api/models/FetchPaperFulltextRequestBody.ts
@@ -6,5 +6,6 @@ export type FetchPaperFulltextRequestBody = {
     arxiv_id?: (string | null);
     doi?: (string | null);
     pdf_url?: (string | null);
+    max_chars?: (number | null);
 };
 

--- a/frontend/src/lib/api/models/FetchPaperFulltextResponseBody.ts
+++ b/frontend/src/lib/api/models/FetchPaperFulltextResponseBody.ts
@@ -6,6 +6,8 @@ export type FetchPaperFulltextResponseBody = {
     text: string;
     status: FetchPaperFulltextResponseBody.status;
     resolved_from: (string | null);
+    total_chars: number;
+    truncated: boolean;
     execution_time: Record<string, Array<number>>;
 };
 export namespace FetchPaperFulltextResponseBody {

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -2555,7 +2555,9 @@ components:
             type: array
           - type: 'null'
           title: Result Figures
-          description: Result figure filenames (e.g. plot.pdf)
+          description: Result figure paths relative to the results directory, which
+            is also their path under the paper's images/ (e.g. run-1/plot.pdf is referenced
+            as images/run-1/plot.pdf)
         diagram_figures:
           anyOf:
           - items:
@@ -2563,7 +2565,8 @@ components:
             type: array
           - type: 'null'
           title: Diagram Figures
-          description: Method diagram filenames (e.g. architecture.pdf)
+          description: Method diagram paths, relative in the same way as result_figures
+            (e.g. diagram/architecture.pdf)
         metrics_data:
           anyOf:
           - additionalProperties: true
@@ -2646,6 +2649,11 @@ components:
           - type: string
           - type: 'null'
           title: Pdf Url
+        max_chars:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Max Chars
       type: object
       title: FetchPaperFulltextRequestBody
     FetchPaperFulltextResponseBody:
@@ -2665,6 +2673,12 @@ components:
           - type: string
           - type: 'null'
           title: Resolved From
+        total_chars:
+          type: integer
+          title: Total Chars
+        truncated:
+          type: boolean
+          title: Truncated
         execution_time:
           additionalProperties:
             items:
@@ -2677,6 +2691,8 @@ components:
       - text
       - status
       - resolved_from
+      - total_chars
+      - truncated
       - execution_time
       title: FetchPaperFulltextResponseBody
     FetchRunIdsRequestBody:


### PR DESCRIPTION
## 背景と目的

`fetch_paper_fulltext` には、無停止運転で論文の中身が静かに失われる問題が 2 つあります。

- **識別子を多く渡すほど結果が悪くなる**
  doi は Semantic Scholar の open-access 解決にしか行かないため、そのインデックスに載っていない論文は `status=abstract_only` になります。bioRxiv がまさにこれで、自前で PDF をホストしているのにインデックスには載っていません。**アブストラクトしか読んでいない論文を、読んだつもりで書き始めます。** 2026-08-05 の `auto-research-claude-code` 実走で PLINDER / Runs N' Poses の 2 本がこれに該当しました。
  - では `search_papers` が同じ行で返す `pdf_url` を併せて渡せばよいかというと、そちらはもっと悪い挙動でした。`_resolve_pdf_url` は `pdf_url` を見た時点で return するため **doi の照会に進まず**、アブストラクトの退避先が確保されません。つまり URL が死んでいると `not_found` になり、**doi 単独なら得られたはずのアブストラクトごと失われます。**
  - スキルは「両方渡せ」と案内しており、その指示と実装が正面から衝突していました。
- **本文の長さを制御できない**
  同じ実走で PLINDER 論文の本文が 84,198 文字あり、MCP のトークン上限を超えて**結果がファイルに退避されました**。つまり長すぎて読みにくいのではなく、ツールの戻り値として機能していません。無停止運転では「論文を数本読む」だけでコンテキストを使い切ります。

加えて、ツールの docstring が識別子の優先順位を実装と逆に説明していました。

## 変更内容

以下の機能が変更されました：

1. PDF の解決を候補リスト方式にし、doi の照会を「候補が尽きたとき」に遅延実行する。照会結果はアブストラクトだけでなく URL 候補としても試行列に戻す
2. `max_chars` による本文の長さ制御と、切られたことを呼び出し側に伝える `total_chars` / `truncated` の追加
3. 識別子の優先順位に関する docstring の訂正

実装の詳細は以下の通りです：

<details>
<summary><code>1. 候補リスト方式への変更と doi の遅延照会</code></summary>

**実装概要**

解決を「単一 URL の決定」から「順に試す候補リスト」に変更しました。

- **`_resolve_pdf_url`**: ネットワークを使わずに得られる候補だけを集めます
  1. `arxiv_id` 由来の arXiv PDF
  2. arXiv 発行 DOI (`10.48550/arxiv.<id>`) 由来の arXiv PDF
  3. 呼び出し側が渡した `pdf_url`
  - 候補が 1 つも無いときだけ、この時点で doi を照会します（試すものが他に無いため）

- **`_lookup_doi`**: Semantic Scholar から**候補とアブストラクトの両方**を取得します
  - `externalIds.ArXiv` があれば arXiv PDF を候補に追加
  - `openAccessPdf` があれば候補に追加
  - `abstract` を退避先として保持

- **`_download_and_extract`**: 候補を順に試し、**尽きた時点で doi を照会**して得られた候補を試行列に加え、それでも駄目ならアブストラクト、最後に `not_found`

- **成立する性質**: **識別子を多く渡して結果が悪くなることはありません。**
  - 照会結果をアブストラクトだけでなく**候補としても試行列に戻す**のが要点です。アブストラクトだけ回収して終わると、doi 単独なら `externalIds.ArXiv` から本文が取れていたケースで `abstract_only` に落ち、逆転の位置がずれるだけになります
  - 照会が遅延なのは Semantic Scholar のレート制限が厳しいためです（実測で並列 5 クエリが 5 本とも 429）。URL が通る要求は照会コストを一切払いません
  - 照会が失敗しても直接候補は失われません
  - 同じ URL は 2 回ダウンロードしません

</details>

<details>
<summary><code>2. max_chars / total_chars / truncated</code></summary>

**実装概要**

`_truncate()` を追加し、本文とアブストラクトの両方に適用しています。

- **State の追加**:
  - 入力 `max_chars: Optional[int]`
  - 出力 `total_chars: int`、`truncated: bool`

- **既定値**:

  | 経路 | 既定 | 理由 |
  |---|---|---|
  | MCP `fetch_paper_fulltext` | `40000` | モデルのコンテキストと MCP のトークン上限を守るため |
  | HTTP `POST /papers/fulltext` | `None`（無制限） | ブラウザに返すだけでコンテキスト制約が無いため |

- **設計の要点は「切ること」ではなく「切ったと分かること」**です。`total_chars` が全長を、`truncated` が切られたかどうかを返すので、呼び出し側は必要なときだけ意図的に上限を上げられます。黙って切れるのが最も危険なため、この 2 つを戻り値に入れています。
  - 既知の限界として、文字数での機械的なカットなので文の途中で切れ、末尾から落ちるため Limitations / Conclusion が失われ得ます。段落境界での分割や先頭 + 末尾の保持は今回の範囲外としました。
  - セクション指定による取得も未実装です。PDF からのセクション抽出が必要で、本 PR の範囲を超えます。

</details>

<details>
<summary><code>3. docstring の訂正</code></summary>

**実装概要**

`fetch_paper_fulltext` の docstring は「1 つの識別子を渡せ（arXiv ID → DOI → PDF URL の順で試す）」と説明していましたが、実装は以前から `arxiv_id` → `pdf_url` → `doi` の順です。

- 実際の優先順位に訂正
- **複数渡すことが無駄ではなく有用である**ことを明記（`doi` と `pdf_url` の両方が得られたら両方渡す）
- `max_chars` を既定のままにし、全文が必要な論文だけ引き上げるよう案内

</details>

4. テスト:
   - `backend/tests/unit/usecases/retrieve/test_fetch_paper_fulltext.py` を新規追加（14 件）
     - **性質そのものの検証**: arXiv ミラー有り / open-access 有り / アブストラクトのみ / 何も無し の 4 ケースで、`pdf_url` を追加しても結果が悪化しないこと
     - 死んだ `pdf_url` がアブストラクトを失わせないこと（今回の逆転の回帰テスト）
     - 死んだ `pdf_url` が、doi しか知らない arXiv URL への到達を妨げないこと
     - `pdf_url` が通るときは Semantic Scholar を一度も叩かないこと
     - 照会が 429 で失敗しても直接候補が生き残ること
     - `arxiv_id` が `pdf_url` より先に試されること、arXiv 発行 DOI は照会不要であること
     - 同一 URL を 2 回ダウンロードしないこと
     - 84,198 文字が上限で切られ、`total_chars` が全長を報告すること
     - 上限ちょうど・`max_chars=0` などの境界値

5. その他:
   - `backend/src/airas/dashboard/api/schemas/papers.py` / `routes/v1/papers.py`: HTTP 側にも同じ引数と戻り値を追加
   - `schema/openapi.yaml` / `frontend/src/lib/api/models/`: pre-commit の自動再生成による更新
     - `ExperimentalResults.ts` の description 更新分は https://github.com/airas-org/airas/pull/977 でマージ済みの変更が再生成に反映されたもので、本 PR の変更ではありません
