### PR TITLE
feat: publish the input shapes the generation tools accept

### DIFF
--- a/backend/src/airas/core/types/experimental_design.py
+++ b/backend/src/airas/core/types/experimental_design.py
@@ -100,6 +100,12 @@ class DatasetConfig(BaseModel):
 
 class ComputeEnvironment(BaseModel):
     os: str | None = None
+    # CPU architecture, as `uname -m` reports it (e.g. "x86_64", "aarch64").
+    # This decides whether a dependency has a wheel at all, so an experiment
+    # designed without it can resolve locally and have nothing to install on
+    # the target. Worth stating even when the rest of the environment is not
+    # known.
+    arch: str | None = None
     cpu_cores: int | None = None
     ram_gb: int | None = None
     gpu_type: str | None = None

--- a/backend/src/airas/core/types/research_study.py
+++ b/backend/src/airas/core/types/research_study.py
@@ -47,17 +47,33 @@ class MetaData(BaseModel):
 
 
 class ResearchStudy(BaseModel):
+    """One prior study, as the generation prompts consume it.
+
+    Only `title` is required. The rest default to empty so a study can be
+    assembled by hand from a `search_papers` row — which is the documented
+    path whenever `retrieve_papers` is unavailable — without inventing a
+    full text or a reference list that the caller does not have.
+    """
+
     title: str = Field(..., description="")
-    full_text: str = Field(..., description="")
+    abstract: Optional[str] = Field(
+        None,
+        description=(
+            "The study's abstract. Populated directly from a search result; "
+            "the only summary available when no full text was retrieved."
+        ),
+    )
+    full_text: str = Field(default="", description="")
     references: list[str] = Field(
-        ..., description=""
+        default_factory=list, description=""
     )  # TODO: Consider how much information to obtain from the cited papers.
