### PR TITLE
feat: verify the paper actually builds before publishing it

### DIFF
--- a/backend/src/airas/core/types/latex.py
+++ b/backend/src/airas/core/types/latex.py
@@ -1,8 +1,50 @@
-from typing import Literal
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
 
 from airas.core.types.github import GitHubRepositoryInfo
 
 LATEX_TEMPLATE_NAME = Literal["iclr2024", "agents4science_2025", "mdpi"]
+
+
+class LatexBuildReport(BaseModel):
+    """What a LaTeX build produced, and what is wrong with it.
+
+    The fields below are the failures that still render a PDF, so a build
+    that only checks the exit status calls them a success: a citation that
+    prints as `?`, a figure that never made it into images/, a dangling
+    \\ref. They are reported separately because each has a different fix.
+    """
+
+    ok: bool = Field(
+        description=(
+            "True only if a PDF was produced with no undefined citation, no "
+            "undefined reference, and no missing figure"
+        )
+    )
+    compiled: bool = Field(description="Whether a PDF file was produced at all")
+    page_count: Optional[int] = Field(
+        default=None, description="Pages in the produced PDF"
+    )
+    undefined_citations: list[str] = Field(
+        default_factory=list,
+        description="Citation keys that render as '?' (missing from the .bib)",
+    )
+    undefined_references: list[str] = Field(
+        default_factory=list,
+        description="\\ref/\\label targets that render as '??'",
+    )
+    missing_figures: list[str] = Field(
+        default_factory=list,
+        description="Figure paths the document includes but the project lacks",
+    )
+    errors: list[str] = Field(
+        default_factory=list, description="LaTeX errors, in the order emitted"
+    )
+    log_tail: str = Field(
+        default="", description="Tail of the build log, for diagnosing errors"
+    )
+
 
 # Official LaTeX template repository
 LATEX_TEMPLATE_REPOSITORY_INFO = GitHubRepositoryInfo(

--- a/backend/src/airas/core/types/latex.py
+++ b/backend/src/airas/core/types/latex.py
@@ -19,7 +19,7 @@ class LatexBuildReport(BaseModel):
     ok: bool = Field(
         description=(
             "True only if a PDF was produced with no undefined citation, no "
-            "undefined reference, and no missing figure"
+            "undefined reference, no missing figure, and no LaTeX error"
         )
     )
     compiled: bool = Field(description="Whether a PDF file was produced at all")

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -82,7 +82,7 @@ from airas.infra.openalex_client import OpenAlexClient
 from airas.infra.retry_policy import HTTPClientFatalError, HTTPClientRetryableError
 from airas.infra.semantic_scholar_client import SemanticScholarClient
 from airas.infra.seyval_client import SeyvalClient
-from airas.mcp.prompt_registry import build_generation_prompt, get_input_json_schema
+from airas.mcp.prompt_registry import build_generation_prompt
 from airas.resources.libraries.library_docs import LIBRARY_DOCS
 from airas.usecases.analyzers.analyze_experiment_subgraph.analyze_experiment_subgraph import (
     AnalyzeExperimentLLMMapping,
@@ -358,33 +358,11 @@ def get_generation_prompt(step: str, inputs: dict[str, Any]) -> dict[str, Any]:
       experiment_code, research_study_list, references_bib
     - "latex_conversion": paper_content, figures_dir (optional)
 
-    Returns a fully rendered `prompt`, an `input_json_schema` describing the
-    exact shape of `inputs` for this step, an `output_json_schema` describing
+    Returns a fully rendered `prompt`, an `output_json_schema` describing
     exactly the data format to produce in one pass, and a `flow` note on
-    how the output feeds the next step. Call `get_input_schema` first if you
-    are assembling an input by hand — `research_study_list` entries in
-    particular are `ResearchStudy` objects, not `search_papers` rows, and
-    share no key names with them.
+    how the output feeds the next step.
     """
     return build_generation_prompt(step, inputs)
-
-
-@mcp.tool()
-def get_input_schema(step: str) -> dict[str, Any]:
-    """The JSON Schema of the `inputs` a `get_generation_prompt` step takes.
-
-    Use before assembling an input by hand, so the shape is known up front
-    instead of being discovered through a validation error. The steps are
-    the same as `get_generation_prompt`'s. No API keys required.
-
-    Assembling `research_study_list` from `search_papers` output is the
-    common case and needs a translation: a search row's `authors`,
-    `citations` and `arxiv_id` live under `meta_data` on a `ResearchStudy`,
-    and only `title` is required — a study with just `title` and `abstract`
-    is valid, so nothing has to be invented for papers whose full text was
-    not retrieved.
-    """
-    return get_input_json_schema(step)
 
 
 @mcp.tool()
@@ -846,8 +824,6 @@ async def prepare_repository(
 
     Sets up the repository (from the AIRAS experiment template) and the
     working branch. Run this once before `dispatch_code_generation`.
-    Returns `html_url` and `clone_url` alongside the readiness flags, so the
-    next step — cloning it locally — needs nothing reconstructed by hand.
     Requires GH_PERSONAL_ACCESS_TOKEN.
     """
     config = GitHubConfig(
@@ -866,8 +842,6 @@ async def prepare_repository(
     return {
         "is_repository_ready": result["is_repository_ready"],
         "is_branch_ready": result["is_branch_ready"],
-        "html_url": result["html_url"],
-        "clone_url": result["clone_url"],
     }
 
 
@@ -885,7 +859,6 @@ async def dispatch_experiment(
     inputs_from_runs: list[str] | None = None,
     time_limit: str | None = None,
     resource_count: int | None = None,
-    required_env_vars: list[str] | None = None,
 ) -> dict[str, Any]:
     """Start an experiment run (asynchronous). The code must already be pushed.
 
@@ -905,16 +878,11 @@ async def dispatch_experiment(
       you registered, "byo:<uuid>" from the Seyval MCP server's
       `list_computes`; it defaults to SEYVAL_COMPUTE_ID, and without either the
       run goes to Seyval-managed compute. `compute_type` sets the resource
-      request in both cases (e.g. "cpu-general", "gpu-a10"). Seyval keeps the run's
+      request in both cases (e.g. "cpu-general", "gpu-a10"). The W&B API key
+      must be registered as an env var on the Seyval side. Seyval keeps the run's
       results on its own side, so call `import_run_outputs` once the run
       finishes — before `fetch_experiment_results`, which reads the
       repository.
-
-    `required_env_vars` lists the env vars Seyval must have registered before
-    it will start the run, and defaults to `["WANDB_API_KEY"]`. Seyval
-    rejects the run outright when one is missing, so pass `[]` for an
-    experiment that does not use Weights & Biases rather than registering a
-    dummy key.
 
     `inputs_from_runs`, `time_limit` and `resource_count` apply to "seyval"
     only. `inputs_from_runs` takes `execution_id`s of earlier completed runs
@@ -947,7 +915,6 @@ async def dispatch_experiment(
                 inputs_from_runs=inputs_from_runs,
                 time_limit=time_limit,
                 resource_count=resource_count,
-                required_env_vars=required_env_vars,
             )
             .build_graph()
             .ainvoke(

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -128,6 +128,11 @@ from airas.usecases.publication.generate_latex_subgraph.generate_latex_subgraph 
     GenerateLatexLLMMapping,
     GenerateLatexSubgraph,
 )
+from airas.usecases.publication.nodes.verify_latex_build import verify_latex_build
+from airas.usecases.publication.open_in_overleaf_subgraph.nodes.collect_latex_project_files import (
+    collect_latex_project_files,
+    collect_latex_project_files_local,
+)
 from airas.usecases.retrieve.fetch_paper_fulltext_subgraph.fetch_paper_fulltext_subgraph import (
     FetchPaperFulltextSubgraph,
 )
@@ -487,9 +492,14 @@ async def fetch_paper_fulltext(
     (no open-access PDF found, abstract returned instead), or "not_found".
 
     A paper can run to 80k+ characters, so the text is capped at `max_chars`
-    (default 40000) and `total_chars` reports the full length with
-    `truncated` saying whether anything was cut. Raise the cap deliberately;
-    reading a few uncapped papers is enough to exhaust a context window.
+    — **characters, not tokens**, default 40000 — with `total_chars`
+    reporting the full length and `truncated` saying whether anything was
+    cut. There is no paging: raising the cap re-fetches the paper from the
+    start. Neither MCP nor this server imposes a size limit; the cap exists
+    because reading a few uncapped papers exhausts a context window, and
+    because a client may divert an oversized result to a file. The default
+    assumes English prose at roughly four characters per token — lower it
+    explicitly for CJK text, where a character is closer to a token.
     No API keys required.
     """
     if not (arxiv_id or doi or pdf_url):
@@ -1518,10 +1528,14 @@ async def compile_latex(
     One of the two publication exits after main.tex has been pushed to
     `.research/latex/{template}/` (the other is `open_in_overleaf`; they
     are independent and can both be used).
-    Dispatches the LaTeX compilation workflow for the pushed sources;
-    figure PDFs under `.research/results/` and `.research/diagrams/` are
-    materialized into `images/` at build time. Returns immediately with
-    `paper_url` (when available); track the run with `get_workflow_runs`.
+    Dispatches the LaTeX compilation workflow for the pushed sources.
+    The workflow materializes every PDF under `.research/results/` and
+    `.research/diagrams/` into the template's `images/` with the directory
+    structure preserved, so figures need only be pushed, not pre-staged.
+    Returns as soon as the dispatch is accepted, which is not a
+    compile result — `paper_url` is where the PDF will land if the run
+    succeeds, so track the run with `get_workflow_runs`, and use
+    `verify_latex` to find out whether the document is actually sound.
     `model` (required) is forwarded to the compilation workflow as the
     coding-agent model (`model_name`) — call `get_available_llms` to list
     valid models. Requires GH_PERSONAL_ACCESS_TOKEN.
@@ -1548,6 +1562,63 @@ async def compile_latex(
         "compile_latex_dispatched": result["compile_latex_dispatched"],
         "paper_url": result["paper_url"],
     }
+
+
+@mcp.tool()
+async def verify_latex(
+    github_owner: str = "",
+    repository_name: str = "",
+    branch_name: str = "",
+    latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
+    local_path: str | None = None,
+) -> dict[str, Any]:
+    """Compile the paper locally and report whether it is actually sound.
+
+    Use this before `open_in_overleaf` or `compile_latex` — those produce a
+    link and a dispatch receipt, neither of which tells you the document
+    built. This one builds it and answers the questions that decide whether
+    the paper is publishable: did a PDF come out (`compiled`, `page_count`),
+    do any citations render as `?` (`undefined_citations` — the usual cause
+    is writing main.tex without also writing the generated bibliography to
+    `.research/latex/{template}/references.bib`, whose shipped version is a
+    single placeholder entry), do any `\\ref`s render as `??`
+    (`undefined_references`), and is any figure referenced but absent
+    (`missing_figures`). `ok` is true only when all of those are clean.
+
+    It compiles exactly the file set `open_in_overleaf` would export, so a
+    clean report means the exported project compiles as-is.
+
+    Pass `local_path` — the absolute path of your local clone — to check the
+    working tree with no push and no API keys. Otherwise pass
+    `github_owner`/`repository_name`/`branch_name` to check what was pushed
+    (requires GH_PERSONAL_ACCESS_TOKEN). Requires a local TeX distribution;
+    `pdflatex` must be on PATH.
+    """
+    refresh_environment()
+
+    if local_path:
+        latex_files = await asyncio.to_thread(
+            collect_latex_project_files_local, local_path, latex_template_name
+        )
+    else:
+        if not (github_owner and repository_name and branch_name):
+            raise ValueError(
+                "Provide local_path, or all of github_owner, repository_name "
+                "and branch_name."
+            )
+        latex_files = await asyncio.to_thread(
+            collect_latex_project_files,
+            GitHubConfig(
+                github_owner=github_owner,
+                repository_name=repository_name,
+                branch_name=branch_name,
+            ),
+            latex_template_name,
+            _github_client(),
+        )
+
+    report = await asyncio.to_thread(verify_latex_build, latex_files)
+    return report.model_dump()
 
 
 @mcp.tool()

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -82,7 +82,7 @@ from airas.infra.openalex_client import OpenAlexClient
 from airas.infra.retry_policy import HTTPClientFatalError, HTTPClientRetryableError
 from airas.infra.semantic_scholar_client import SemanticScholarClient
 from airas.infra.seyval_client import SeyvalClient
-from airas.mcp.prompt_registry import build_generation_prompt
+from airas.mcp.prompt_registry import build_generation_prompt, get_input_json_schema
 from airas.resources.libraries.library_docs import LIBRARY_DOCS
 from airas.usecases.analyzers.analyze_experiment_subgraph.analyze_experiment_subgraph import (
     AnalyzeExperimentLLMMapping,
@@ -358,11 +358,33 @@ def get_generation_prompt(step: str, inputs: dict[str, Any]) -> dict[str, Any]:
       experiment_code, research_study_list, references_bib
     - "latex_conversion": paper_content, figures_dir (optional)
 
-    Returns a fully rendered `prompt`, an `output_json_schema` describing
+    Returns a fully rendered `prompt`, an `input_json_schema` describing the
+    exact shape of `inputs` for this step, an `output_json_schema` describing
     exactly the data format to produce in one pass, and a `flow` note on
-    how the output feeds the next step.
+    how the output feeds the next step. Call `get_input_schema` first if you
+    are assembling an input by hand — `research_study_list` entries in
+    particular are `ResearchStudy` objects, not `search_papers` rows, and
+    share no key names with them.
     """
     return build_generation_prompt(step, inputs)
+
+
+@mcp.tool()
+def get_input_schema(step: str) -> dict[str, Any]:
+    """The JSON Schema of the `inputs` a `get_generation_prompt` step takes.
+
+    Use before assembling an input by hand, so the shape is known up front
+    instead of being discovered through a validation error. The steps are
+    the same as `get_generation_prompt`'s. No API keys required.
+
+    Assembling `research_study_list` from `search_papers` output is the
+    common case and needs a translation: a search row's `authors`,
+    `citations` and `arxiv_id` live under `meta_data` on a `ResearchStudy`,
+    and only `title` is required — a study with just `title` and `abstract`
+    is valid, so nothing has to be invented for papers whose full text was
+    not retrieved.
+    """
+    return get_input_json_schema(step)
 
 
 @mcp.tool()
@@ -824,6 +846,8 @@ async def prepare_repository(
 
     Sets up the repository (from the AIRAS experiment template) and the
     working branch. Run this once before `dispatch_code_generation`.
+    Returns `html_url` and `clone_url` alongside the readiness flags, so the
+    next step — cloning it locally — needs nothing reconstructed by hand.
     Requires GH_PERSONAL_ACCESS_TOKEN.
     """
     config = GitHubConfig(
@@ -842,6 +866,8 @@ async def prepare_repository(
     return {
         "is_repository_ready": result["is_repository_ready"],
         "is_branch_ready": result["is_branch_ready"],
+        "html_url": result["html_url"],
+        "clone_url": result["clone_url"],
     }
 
 
@@ -859,6 +885,7 @@ async def dispatch_experiment(
     inputs_from_runs: list[str] | None = None,
     time_limit: str | None = None,
     resource_count: int | None = None,
+    required_env_vars: list[str] | None = None,
 ) -> dict[str, Any]:
     """Start an experiment run (asynchronous). The code must already be pushed.
 
@@ -878,11 +905,16 @@ async def dispatch_experiment(
       you registered, "byo:<uuid>" from the Seyval MCP server's
       `list_computes`; it defaults to SEYVAL_COMPUTE_ID, and without either the
       run goes to Seyval-managed compute. `compute_type` sets the resource
-      request in both cases (e.g. "cpu-general", "gpu-a10"). The W&B API key
-      must be registered as an env var on the Seyval side. Seyval keeps the run's
+      request in both cases (e.g. "cpu-general", "gpu-a10"). Seyval keeps the run's
       results on its own side, so call `import_run_outputs` once the run
       finishes — before `fetch_experiment_results`, which reads the
       repository.
+
+    `required_env_vars` lists the env vars Seyval must have registered before
+    it will start the run, and defaults to `["WANDB_API_KEY"]`. Seyval
+    rejects the run outright when one is missing, so pass `[]` for an
+    experiment that does not use Weights & Biases rather than registering a
+    dummy key.
 
     `inputs_from_runs`, `time_limit` and `resource_count` apply to "seyval"
     only. `inputs_from_runs` takes `execution_id`s of earlier completed runs
@@ -915,6 +947,7 @@ async def dispatch_experiment(
                 inputs_from_runs=inputs_from_runs,
                 time_limit=time_limit,
                 resource_count=resource_count,
+                required_env_vars=required_env_vars,
             )
             .build_graph()
             .ainvoke(
@@ -1583,10 +1616,17 @@ async def verify_latex(
     `.research/latex/{template}/references.bib`, whose shipped version is a
     single placeholder entry), do any `\\ref`s render as `??`
     (`undefined_references`), and is any figure referenced but absent
-    (`missing_figures`). `ok` is true only when all of those are clean.
+    (`missing_figures`). `ok` is true only when all of those are clean and
+    `errors` — the `!` lines from the log, which is where a missing package
+    or a broken environment shows up — is empty too.
 
-    It compiles exactly the file set `open_in_overleaf` would export, so a
-    clean report means the exported project compiles as-is.
+    It compiles exactly the file set `open_in_overleaf` would export, so
+    what is checked is what would be shipped. The toolchain is still the
+    local one — Overleaf builds its own TeX Live image through latexmk — so
+    read the two verdicts differently: `ok=False` is a property of the
+    document and will follow it anywhere, while `ok=True` says this machine
+    built it, not that Overleaf will. A package installed there but not
+    here is the likely way the two disagree.
 
     Pass `local_path` — the absolute path of your local clone — to check the
     working tree with no push and no API keys. Otherwise pass

--- a/backend/src/airas/usecases/publication/compile_latex_subgraph/compile_latex_subgraph.py
+++ b/backend/src/airas/usecases/publication/compile_latex_subgraph/compile_latex_subgraph.py
@@ -76,10 +76,14 @@ class CompileLatexSubgraph:
 
         if success:
             logger.info(f"Workflow {self.workflow_file} dispatched successfully")
+            # compile_latex.yml moves the PDF to .research/<paper_name>.pdf,
+            # not into the template subdirectory it was built in. The URL is
+            # where the file will land if the run succeeds; dispatch only
+            # means the request was accepted, so it can still 404.
             paper_url = (
                 f"https://github.com/{github_config.github_owner}/"
                 f"{github_config.repository_name}/blob/{github_config.branch_name}/"
-                f".research/latex/{self.latex_template_name}/{self.paper_name}.pdf"
+                f".research/{self.paper_name}.pdf"
             )
             return {"compile_latex_dispatched": True, "paper_url": paper_url}
         else:

--- a/backend/src/airas/usecases/publication/nodes/verify_latex_build.py
+++ b/backend/src/airas/usecases/publication/nodes/verify_latex_build.py
@@ -6,8 +6,18 @@ you a link was produced. Neither answers the question that actually matters
 when no human opens the PDF: did it build, are the citations resolved, are
 the figures there.
 
-The input is the same file map the Overleaf export sends, so a clean report
-here means the exported project compiles as-is.
+What this shares with the Overleaf export is its *input*: the same file map
+the export sends, so the thing being checked is the thing being shipped,
+not a rehearsal of it. The *toolchain* is not shared. This runs whatever TeX
+distribution is installed here, through a fixed pdflatex/bibtex/pdflatex
+sequence; Overleaf runs its own TeX Live image through latexmk, and can be
+set to biber or to a different engine entirely.
+
+So the two verdicts are not symmetric. `ok=False` is worth trusting: a
+citation that renders as '?', a figure that renders as a box and a `!` in
+the log are properties of the document, and travel. `ok=True` is not proof
+that Overleaf will build it — a package missing *here* fails here and
+compiles there, which is the likely direction of disagreement.
 """
 
 import logging
@@ -31,6 +41,13 @@ _UNWRAPPED_LOG_ENV = {
     "half_error_line": "238",
 }
 
+# The .tex being compiled comes out of a repository, so it is not trusted
+# input. TeX can read and write arbitrary paths, and this tool hands the log
+# tail back to the caller — `\input{/etc/passwd}` would be enough. Paranoid
+# mode confines reads and writes to the build directory and TEXMF, and shell
+# escape is refused outright rather than left to the distribution's default.
+_SANDBOX_ENV = {"openin_any": "p", "openout_any": "p"}
+
 _PDFLATEX_TIMEOUT_SECONDS = 180.0
 _BIBTEX_TIMEOUT_SECONDS = 60.0
 _LOG_TAIL_CHARS = 4000
@@ -39,6 +56,11 @@ _UNDEFINED_CITATION = re.compile(r"Citation [`'\"]([^`'\"]+)['\"] on page")
 _UNDEFINED_REFERENCE = re.compile(r"Reference [`'\"]([^`'\"]+)['\"] on page")
 _MISSING_FILE = re.compile(r"File [`'\"]([^`'\"]+)['\"] not found")
 _ERROR_LINE = re.compile(r"^! (.+)$", re.MULTILINE)
+
+# Extensions that a "File ... not found" can carry without it being a figure.
+# A missing figure is usually reported with no extension at all, so this has
+# to be a denylist: an allowlist of image formats would discard the real ones.
+_NON_FIGURE_SUFFIXES = {".sty", ".cls", ".bib", ".bst", ".tex", ".def", ".cfg"}
 
 
 class LatexToolchainMissingError(RuntimeError):
@@ -60,7 +82,7 @@ def _write_project(latex_files: dict[str, bytes], build_dir: Path) -> None:
 
 
 def _run(command: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess:
-    env = {**os.environ, **_UNWRAPPED_LOG_ENV}
+    env = {**os.environ, **_UNWRAPPED_LOG_ENV, **_SANDBOX_ENV}
     return subprocess.run(
         command,
         cwd=cwd,
@@ -132,12 +154,22 @@ def verify_latex_build(
             "pdflatex",
             "-interaction=nonstopmode",
             "-halt-on-error=0",
+            "-no-shell-escape",
             main_tex_name,
         ]
 
+        needs_bibtex = _needs_bibtex(main_tex_path.read_text(errors="replace"))
+        if needs_bibtex and shutil.which("bibtex") is None:
+            raise LatexToolchainMissingError(
+                "The document has a bibliography but bibtex was not found on "
+                "PATH. Install it (it ships with texlive-binaries) — without "
+                "it every citation would be reported as undefined whether or "
+                "not the bibliography is sound."
+            )
+
         try:
             _run(pdflatex, build_dir, _PDFLATEX_TIMEOUT_SECONDS)
-            if _needs_bibtex(main_tex_path.read_text(errors="replace")):
+            if needs_bibtex:
                 bibtex_result = _run(
                     ["bibtex", stem], build_dir, _BIBTEX_TIMEOUT_SECONDS
                 )
@@ -153,7 +185,7 @@ def verify_latex_build(
             _run(pdflatex, build_dir, _PDFLATEX_TIMEOUT_SECONDS)
         except subprocess.TimeoutExpired as e:
             raise TimeoutError(
-                f"LaTeX build exceeded {_PDFLATEX_TIMEOUT_SECONDS:.0f}s. The "
+                f"{Path(e.cmd[0]).name} timed out after {e.timeout:.0f}s. The "
                 "document may be stuck on an unclosed environment."
             ) from e
 
@@ -165,15 +197,19 @@ def verify_latex_build(
         compiled = pdf_path.is_file()
         page_count = _page_count(pdf_path) if compiled else None
 
-        # Two kinds of false positive to drop. graphicx probes for a graphic
-        # under several extensions and names one probe with the unexpanded
-        # macro `\Gin@base`, which is not a path anyone can supply. And a
-        # "not found" for a file the project does ship is just that probing.
+        # Three things to drop from the raw "File ... not found" list.
+        # graphicx probes for a graphic under several extensions and names
+        # one probe with the unexpanded macro `\Gin@base`, which is not a
+        # path anyone can supply. A "not found" for a file the project does
+        # ship is that same probing. And a missing package or class is not a
+        # figure — it is already reported through `errors`, where LaTeX
+        # raises it as `! LaTeX Error: File 'foo.sty' not found`.
         project_paths = set(latex_files)
         missing_figures = [
             name
             for name in missing_files
             if "\\" not in name
+            and Path(name).suffix.lower() not in _NON_FIGURE_SUFFIXES
             and name not in project_paths
             and not any(path.startswith(f"{name}.") for path in project_paths)
         ]

--- a/backend/src/airas/usecases/publication/nodes/verify_latex_build.py
+++ b/backend/src/airas/usecases/publication/nodes/verify_latex_build.py
@@ -1,0 +1,201 @@
+"""Compile a collected LaTeX project locally and report what is wrong with it.
+
+This exists because dispatching `compile_latex.yml` only tells you the
+workflow-dispatch request was accepted, and the Overleaf export only tells
+you a link was produced. Neither answers the question that actually matters
+when no human opens the PDF: did it build, are the citations resolved, are
+the figures there.
+
+The input is the same file map the Overleaf export sends, so a clean report
+here means the exported project compiles as-is.
+"""
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from airas.core.types.latex import LatexBuildReport
+
+logger = logging.getLogger(__name__)
+
+# TeX wraps log lines at ~79 characters by default, which splits the very
+# messages parsed below across lines. These are the documented knobs for
+# turning that off; without them the regexes silently under-report.
+_UNWRAPPED_LOG_ENV = {
+    "max_print_line": "10000",
+    "error_line": "254",
+    "half_error_line": "238",
+}
+
+_PDFLATEX_TIMEOUT_SECONDS = 180.0
+_BIBTEX_TIMEOUT_SECONDS = 60.0
+_LOG_TAIL_CHARS = 4000
+
+_UNDEFINED_CITATION = re.compile(r"Citation [`'\"]([^`'\"]+)['\"] on page")
+_UNDEFINED_REFERENCE = re.compile(r"Reference [`'\"]([^`'\"]+)['\"] on page")
+_MISSING_FILE = re.compile(r"File [`'\"]([^`'\"]+)['\"] not found")
+_ERROR_LINE = re.compile(r"^! (.+)$", re.MULTILINE)
+
+
+class LatexToolchainMissingError(RuntimeError):
+    """Raised when pdflatex is not installed on this machine."""
+
+
+def _write_project(latex_files: dict[str, bytes], build_dir: Path) -> None:
+    for relative_path, content in latex_files.items():
+        target = build_dir / relative_path
+        # The collector already rejects escaping paths; re-check because this
+        # writes to disk outside the repository.
+        if not target.resolve().is_relative_to(build_dir.resolve()):
+            logger.warning(
+                f"Skipping path outside the build directory: {relative_path}"
+            )
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
+
+def _run(command: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess:
+    env = {**os.environ, **_UNWRAPPED_LOG_ENV}
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        errors="replace",
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _needs_bibtex(main_tex: str) -> bool:
+    return "\\bibliography{" in main_tex or "\\bibliographystyle{" in main_tex
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))
+
+
+def _parse_log(log: str) -> tuple[list[str], list[str], list[str], list[str]]:
+    citations = _dedupe(_UNDEFINED_CITATION.findall(log))
+    references = _dedupe(_UNDEFINED_REFERENCE.findall(log))
+    # TeX reports a missing graphic by the name it was asked for, which may
+    # omit the extension the driver would have appended.
+    missing_files = _dedupe(_MISSING_FILE.findall(log))
+    errors = _dedupe(match.strip() for match in _ERROR_LINE.findall(log))
+    return citations, references, missing_files, errors
+
+
+def _page_count(pdf_path: Path) -> int | None:
+    try:
+        from pypdf import PdfReader
+
+        return len(PdfReader(str(pdf_path)).pages)
+    except Exception as e:
+        logger.warning(f"Could not read page count from {pdf_path.name}: {e}")
+        return None
+
+
+def verify_latex_build(
+    latex_files: dict[str, bytes],
+    main_tex_name: str = "main.tex",
+) -> LatexBuildReport:
+    """Build `latex_files` in a scratch directory and report the result.
+
+    Runs the same pdflatex/bibtex/pdflatex/pdflatex sequence the CI LaTeX
+    agent uses, so the findings match what that agent would see.
+    """
+    if shutil.which("pdflatex") is None:
+        raise LatexToolchainMissingError(
+            "pdflatex was not found on PATH. Install a TeX distribution "
+            "(e.g. `apt-get install texlive-latex-recommended "
+            "texlive-latex-extra texlive-fonts-recommended texlive-science`) "
+            "to verify the paper locally, or push and use compile_latex."
+        )
+
+    stem = Path(main_tex_name).stem
+
+    with tempfile.TemporaryDirectory(prefix="airas-latex-") as tmp:
+        build_dir = Path(tmp)
+        _write_project(latex_files, build_dir)
+
+        main_tex_path = build_dir / main_tex_name
+        if not main_tex_path.is_file():
+            raise ValueError(f"{main_tex_name} is not present in the collected project")
+
+        pdflatex = [
+            "pdflatex",
+            "-interaction=nonstopmode",
+            "-halt-on-error=0",
+            main_tex_name,
+        ]
+
+        try:
+            _run(pdflatex, build_dir, _PDFLATEX_TIMEOUT_SECONDS)
+            if _needs_bibtex(main_tex_path.read_text(errors="replace")):
+                bibtex_result = _run(
+                    ["bibtex", stem], build_dir, _BIBTEX_TIMEOUT_SECONDS
+                )
+                if bibtex_result.returncode != 0:
+                    logger.info(
+                        f"bibtex exited {bibtex_result.returncode}; "
+                        "continuing so the undefined citations are reported"
+                    )
+            # Two more passes: the first resolves citations and references
+            # from the freshly written .aux/.bbl, the second settles page
+            # numbers those may have shifted.
+            _run(pdflatex, build_dir, _PDFLATEX_TIMEOUT_SECONDS)
+            _run(pdflatex, build_dir, _PDFLATEX_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired as e:
+            raise TimeoutError(
+                f"LaTeX build exceeded {_PDFLATEX_TIMEOUT_SECONDS:.0f}s. The "
+                "document may be stuck on an unclosed environment."
+            ) from e
+
+        log_path = build_dir / f"{stem}.log"
+        log = log_path.read_text(errors="replace") if log_path.is_file() else ""
+        citations, references, missing_files, errors = _parse_log(log)
+
+        pdf_path = build_dir / f"{stem}.pdf"
+        compiled = pdf_path.is_file()
+        page_count = _page_count(pdf_path) if compiled else None
+
+        # Two kinds of false positive to drop. graphicx probes for a graphic
+        # under several extensions and names one probe with the unexpanded
+        # macro `\Gin@base`, which is not a path anyone can supply. And a
+        # "not found" for a file the project does ship is just that probing.
+        project_paths = set(latex_files)
+        missing_figures = [
+            name
+            for name in missing_files
+            if "\\" not in name
+            and name not in project_paths
+            and not any(path.startswith(f"{name}.") for path in project_paths)
+        ]
+
+    report = LatexBuildReport(
+        ok=compiled
+        and not citations
+        and not references
+        and not missing_figures
+        and not errors,
+        compiled=compiled,
+        page_count=page_count,
+        undefined_citations=citations,
+        undefined_references=references,
+        missing_figures=missing_figures,
+        errors=errors,
+        log_tail=log[-_LOG_TAIL_CHARS:],
+    )
+    logger.info(
+        f"LaTeX build: compiled={report.compiled} pages={report.page_count} "
+        f"undefined_citations={len(report.undefined_citations)} "
+        f"missing_figures={len(report.missing_figures)} "
+        f"errors={len(report.errors)}"
+    )
+    return report

--- a/backend/src/airas/usecases/retrieve/fetch_paper_fulltext_subgraph/fetch_paper_fulltext_subgraph.py
+++ b/backend/src/airas/usecases/retrieve/fetch_paper_fulltext_subgraph/fetch_paper_fulltext_subgraph.py
@@ -22,7 +22,18 @@ FulltextStatus = Literal["fulltext", "abstract_only", "not_found"]
 
 
 def _truncate(text: str, max_chars: Optional[int]) -> dict:
-    """Cap `text`, reporting the full length so the caller can page on."""
+    """Cap `text` at `max_chars` characters, reporting what was cut.
+
+    Characters, not tokens. The constraint being protected is a token
+    budget, so this is a proxy calibrated on English prose at roughly four
+    characters per token; CJK text runs closer to one, where the same cap
+    admits several times the tokens it is meant to.
+
+    There is no paging: the discarded tail is only recoverable by asking
+    again with a larger cap, which re-downloads and re-extracts the PDF.
+    `total_chars` and `truncated` are here so the caller knows the tail
+    exists, not so it can fetch it in pieces.
+    """
     total_chars = len(text)
     if max_chars is None or max_chars <= 0 or total_chars <= max_chars:
         return {"text": text, "total_chars": total_chars, "truncated": False}

--- a/backend/tests/unit/usecases/publication/test_verify_latex_build.py
+++ b/backend/tests/unit/usecases/publication/test_verify_latex_build.py
@@ -1,0 +1,139 @@
+"""The failures that still produce a PDF have to be reported as failures.
+
+An undefined citation prints as `?`, an absent figure prints as a box, and
+pdflatex exits happily in both cases. Without these checks a fully
+automated run ships either one without noticing.
+"""
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from airas.usecases.publication.nodes.verify_latex_build import verify_latex_build
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("pdflatex") is None, reason="requires a local TeX distribution"
+)
+
+BIB = b"""
+@article{known2020,
+  author  = {A. Author},
+  title   = {A Known Title},
+  journal = {Journal},
+  year    = {2020}
+}
+"""
+
+
+def _document(body: str) -> bytes:
+    return (
+        "\\documentclass{article}\n"
+        "\\usepackage{graphicx}\n"
+        "\\begin{document}\n"
+        f"{body}\n"
+        "\\bibliographystyle{plain}\n"
+        "\\bibliography{references}\n"
+        "\\end{document}\n"
+    ).encode()
+
+
+@pytest.fixture(scope="module")
+def figure_pdf() -> bytes:
+    """A real one-page PDF, standing in for a rendered chart."""
+    with tempfile.TemporaryDirectory() as tmp:
+        directory = Path(tmp)
+        (directory / "f.tex").write_bytes(
+            b"\\documentclass{article}\\begin{document}figure\\end{document}"
+        )
+        subprocess.run(
+            ["pdflatex", "-interaction=nonstopmode", "f.tex"],
+            cwd=directory,
+            capture_output=True,
+            check=False,
+        )
+        return (directory / "f.pdf").read_bytes()
+
+
+def test_sound_document_is_ok(figure_pdf):
+    report = verify_latex_build(
+        {
+            "main.tex": _document(
+                "Cited \\cite{known2020}.\n"
+                "\\begin{figure}\\includegraphics[width=0.4\\linewidth]"
+                "{images/chart/loss.pdf}\\caption{Loss}\\end{figure}"
+            ),
+            "references.bib": BIB,
+            "images/chart/loss.pdf": figure_pdf,
+        }
+    )
+
+    assert report.ok
+    assert report.compiled
+    assert report.page_count == 1
+    assert report.undefined_citations == []
+    assert report.missing_figures == []
+
+
+def test_citation_absent_from_the_bibliography_is_reported():
+    report = verify_latex_build(
+        {
+            "main.tex": _document("Cited \\cite{never_added}."),
+            "references.bib": BIB,
+        }
+    )
+
+    # This is what shipping the template's placeholder references.bib looks
+    # like: a PDF is produced, and every citation in it reads '?'.
+    assert report.compiled
+    assert not report.ok
+    assert report.undefined_citations == ["never_added"]
+
+
+def test_figure_referenced_but_not_shipped_is_reported():
+    report = verify_latex_build(
+        {
+            "main.tex": _document(
+                "\\begin{figure}\\includegraphics[width=0.4\\linewidth]"
+                "{images/chart/absent.pdf}\\caption{Absent}\\end{figure}"
+            ),
+            "references.bib": BIB,
+        }
+    )
+
+    assert not report.ok
+    assert report.missing_figures == ["images/chart/absent.pdf"]
+
+
+def test_graphicx_extension_probing_is_not_a_missing_figure(figure_pdf):
+    """graphicx names one probe with the raw macro `\\Gin@base`."""
+    report = verify_latex_build(
+        {
+            "main.tex": _document(
+                "\\begin{figure}\\includegraphics[width=0.4\\linewidth]"
+                "{images/chart/absent.pdf}\\caption{Absent}\\end{figure}"
+            ),
+            "references.bib": BIB,
+        }
+    )
+
+    assert all("\\" not in name for name in report.missing_figures)
+
+
+def test_dangling_reference_is_reported():
+    report = verify_latex_build(
+        {
+            "main.tex": _document("See section~\\ref{sec:nowhere}."),
+            "references.bib": BIB,
+        }
+    )
+
+    assert not report.ok
+    assert report.undefined_references == ["sec:nowhere"]
+
+
+def test_missing_main_tex_is_rejected():
+    with pytest.raises(ValueError, match="main.tex"):
+        verify_latex_build({"references.bib": BIB})

--- a/backend/tests/unit/usecases/publication/test_verify_latex_build.py
+++ b/backend/tests/unit/usecases/publication/test_verify_latex_build.py
@@ -14,8 +14,10 @@ import pytest
 
 from airas.usecases.publication.nodes.verify_latex_build import verify_latex_build
 
+# Every document here ends in \bibliography{references}, so bibtex runs too.
 pytestmark = pytest.mark.skipif(
-    shutil.which("pdflatex") is None, reason="requires a local TeX distribution"
+    shutil.which("pdflatex") is None or shutil.which("bibtex") is None,
+    reason="requires a local TeX distribution (pdflatex and bibtex)",
 )
 
 BIB = b"""
@@ -137,3 +139,52 @@ def test_dangling_reference_is_reported():
 def test_missing_main_tex_is_rejected():
     with pytest.raises(ValueError, match="main.tex"):
         verify_latex_build({"references.bib": BIB})
+
+
+def test_the_document_cannot_read_files_outside_the_build_directory(tmp_path):
+    """The .tex comes out of a repository, so it is not trusted input.
+
+    TeX can open any path the process can, and `log_tail` is handed back to
+    the caller — so a document that reads a file and echoes it to the log is
+    an exfiltration primitive. (Reading it into the *page* is not, since the
+    PDF never leaves the build directory; the log is the channel that does.)
+    """
+    secret = tmp_path / "secret.txt"
+    secret.write_text("SUPERSECRETVALUE")
+
+    report = verify_latex_build(
+        {
+            "main.tex": (
+                "\\documentclass{article}\n"
+                "\\newread\\leak\n"
+                f"\\openin\\leak={secret}\n"
+                "\\read\\leak to \\stolen\n"
+                "\\closein\\leak\n"
+                "\\begin{document}\n"
+                "\\typeout{LEAKED: \\stolen}\n"
+                "text\n"
+                "\\end{document}\n"
+            ).encode(),
+        }
+    )
+
+    assert "SUPERSECRETVALUE" not in report.log_tail
+    # The read is refused outright rather than silently returning nothing.
+    assert not report.compiled
+    assert not report.ok
+
+
+def test_a_missing_package_is_an_error_not_a_missing_figure():
+    report = verify_latex_build(
+        {
+            "main.tex": (
+                "\\documentclass{article}\n"
+                "\\usepackage{a-package-that-does-not-exist}\n"
+                "\\begin{document}text\\end{document}\n"
+            ).encode(),
+        }
+    )
+
+    assert report.missing_figures == []
+    assert any("not found" in error for error in report.errors)
+    assert not report.ok


### PR DESCRIPTION
## 背景と目的

論文が実際に成立しているかを、パイプラインの誰も確認していません。

- `compile_latex` は**ワークフローの dispatch が受理された**時点で返ります。ビルド結果ではありません
- `open_in_overleaf` は**リンクが生成された**時点で返ります。中身は見ていません

そして LaTeX の失敗の多くは**エラーになりません**。未定義の引用は `?` として、存在しない図は枠として描画され、`pdflatex` は正常終了します。人が PDF を開く前提なら気付けますが、無停止運転では**誰も気付かないまま「論文ができた」ことになります。**

2026-08-05 の `auto-research-claude-code` 実走では、この確認を手作業で行いました。テンプレート同梱の `references.bib` はプレースホルダ 1 件しか無いため、生成した bib で上書きしなければ全ての `\cite` が `?` になります。つまり**踏みやすい失敗が実際に存在し、しかも自動では検出されません。**

あわせて `compile_latex` の戻り値 `paper_url` が 404 になる問題があります。ワークフローは PDF を `.research/{paper_name}.pdf` に移動しますが、`paper_url` は `.research/latex/{template}/{paper_name}.pdf` を指していました。

## 変更内容

以下の機能が変更されました：

1. `verify_latex` MCP ツールの追加: LaTeX プロジェクトをローカルでコンパイルし、成立しているかを構造化して報告する
2. `LatexBuildReport` 型の追加
3. `compile_latex` の `paper_url` を実際の出力先に修正
4. `fetch_paper_fulltext` の docstring 訂正（https://github.com/airas-org/airas/pull/978 の積み残し）

実装の詳細は以下の通りです：

<details>
<summary><code>1. verify_latex ツールと verify_latex_build</code></summary>

**実装概要**

`backend/src/airas/usecases/publication/nodes/verify_latex_build.py` を新規追加し、`verify_latex` として MCP に公開しました。

- **入力は `open_in_overleaf` と同じファイル集合**です。`collect_latex_project_files` / `collect_latex_project_files_local` を再利用しているため、**検査対象が出荷対象そのもの**になります。事前チェックとして意味を持つのはこの点です
  - ただし**同じなのは入力だけで、ツールチェーンは同じではありません。** Overleaf は自前の TeX Live イメージを `latexmk` で駆動し、biber や別エンジンも選べます。こちらはローカルの TeX を `pdflatex` → `bibtex` → `pdflatex` ×2 の固定手順で回します
  - したがって 2 つの判定は非対称です。**`ok=False` は文書自身の性質**（`?` になる引用、枠になる図、`!` エラー）なのでどこへ行っても再現します。一方 **`ok=True` は Overleaf で通る証明にはなりません** — ローカルに無いパッケージが原因の偽陽性が、乖離としては起きやすい方向です
  - Overleaf は export でありコンパイル結果を読み返せないため、**渡す前にローカルで潰せるものを潰す**のが本ツールの位置づけです
  - `local_path` を渡すとローカルの作業ツリーを検査します（push 不要・GitHub トークン不要）
  - 省略時は push 済みリポジトリを対象にします

- **ビルド手順**は CI の LaTeX エージェントと同じ `pdflatex` → `bibtex` → `pdflatex` ×2 です
  - 2 回目で `.aux` / `.bbl` から引用と参照が解決され、3 回目でページ番号が確定します
  - `bibtex` が非ゼロ終了しても中断しません。未定義の引用を報告することが目的なので、そこで止めると分からなくなります

- **報告内容** (`LatexBuildReport`):

  | フィールド | 内容 |
  |---|---|
  | `ok` | 下記が全て空で、かつ PDF が生成された場合に真 |
  | `compiled` / `page_count` | PDF が出たか、何ページか |
  | `undefined_citations` | `?` になる引用 |
  | `undefined_references` | `??` になる参照 |
  | `missing_figures` | 枠だけになる図 |
  | `errors` | ログ中の `!` 行 |
  | `log_tail` | 末尾 4000 文字 |

</details>

<details>
<summary><code>2. ログ解析とサンドボックス</code></summary>

**実装概要**

素朴に `grep` すると取りこぼす、あるいは誤検出する箇所があります。

- **TeX はログ行を約 79 桁で折り返します。** 解析対象のメッセージ自体が行の途中で分断されるため、正規表現が**黙って取りこぼします**
  - `max_print_line=10000` / `error_line=254` / `half_error_line=238` を環境変数で渡して折り返しを無効化しています
  - 実走時の手作業では `tr -d '\n'` で回避していましたが、こちらが正攻法です

- **`graphicx` は図を複数の拡張子で探索します。** その過程で存在しないファイル名に対する "File ... not found" がログに出ます
  - 探索の 1 つは未展開のマクロ `\Gin@base` を名前として報告します。これは利用者が指定し得ないため、`\` を含む名前を除外しています
  - プロジェクトが実際に同梱しているファイルへの "not found" も探索の副産物なので、同梱ファイル名およびその拡張子違いと一致するものを除外しています
  - この 2 つを除外しないと、正常なプロジェクトでも `missing_figures` が空になりません

- **信頼できない入力としての扱い**: コンパイル対象の `.tex` はリポジトリ由来なので、信頼できる前提を置けません
  - TeX はプロセスが開ける任意のパスを読めます。そして本ツールは `log_tail` を呼び出し側に返すため、**ファイルを読んでログに書き出す文書は情報漏えいの手段になります。** 実際に `\openin` と `\typeout` を使った 6 行の `main.tex` で、ファイルの中身が戻り値のレポートに入ることを確認しました
  - `openin_any` / `openout_any` を paranoid に固定し、読み書きをビルドディレクトリと TEXMF に限定しています。shell escape もディストリビューションの既定に委ねず `-no-shell-escape` で明示的に拒否します
  - ビルドは一時ディレクトリで行い、そこから外に出るパスへの書き込みも拒否します

- **その他の防御**:
  - `pdflatex` 未インストール時は `LatexToolchainMissingError` で明示的に失敗します。検証していないのに検証したつもりになるのを防ぐためです。参考文献を持つ文書では `bibtex` の存在も事前に確認します（無いまま走らせると、健全な参考文献でも全引用が未定義として報告されるため）
  - タイムアウト時は、どのコマンドがどの制限値で止まったかを報告します（環境の閉じ忘れで停止するため）

</details>

<details>
<summary><code>3. compile_latex の paper_url 修正と docstring</code></summary>

**実装概要**

- **`paper_url` の修正**: ワークフローの "Verify and Move compiled PDF" ステップは PDF を `.research/{paper_name}.pdf` に移動します。`.research/latex/{template}/` を含んでいた従来の URL は 404 になっていました
- **docstring の訂正**: 戻り値が dispatch のレシートでありビルド結果ではないこと、図はワークフローが構造保持で配置するので事前配置が不要であること、実際の成否は `verify_latex` で確認することを明記しました

</details>

4. テスト:
   - `backend/tests/unit/usecases/publication/test_verify_latex_build.py` を新規追加（8 件）
     - `pdflatex` / `bibtex` が無い環境ではスキップします
     - 健全な文書が `ok` になること
     - **PDF が出ているのに `ok` が偽になること** — 参考文献に無い引用、同梱されていない図、宙に浮いた `\ref`。いずれも `compiled` は真です
     - `graphicx` の拡張子探索を `missing_figures` に混ぜないこと
     - **パッケージの欠落は `missing_figures` ではなく `errors` として報告されること**
     - **ビルドディレクトリ外のファイルを読み出せないこと**（`\openin` + `\typeout` による漏えい経路）
     - `main.tex` が無ければ拒否すること

5. その他:
   - `backend/src/airas/usecases/retrieve/fetch_paper_fulltext_subgraph/fetch_paper_fulltext_subgraph.py` / `backend/src/airas/mcp/server.py`: `max_chars` の docstring 訂正
     - **文字数でありトークン数ではない**こと。英語の散文で約 4 文字/トークンを想定した較正値であり、CJK では 1 文字が 1 トークンに近いため明示的に下げる必要があること
     - **paging は無い**こと。上限を上げると先頭から取り直しになります。`total_chars` / `truncated` は「切られた分がある」と知らせるためのもので、分割取得のためではありません
     - サイズ上限を持っているのは **MCP 仕様でも本サーバーでもなく MCP クライアント**であること
   - 独立した PR にせず本 PR に含めています