-    meta_data: MetaData = Field(..., description="")
-    llm_extracted_info: LLMExtractedInfo
+    meta_data: MetaData = Field(default_factory=MetaData, description="")
+    llm_extracted_info: LLMExtractedInfo = Field(default_factory=LLMExtractedInfo)
 
     def to_formatted_json(self) -> str:
         data_dict = {
             "Title": self.title,
+            "Abstract": self.abstract,
             "Main Contributions": self.llm_extracted_info.main_contributions,
             "Methods": self.llm_extracted_info.methodology,
             "Experimental Setup": self.llm_extracted_info.experimental_setup,

--- a/backend/src/airas/mcp/prompt_registry.py
+++ b/backend/src/airas/mcp/prompt_registry.py
@@ -297,14 +297,21 @@ def get_input_json_schema(step: str) -> dict[str, Any]:
     """The JSON Schema of the `inputs` a step expects."""
     if model := _EXTRA_INPUT_SCHEMAS.get(step):
         return model.model_json_schema()
-    _require_known_step(step)
+    if step not in _STEP_BUILDERS:
+        # Lists the non-step schemas too, because this is the one place they
+        # can be asked for. The generation path below must not: offering
+        # research_history as an "available step" would send the caller
+        # straight into a second error.
+        raise ValueError(
+            f"No input schema for '{step}'. Available: {', '.join(_KNOWN_SCHEMAS)}"
+        )
     return _STEP_BUILDERS[step][0].model_json_schema()
 
 
 def _require_known_step(step: str) -> None:
     if step not in _STEP_BUILDERS:
         raise ValueError(
-            f"Unknown step '{step}'. Available: {', '.join(_KNOWN_SCHEMAS)}"
+            f"Unknown step '{step}'. Available: {', '.join(GENERATION_STEPS)}"
         )
 
 

--- a/backend/src/airas/mcp/prompt_registry.py
+++ b/backend/src/airas/mcp/prompt_registry.py
@@ -11,6 +11,7 @@ Each generation step in AIRAS can run in one of two modes:
   top of them, so the two modes cannot drift apart.
 
 Every step returns a single fully rendered ``prompt``, an
+``input_json_schema`` describing the shape of ``inputs`` it accepts, an
 ``output_json_schema`` describing exactly the data format to produce, and a
 ``flow`` note on how the output is used next. Steps that loop internally on
 the backend (hypothesis refinement, paper refinement) are intentionally
@@ -19,9 +20,10 @@ instead of replaying the backend's iteration loop.
 """
 
 import json
-from typing import Any
+from typing import Any, Optional
 
 from jinja2 import Environment
+from pydantic import BaseModel
 
 from airas.core.types.experiment_code import ExperimentCode
 from airas.core.types.experiment_history import ExperimentHistory
@@ -31,6 +33,7 @@ from airas.core.types.experimental_design import (
 )
 from airas.core.types.experimental_results import ExperimentalResults
 from airas.core.types.paper import PaperContent
+from airas.core.types.research_history import ResearchHistory
 from airas.core.types.research_hypothesis import ResearchHypothesis
 from airas.core.types.research_study import ResearchStudy
 from airas.resources.datasets.language.prompt_engineering import (
@@ -79,16 +82,62 @@ GENERATION_STEPS = (
 )
 
 
+# The shape of `inputs` for each step. These both validate the call and are
+# published as `input_json_schema`, so a host can see what a step wants
+# before calling it rather than discovering it from a validation error.
+# Host mode is expected to assemble some of these by hand — a
+# research_study_list built from search_papers rows, for instance — and
+# there is no other place that shape is written down.
+
+
+class _ResearchQueriesInputs(BaseModel):
+    research_topic: str
+    num_queries: int = 2
+
+
+class _HypothesisInputs(BaseModel):
+    research_topic: str
+    research_study_list: list[ResearchStudy]
+
+
+class _ExperimentalDesignInputs(BaseModel):
+    research_hypothesis: ResearchHypothesis
+    compute_environment: Optional[ComputeEnvironment] = None
+    num_models_to_use: int = 2
+    num_datasets_to_use: int = 2
+    num_comparative_methods: int = 2
+
+
+class _ExperimentAnalysisInputs(BaseModel):
+    research_hypothesis: ResearchHypothesis
+    experimental_design: ExperimentalDesign
+    experiment_code: ExperimentCode
+    experimental_results: ExperimentalResults
+
+
+class _PaperWritingInputs(BaseModel):
+    research_hypothesis: ResearchHypothesis
+    experiment_history: ExperimentHistory
+    experiment_code: ExperimentCode
+    research_study_list: list[ResearchStudy]
+    references_bib: str
+
+
+class _LatexConversionInputs(BaseModel):
+    paper_content: PaperContent
+    figures_dir: str = "images"
+
+
 def _render(template: str, data: dict[str, Any]) -> str:
     return Environment().from_string(template).render(data)
 
 
-def _research_queries(inputs: dict[str, Any]) -> dict[str, Any]:
+def _research_queries(inputs: _ResearchQueriesInputs) -> dict[str, Any]:
     prompt = _render(
         generate_queries_prompt,
         {
-            "research_topic": inputs["research_topic"],
-            "n_queries": inputs.get("num_queries", 2),
+            "research_topic": inputs.research_topic,
+            "n_queries": inputs.num_queries,
         },
     )
     return {
@@ -101,14 +150,13 @@ def _research_queries(inputs: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _hypothesis(inputs: dict[str, Any]) -> dict[str, Any]:
+def _hypothesis(inputs: _HypothesisInputs) -> dict[str, Any]:
     prompt = _render(
         generate_simple_hypothesis_prompt,
         {
-            "research_topic": inputs["research_topic"],
+            "research_topic": inputs.research_topic,
             "research_study_list": [
-                ResearchStudy.to_formatted_json(ResearchStudy.model_validate(study))
-                for study in inputs["research_study_list"]
+                study.to_formatted_json() for study in inputs.research_study_list
             ],
         },
     )
@@ -123,24 +171,19 @@ def _hypothesis(inputs: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _experimental_design(inputs: dict[str, Any]) -> dict[str, Any]:
-    compute_environment = ComputeEnvironment.model_validate(
-        inputs.get("compute_environment") or {}
-    )
+def _experimental_design(inputs: _ExperimentalDesignInputs) -> dict[str, Any]:
     prompt = _render(
         generate_experimental_design_prompt,
         {
-            "research_hypothesis": ResearchHypothesis.model_validate(
-                inputs["research_hypothesis"]
-            ),
-            "compute_environment": compute_environment,
+            "research_hypothesis": inputs.research_hypothesis,
+            "compute_environment": inputs.compute_environment or ComputeEnvironment(),
             "model_list": json.dumps(LLM_API_MODELS, indent=4, ensure_ascii=False),
             "dataset_list": json.dumps(
                 PROMPT_ENGINEERING_DATASETS, indent=4, ensure_ascii=False
             ),
-            "num_models_to_use": inputs.get("num_models_to_use", 2),
-            "num_datasets_to_use": inputs.get("num_datasets_to_use", 2),
-            "num_comparative_methods": inputs.get("num_comparative_methods", 2),
+            "num_models_to_use": inputs.num_models_to_use,
+            "num_datasets_to_use": inputs.num_datasets_to_use,
+            "num_comparative_methods": inputs.num_comparative_methods,
         },
     )
     return {
@@ -154,20 +197,14 @@ def _experimental_design(inputs: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _experiment_analysis(inputs: dict[str, Any]) -> dict[str, Any]:
+def _experiment_analysis(inputs: _ExperimentAnalysisInputs) -> dict[str, Any]:
     prompt = _render(
         analyze_experiment_prompt,
         {
-            "research_hypothesis": ResearchHypothesis.model_validate(
-                inputs["research_hypothesis"]
-            ),
-            "experimental_design": ExperimentalDesign.model_validate(
-                inputs["experimental_design"]
-            ),
-            "experiment_code": ExperimentCode.model_validate(inputs["experiment_code"]),
-            "experimental_results": ExperimentalResults.model_validate(
-                inputs["experimental_results"]
-            ),
+            "research_hypothesis": inputs.research_hypothesis,
+            "experimental_design": inputs.experimental_design,
+            "experiment_code": inputs.experiment_code,
+            "experimental_results": inputs.experimental_results,
         },
     )
     return {
@@ -180,20 +217,13 @@ def _experiment_analysis(inputs: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _paper_writing(inputs: dict[str, Any]) -> dict[str, Any]:
+def _paper_writing(inputs: _PaperWritingInputs) -> dict[str, Any]:
     note = generate_note(
-        research_hypothesis=ResearchHypothesis.model_validate(
-            inputs["research_hypothesis"]
-        ),
-        experiment_history=ExperimentHistory.model_validate(
-            inputs["experiment_history"]
-        ),
-        experiment_code=ExperimentCode.model_validate(inputs["experiment_code"]),
-        research_study_list=[
-            ResearchStudy.model_validate(study)
-            for study in inputs["research_study_list"]
-        ],
-        references_bib=inputs["references_bib"],
+        research_hypothesis=inputs.research_hypothesis,
+        experiment_history=inputs.experiment_history,
+        experiment_code=inputs.experiment_code,
+        research_study_list=inputs.research_study_list,
+        references_bib=inputs.references_bib,
     )
     prompt = _render(write_prompt, {"note": note, "tips_dict": section_tips_prompt})
     return {
@@ -207,12 +237,12 @@ def _paper_writing(inputs: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _latex_conversion(inputs: dict[str, Any]) -> dict[str, Any]:
-    paper_content = PaperContent.model_validate(inputs["paper_content"])
+def _latex_conversion(inputs: _LatexConversionInputs) -> dict[str, Any]:
+    paper_content = inputs.paper_content
     prompt = _render(
         convert_to_latex_prompt,
         {
-            "figures_dir": inputs.get("figures_dir", "images"),
+            "figures_dir": inputs.figures_dir,
             "sections": [
                 {"name": field, "content": getattr(paper_content, field)}
                 for field in PaperContent.model_fields.keys()
@@ -232,24 +262,58 @@ def _latex_conversion(inputs: dict[str, Any]) -> dict[str, Any]:
             "<< background >>, << method >>, << experimental_setup >>, "
             "<< results >>, << conclusion >> — replace each marker with the "
             "corresponding section and save the result as "
-            ".research/latex/{template}/main.tex, then push it with git."
+            ".research/latex/{template}/main.tex. 3) Write the bibliography "
+            "from generate_bibfile to "
+            ".research/latex/{template}/references.bib, overwriting the "
+            "placeholder the template ships — without this every \\cite "
+            "renders as '?'. 4) Check the result with verify_latex before "
+            "publishing, then push both files with git."
         ),
     }
 
 
-_STEP_BUILDERS = {
-    "research_queries": _research_queries,
-    "hypothesis": _hypothesis,
-    "experimental_design": _experimental_design,
-    "experiment_analysis": _experiment_analysis,
-    "paper_writing": _paper_writing,
-    "latex_conversion": _latex_conversion,
+_STEP_BUILDERS: dict[str, tuple[type[BaseModel], Any]] = {
+    "research_queries": (_ResearchQueriesInputs, _research_queries),
+    "hypothesis": (_HypothesisInputs, _hypothesis),
+    "experimental_design": (_ExperimentalDesignInputs, _experimental_design),
+    "experiment_analysis": (_ExperimentAnalysisInputs, _experiment_analysis),
+    "paper_writing": (_PaperWritingInputs, _paper_writing),
+    "latex_conversion": (_LatexConversionInputs, _latex_conversion),
 }
 
 
-def build_generation_prompt(step: str, inputs: dict[str, Any]) -> dict[str, Any]:
+# Not a generation step, but the same problem: `upload_research_history`
+# takes a dict whose accepted shape was written down nowhere, and pydantic's
+# default `extra="ignore"` discarded every key that missed it. Publishing it
+# here keeps one place to ask "what does this tool want".
+_EXTRA_INPUT_SCHEMAS: dict[str, type[BaseModel]] = {
+    "research_history": ResearchHistory,
+}
+
+_KNOWN_SCHEMAS = (*GENERATION_STEPS, *_EXTRA_INPUT_SCHEMAS)
+
+
+def get_input_json_schema(step: str) -> dict[str, Any]:
+    """The JSON Schema of the `inputs` a step expects."""
+    if model := _EXTRA_INPUT_SCHEMAS.get(step):
+        return model.model_json_schema()
+    _require_known_step(step)
+    return _STEP_BUILDERS[step][0].model_json_schema()
+
+
+def _require_known_step(step: str) -> None:
     if step not in _STEP_BUILDERS:
         raise ValueError(
-            f"Unknown step '{step}'. Available: {', '.join(GENERATION_STEPS)}"
+            f"Unknown step '{step}'. Available: {', '.join(_KNOWN_SCHEMAS)}"
         )
-    return {"step": step, **_STEP_BUILDERS[step](inputs)}
+
+
+def build_generation_prompt(step: str, inputs: dict[str, Any]) -> dict[str, Any]:
+    _require_known_step(step)
+    input_model, builder = _STEP_BUILDERS[step]
+    validated = input_model.model_validate(inputs)
+    return {
+        "step": step,
+        "input_json_schema": input_model.model_json_schema(),
+        **builder(validated),
+    }

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -29,7 +29,7 @@ import httpx
 import vl_convert as vlc
 from mcp.server.fastmcp import FastMCP
 from PIL import Image
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from airas.cli import DEFAULT_DASHBOARD_PORT
 from airas.core.credentials import SETUP_INSTRUCTIONS, refresh_environment
@@ -1297,6 +1297,11 @@ def _reject_unknown_history_keys(research_history: dict[str, Any]) -> None:
     where a file written by hand — which the skills instruct agents to
     do — must not make the whole restore fail.
     """
+    if not isinstance(research_history, dict):
+        raise ValueError(
+            "research_history must be a JSON object keyed by field name, not "
+            f"{type(research_history).__name__}."
+        )
     unknown = sorted(set(research_history) - set(ResearchHistory.model_fields))
     if not unknown:
         return
@@ -1310,12 +1315,41 @@ def _reject_unknown_history_keys(research_history: dict[str, Any]) -> None:
     )
 
 
+class _ResearchHistoryInput(ResearchHistory):
+    """The upload-side view of ResearchHistory: same fields, nothing dropped.
+
+    Typing the tool parameter as this rather than `dict[str, Any]` is what
+    puts the field list into the schema the MCP client already reads from
+    `tools/list` — a plain dict publishes `additionalProperties: true` and
+    no properties at all, which tells the caller nothing. `extra="forbid"`
+    both refuses the keys that used to vanish and shows up in that schema,
+    so the boundary advertises that it is strict.
+
+    ResearchHistory itself stays lenient: it also parses
+    `.research/research_history.json` back out of the repository, where a
+    file written by hand — which the skills instruct agents to do — must
+    not make the whole restore fail.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_dropped_keys(cls, data: Any) -> Any:
+        # pydantic's own "Extra inputs are not permitted" does not mention
+        # additional_data, and a caller who is not told about the escape
+        # hatch just deletes the data instead of moving it.
+        if isinstance(data, dict):
+            _reject_unknown_history_keys(data)
+        return data
+
+
 @mcp.tool()
 async def upload_research_history(
     github_owner: str,
     repository_name: str,
     branch_name: str,
-    research_history: dict[str, Any],
+    research_history: _ResearchHistoryInput,
     commit_message: str | None = None,
 ) -> dict[str, Any]:
     """Save research history (hypothesis, design, results, ...) to the experiment repository.
@@ -1324,16 +1358,12 @@ async def upload_research_history(
     accumulated history lets you resume work in a later session with
     `download_research_history`. Requires GH_PERSONAL_ACCESS_TOKEN.
 
-    `research_history` accepts only the declared fields — `research_topic`,
-    `queries`, `research_study_list`, `research_hypothesis`,
-    `experiment_history`, `experiment_code`, `paper_content`,
-    `references_bib`, `latex_text`, `paper_url`, `full_html`,
-    `github_pages_url`, `paper_review_scores` — plus `additional_data`, a
-    free-form dict for anything the schema has no home for. Call
-    `get_input_schema("research_history")` for the full shape. Any other
-    top-level key is rejected rather than dropped.
+    `research_history` takes only the fields in this tool's own schema, and
+    any other top-level key is rejected rather than dropped. Anything the
+    schema has no home for belongs under `additional_data`, a free-form
+    dict. `get_input_schema("research_history")` returns the same shape if
+    you would rather ask for it directly.
     """
-    _reject_unknown_history_keys(research_history)
     result = (
         await GithubUploadSubgraph(_github_client())
         .build_graph()
@@ -1344,7 +1374,7 @@ async def upload_research_history(
                     repository_name=repository_name,
                     branch_name=branch_name,
                 ),
-                "research_history": ResearchHistory.model_validate(research_history),
+                "research_history": research_history,
                 "commit_message": commit_message,
             }
         )

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -82,7 +82,7 @@ from airas.infra.openalex_client import OpenAlexClient
 from airas.infra.retry_policy import HTTPClientFatalError, HTTPClientRetryableError
 from airas.infra.semantic_scholar_client import SemanticScholarClient
 from airas.infra.seyval_client import SeyvalClient
-from airas.mcp.prompt_registry import build_generation_prompt
+from airas.mcp.prompt_registry import build_generation_prompt, get_input_json_schema
 from airas.resources.libraries.library_docs import LIBRARY_DOCS
 from airas.usecases.analyzers.analyze_experiment_subgraph.analyze_experiment_subgraph import (
     AnalyzeExperimentLLMMapping,
@@ -358,11 +358,35 @@ def get_generation_prompt(step: str, inputs: dict[str, Any]) -> dict[str, Any]:
       experiment_code, research_study_list, references_bib
     - "latex_conversion": paper_content, figures_dir (optional)
 
-    Returns a fully rendered `prompt`, an `output_json_schema` describing
+    Returns a fully rendered `prompt`, an `input_json_schema` describing the
+    exact shape of `inputs` for this step, an `output_json_schema` describing
     exactly the data format to produce in one pass, and a `flow` note on
-    how the output feeds the next step.
+    how the output feeds the next step. Call `get_input_schema` first if you
+    are assembling an input by hand — `research_study_list` entries in
+    particular are `ResearchStudy` objects, not `search_papers` rows, and
+    share no key names with them.
     """
     return build_generation_prompt(step, inputs)
+
+
+@mcp.tool()
+def get_input_schema(step: str) -> dict[str, Any]:
+    """The JSON Schema of an input a tool takes.
+
+    Use before assembling one by hand, so the shape is known up front
+    instead of being discovered through a validation error — or, worse, not
+    discovered at all. `step` is any of `get_generation_prompt`'s steps, or
+    `research_history` for what `upload_research_history` accepts. No API
+    keys required.
+
+    Assembling `research_study_list` from `search_papers` output is the
+    common case and needs a translation: a search row's `authors`,
+    `citations` and `arxiv_id` live under `meta_data` on a `ResearchStudy`,
+    and only `title` is required — a study with just `title` and `abstract`
+    is valid, so nothing has to be invented for papers whose full text was
+    not retrieved.
+    """
+    return get_input_json_schema(step)
 
 
 @mcp.tool()
@@ -1259,6 +1283,33 @@ async def analyze_experiment(
 # --- Research history persistence (GitHub) ---
 
 
+def _reject_unknown_history_keys(research_history: dict[str, Any]) -> None:
+    """Refuse a key the model would drop, instead of dropping it.
+
+    ResearchHistory leaves pydantic's default `extra="ignore"` in place, so
+    an undeclared top-level key vanishes during validation and the upload
+    still reports success. A caller who passed eight keys and had six
+    silently discarded learns nothing until a later session restores an
+    empty-looking history.
+
+    The strictness belongs here rather than on the model: the same model
+    parses `.research/research_history.json` back out of the repository,
+    where a file written by hand — which the skills instruct agents to
+    do — must not make the whole restore fail.
+    """
+    unknown = sorted(set(research_history) - set(ResearchHistory.model_fields))
+    if not unknown:
+        return
+    raise ValueError(
+        f"research_history has {len(unknown)} key(s) that would be discarded "
+        f"without warning: {', '.join(unknown)}. Accepted fields are "
+        f"{', '.join(ResearchHistory.model_fields)}. Anything that does not "
+        "map onto one of them belongs under `additional_data`, which takes "
+        "an arbitrary dict; call get_input_schema('research_history') for "
+        "the full shape."
+    )
+
+
 @mcp.tool()
 async def upload_research_history(
     github_owner: str,
@@ -1272,7 +1323,17 @@ async def upload_research_history(
     AIRAS persists research state in the GitHub repository, so uploading the
     accumulated history lets you resume work in a later session with
     `download_research_history`. Requires GH_PERSONAL_ACCESS_TOKEN.
+
+    `research_history` accepts only the declared fields — `research_topic`,
+    `queries`, `research_study_list`, `research_hypothesis`,
+    `experiment_history`, `experiment_code`, `paper_content`,
+    `references_bib`, `latex_text`, `paper_url`, `full_html`,
+    `github_pages_url`, `paper_review_scores` — plus `additional_data`, a
+    free-form dict for anything the schema has no home for. Call
+    `get_input_schema("research_history")` for the full shape. Any other
+    top-level key is rejected rather than dropped.
     """
+    _reject_unknown_history_keys(research_history)
     result = (
         await GithubUploadSubgraph(_github_client())
         .build_graph()

--- a/backend/tests/unit/mcp/test_generation_input_schemas.py
+++ b/backend/tests/unit/mcp/test_generation_input_schemas.py
@@ -1,0 +1,163 @@
+"""The shape of `inputs` has to be discoverable before the call.
+
+In host-authoring mode the caller assembles these by hand — a
+`research_study_list` built from `search_papers` rows, a
+`compute_environment` that is an object rather than a string — and the
+shape was written down nowhere. The only way to learn it was to send
+something wrong and read the validation error.
+
+The same models both validate the call and are published as
+`input_json_schema`, so the documented shape cannot drift from the
+accepted one.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from airas.core.types.experimental_design import ComputeEnvironment
+from airas.core.types.research_history import ResearchHistory
+from airas.core.types.research_study import ResearchStudy
+from airas.mcp.prompt_registry import (
+    GENERATION_STEPS,
+    build_generation_prompt,
+    get_input_json_schema,
+)
+from airas.mcp.server import _reject_unknown_history_keys
+
+HYPOTHESIS_INPUTS = {
+    "research_topic": "Whether aggregate docking scores hide per-system failure",
+    "research_study_list": [{"title": "PLINDER", "abstract": "A benchmark."}],
+}
+
+
+@pytest.mark.parametrize("step", GENERATION_STEPS)
+def test_every_step_publishes_a_schema(step):
+    schema = get_input_json_schema(step)
+
+    assert schema["properties"], f"{step} publishes no input fields"
+
+
+def test_an_unknown_step_names_the_ones_that_exist():
+    with pytest.raises(ValueError, match="hypothesis"):
+        get_input_json_schema("hypotheses")
+
+
+def test_the_published_schema_is_the_one_that_validates():
+    """Publishing a second, hand-written schema would let the two drift."""
+    schema = get_input_json_schema("hypothesis")
+    result = build_generation_prompt("hypothesis", HYPOTHESIS_INPUTS)
+
+    assert result["input_json_schema"] == schema
+
+
+def test_the_prompt_call_reports_the_shape_it_wanted():
+    result = build_generation_prompt("hypothesis", HYPOTHESIS_INPUTS)
+
+    assert set(result) == {
+        "step",
+        "input_json_schema",
+        "output_json_schema",
+        "prompt",
+        "flow",
+    }
+
+
+def test_a_missing_input_is_a_validation_error_not_a_key_error():
+    with pytest.raises(ValidationError) as excinfo:
+        build_generation_prompt("hypothesis", {"research_topic": "x"})
+
+    assert excinfo.value.errors()[0]["loc"] == ("research_study_list",)
+
+
+def test_a_study_needs_only_a_title():
+    """A paper that was found but not read still has to be expressible.
+
+    Requiring full_text/references/llm_extracted_info left the caller
+    inventing content for papers it had only seen the abstract of.
+    """
+    study = ResearchStudy(title="PLINDER", abstract="A benchmark.")
+
+    assert study.title == "PLINDER"
+    # The abstract has somewhere to go, and reaches the prompt.
+    assert "A benchmark." in study.to_formatted_json()
+
+
+def test_a_study_list_of_bare_titles_and_abstracts_is_accepted():
+    result = build_generation_prompt("hypothesis", HYPOTHESIS_INPUTS)
+
+    assert "PLINDER" in result["prompt"]
+
+
+def test_compute_environment_carries_the_architecture():
+    """arch decides whether a dependency has an installable wheel at all.
+
+    Without the field it could only be described in free text, where
+    nothing downstream could act on it.
+    """
+    assert "arch" in ComputeEnvironment.model_fields
+
+    schema = get_input_json_schema("experimental_design")
+    compute = schema["$defs"]["ComputeEnvironment"]["properties"]
+    assert "arch" in compute
+
+
+class TestResearchHistoryKeys:
+    """The upload accepted eight top-level keys and kept two, reporting success.
+
+    ResearchHistory leaves pydantic's default `extra="ignore"` in place, so
+    the other six vanished during validation and `is_github_upload` came
+    back true. A later session then restores a history with the experiment
+    results, run ids and paper location simply absent.
+    """
+
+    # The exact call from the 2026-08-05 run.
+    SUPPLIED = {
+        "research_topic": "aggregate docking scores",
+        "research_hypothesis": {},
+        "results": {},
+        "runs": [],
+        "paper": {},
+        "compute": {},
+        "primary_metric": "lddt_pli",
+        "known_infrastructure_constraint": "aarch64",
+    }
+
+    def test_keys_that_would_be_dropped_are_rejected(self):
+        with pytest.raises(ValueError) as excinfo:
+            _reject_unknown_history_keys(self.SUPPLIED)
+
+        message = str(excinfo.value)
+        for dropped in ("results", "runs", "paper", "compute", "primary_metric"):
+            assert dropped in message
+        # The escape hatch has to be named, or the caller just deletes data.
+        assert "additional_data" in message
+
+    def test_the_escape_hatch_is_accepted(self):
+        _reject_unknown_history_keys(
+            {
+                "research_topic": "aggregate docking scores",
+                "additional_data": {"runs": [], "primary_metric": "lddt_pli"},
+            }
+        )
+
+    def test_a_declared_field_is_accepted(self):
+        _reject_unknown_history_keys({"experiment_history": {"cycles": []}})
+
+    def test_the_accepted_shape_is_published(self):
+        schema = get_input_json_schema("research_history")
+
+        assert "additional_data" in schema["properties"]
+        assert "experiment_history" in schema["properties"]
+
+    def test_the_parse_side_stays_lenient(self):
+        """Downloading must not fail on a hand-written file with stray keys.
+
+        The skills tell agents to write .research/research_history.json
+        themselves, and github_download swallows a validation failure into
+        an empty history — strictness there would lose everything.
+        """
+        history = ResearchHistory.model_validate(
+            {"research_topic": "t", "something_a_human_added": 1}
+        )
+
+        assert history.research_topic == "t"

--- a/backend/tests/unit/mcp/test_generation_input_schemas.py
+++ b/backend/tests/unit/mcp/test_generation_input_schemas.py
@@ -42,6 +42,18 @@ def test_an_unknown_step_names_the_ones_that_exist():
         get_input_json_schema("hypotheses")
 
 
+def test_a_generation_step_error_does_not_offer_a_non_step():
+    """research_history has a schema but is not something to generate.
+
+    Listing it among the available steps would send the caller straight
+    into a second error.
+    """
+    with pytest.raises(ValueError, match="Unknown step") as excinfo:
+        build_generation_prompt("research_history", {})
+
+    assert "research_history" not in str(excinfo.value).split("Available:")[1]
+
+
 def test_the_published_schema_is_the_one_that_validates():
     """Publishing a second, hand-written schema would let the two drift."""
     schema = get_input_json_schema("hypothesis")
@@ -161,3 +173,24 @@ class TestResearchHistoryKeys:
         )
 
         assert history.research_topic == "t"
+
+    @pytest.mark.asyncio
+    async def test_the_shape_is_published_where_the_client_already_looks(self):
+        """A `dict[str, Any]` parameter publishes nothing the caller can use.
+
+        The tool listing said `additionalProperties: true` with no
+        properties at all, so a client had no way to learn the shape
+        without a second call it had no reason to make.
+        """
+        from airas.mcp.server import mcp
+
+        tool = {t.name: t for t in await mcp.list_tools()}["upload_research_history"]
+        published = tool.inputSchema["$defs"]["_ResearchHistoryInput"]
+
+        assert published["additionalProperties"] is False
+        assert "additional_data" in published["properties"]
+        assert "experiment_history" in published["properties"]
+
+    def test_a_non_object_is_named_rather_than_raising_a_type_error(self):
+        with pytest.raises(ValueError, match="JSON object"):
+            _reject_unknown_history_keys(["research_topic"])


### PR DESCRIPTION
## 背景と目的

**ツール境界で入力の形が見えません。**

`auto-research-claude-code` は「`retrieve_papers` は LLM キーが要るので自分で抽出しろ」と指示しています。つまり **`research_study_list` を手で組むことが前提のモード**なのに、組むべき形が skill にもツール説明にもどこにも書かれていませんでした。学ぶ手段は「間違った形を送ってバリデーションエラーを読む」しかありません。

しかも `search_papers` の出力形と `ResearchStudy` は**キー名がひとつも一致しません**（`authors` → `meta_data.authors`、`citations` → `meta_data.citation_count`、`abstract` → 対応するフィールドが無い）。滅多に踏まない遠回りではなく、必ず踏みます。

同じ問題が別の場所ではもっと悪い形で出ます。

- **`ResearchStudy` は `full_text` / `references` / `meta_data` / `llm_extracted_info` を必須にしていました。** アブストラクトしか読んでいない論文について、**読んでいない中身を捏造しない限り渡せません**
- **`ComputeEnvironment` に CPU アーキテクチャのフィールドがありません。** aarch64 か x86_64 かは依存に wheel が存在するかどうかを決める根源的な制約ですが、`description` に自由文で書くしかなく、後段が参照できません
- **`upload_research_history` はトップレベルのキーを黙って捨てます。** 8 個のキーを渡したところ 6 個が消え、戻り値は `{"is_github_upload": true}` で成功でした。`ResearchHistory` に `model_config` が無く pydantic の既定が `extra="ignore"` のため、宣言されていないキーはバリデーションの時点で消えています
  - 影響は skill の「後のセッションで `download_research_history` すれば再開できる」という前提そのものです。実際に復元されるのは topic と hypothesis だけで、**実験結果も run ID も論文の所在も残りません**
  - なお器は用意されています。`additional_data`（`dict[str, Any]`）という拡張用の逃げ道があり、知っていれば渡したかった情報はほぼ全部残せました。**道具ではなく、境界でスキーマが見えないことが問題です**

## 変更内容

以下の機能が変更されました：

1. 各生成ステップの入力モデルを定義し、検証とスキーマ公開に同一のモデルを使う
2. `get_input_schema(step)` MCP ツールの追加と、`get_generation_prompt` 戻り値への `input_json_schema` 追加
3. `ResearchStudy` / `ComputeEnvironment` を、手で組める形に変更
4. `upload_research_history` が黙って捨てるキーを拒否するよう変更

実装の詳細は以下の通りです：

<details>
<summary><code>1. 入力モデルと入力スキーマの公開</code></summary>

**実装概要**

`backend/src/airas/mcp/prompt_registry.py` に 6 ステップ分の入力モデルを追加しました。

- `_ResearchQueriesInputs` / `_HypothesisInputs` / `_ExperimentalDesignInputs` / `_ExperimentAnalysisInputs` / `_PaperWritingInputs` / `_LatexConversionInputs`

- **要点は、この 1 つのモデルを検証とスキーマ公開の両方に使っていること**です
  - `build_generation_prompt` は `input_model.model_validate(inputs)` で検証し、同じモデルの `model_json_schema()` を `input_json_schema` として返します
  - 別々に持つと必ずズレるので、**ズレようがない構造**にしています
  - 各ビルダーは `dict` ではなく検証済みモデルを受け取るようになり、`inputs.get("...")` 由来の既定値の散在も解消しました

- **`get_input_schema(step)`**: 呼ぶ前に形を引ける MCP ツールです。バリデーションエラーから学ぶ必要がなくなります
  - 入力モデルが参照する型は `$defs` に展開されるため、**変更していない型も含めて形が見えます**。たとえば 4 回踏まれた `experiment_code` の `{"files": {...}}` は、説明文と例（`'src/train.py'`, `'config/run/run1.yaml'`）ごと出ます

</details>

<details>
<summary><code>2. 手で組める型への変更</code></summary>

**実装概要**

- **`ResearchStudy`**（`backend/src/airas/core/types/research_study.py`）
  - `title` 以外を全て default 付きに変更。`{"title": ..., "abstract": ...}` が有効な study になります
  - `abstract` フィールドを追加し、`to_formatted_json()` にも "Abstract" として出力
    - 従来は `to_formatted_json` が `title` と `llm_extracted_info` しか出さず、アブストラクトの置き場がありませんでした。`full_text` に押し込む回避策が不要になります

- **`ComputeEnvironment`**（`backend/src/airas/core/types/experimental_design.py`）
  - `arch: str | None = None` を追加
  - 依存に wheel が存在するかを決める制約なので、自由文ではなく構造化フィールドとして持ちます

</details>

<details>
<summary><code>3. upload_research_history が捨てるキーの拒否</code></summary>

**実装概要**

`_reject_unknown_history_keys()` を追加し、`upload_research_history` の入口でトップレベルのキーを検査します。

- **引数の型を `dict[str, Any]` から `ResearchHistory` のサブクラスに変更しました。** これが発見可能性側の本丸です
  - `dict[str, Any]` だと FastMCP が `tools/list` に公開するのは `{"additionalProperties": true, "type": "object"}` だけで、**フィールド情報がゼロ**でした。クライアントは受理される形を知りようがありません
  - 型付けにより 14 フィールド全てが `tools/list` に載ります。`extra="forbid"` は `additionalProperties: false` として公開されるので、**境界が「厳格である」ことを自ら明示**します
  - `get_input_schema("research_history")` も引き続き使えますが、**追加の呼び出しをしないクライアントにも情報が届く**ようになりました

- **`ResearchHistory` 本体ではなくサブクラスにした理由**は後述の読み込み側の事情です

- 未知のキーがあれば `ValueError` にし、エラー文に **3 つとも**含めます
  - 捨てられるはずだったキー名
  - 受理されるフィールドの一覧
  - **`additional_data` という逃げ道**（これを示さないと、呼び出し側はデータを削って通すだけになります）

- **厳しさを基底モデルではなくサブクラスに置いた理由**: `ResearchHistory` 本体に `extra="forbid"` を付けると、**読み込み側が壊れます**
  - `github_download.py:48` は同じ `ResearchHistory.model_validate` でリポジトリ上の JSON を読み、失敗を握り潰して**空の履歴を返します**
  - skill の手順は `.research/research_history.json` を自分で書いて push するよう指示しているため、手書きファイルに余計なキーが 1 つ入っただけで**復元が丸ごと空になる**、現状より悪い沈黙に化けます
  - したがって「書き込み側は厳格、読み込み側は寛容」に分けています

- **`get_input_schema("research_history")`** で受理する形を引けるようにし、ツールの docstring にも受理フィールドと `additional_data` を明記しました

</details>

4. テスト:
   - `backend/tests/unit/mcp/test_generation_input_schemas.py` を新規追加（21 件）
     - 全 6 ステップがスキーマを公開すること
     - **公開されるスキーマと検証に使われるスキーマが同一であること** — 別々に持つとズレるため、ここが要点です
     - 入力不足が `KeyError` ではなく `ValidationError` になること、未知の step が既存の step 名を挙げること
     - **`{"title": ..., "abstract": ...}` だけで study が成立し、abstract がプロンプトに届くこと**
     - `arch` が公開スキーマの `ComputeEnvironment` に出ること
     - **実測の 8 キーの呼び出しで、消えるはずだった 5 キーが全てエラー文に出ること**、および `additional_data` が必ず示されること
     - `additional_data` 経由なら受理されること
     - **読み込み側は寛容なままであること**（手書きファイルで復元が壊れない）
     - **`tools/list` が 14 フィールドと `additionalProperties: false` を公開すること**
     - 非オブジェクトが `TypeError` ではなく理由付きの `ValueError` になること
     - 生成ステップのエラーに `research_history` が候補として出ないこと（スキーマはあるが生成対象ではないため、挙げると二重のエラーに誘導してしまう）

5. その他:
   - **`analyze_experiment` の `metrics_data` 沈黙は本 PR では直りません。** 本 PR で公開されるスキーマに `metrics_data` は出るため形は分かりますが、`metrics_data` を持たない dict を渡したときにプロンプトの `# Experimental Results` 節が黙って空になるバグ自体は残ります
     - メモの対処案のうち「ツール説明に `metrics_data` を明記する」だけが本 PR の範囲で、残る 2 つ（結果全体を出す / 警告する）は後続の PR で対応します
