### PR TITLE
fix: stop the generation and execution steps from failing quietly

### DIFF
--- a/backend/src/airas/core/types/research_hypothesis.py
+++ b/backend/src/airas/core/types/research_hypothesis.py
@@ -3,16 +3,33 @@ from __future__ import annotations
 import json
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ResearchHypothesis(BaseModel):
-    # TODO: Consider making some fields optional (e.g. experimental_code).
     open_problems: str
     method: str
     experimental_setup: str
-    primary_metric: str
-    experimental_code: str
+    primary_metric: str = Field(
+        description=(
+            "One standard, machine-extractable metric name. The GAP between "
+            "the proposal and its baselines is computed from this one."
+        )
+    )
+    supporting_metrics: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Further metric names reported alongside the primary one, for "
+            "research whose claim needs more than a single number. Reported "
+            "separately; never aggregated into primary_metric."
+        ),
+    )
+    # A sketch written before the repository, the data, or the code template
+    # have been seen, kept only to convey the idea. The real implementation
+    # replaces it, and the paper-writing step reads this, so an unfaithful
+    # sketch surfaces later as a methods section that describes code nobody
+    # ran. Empty is better than wrong.
+    experimental_code: str = ""
     expected_result: str
     expected_conclusion: str
 
@@ -22,6 +39,7 @@ class ResearchHypothesis(BaseModel):
             "Methods": self.method,
             "Experimental Setup": self.experimental_setup,
             "Primary Metric": self.primary_metric,
+            "Supporting Metrics": self.supporting_metrics,
             "Experimental Code": self.experimental_code,
             "Expected Result": self.expected_result,
             "Expected Conclusion": self.expected_conclusion,

--- a/backend/src/airas/dashboard/launcher.py
+++ b/backend/src/airas/dashboard/launcher.py
@@ -42,11 +42,15 @@ def has_bundled_ui() -> bool:
     return (static_dir / "index.html").is_file()
 
 
-def start_dashboard(port: int, timeout: float = 30.0) -> int:
+def start_dashboard(port: int, timeout: float = 120.0) -> int:
     """Spawn `airas dashboard` in the background and wait until it is healthy.
 
     Returns the child PID. Raises RuntimeError if the process dies or does
-    not become healthy in time.
+    not become healthy in time. A process that is still alive when the wait
+    runs out is left running rather than terminated: cold starts have been
+    seen to log `Application startup complete` well past the old 30s wait,
+    and killing one throws away the work, so retrying the call is what the
+    caller should do — the retry finds it already healthy.
     """
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     with open(LOG_FILE, "ab") as log:
@@ -84,10 +88,10 @@ def start_dashboard(port: int, timeout: float = 30.0) -> int:
             )
         time.sleep(0.3)
 
-    proc.terminate()
-    PID_FILE.unlink(missing_ok=True)
     raise RuntimeError(
-        f"Dashboard did not become healthy within {timeout}s. See {LOG_FILE}."
+        f"Dashboard did not answer /health within {timeout}s, but the process "
+        f"(pid {proc.pid}) is still starting and has been left running. Retry "
+        f"this call — it will reuse the process once it is up. See {LOG_FILE}."
     )
 
 

--- a/backend/src/airas/mcp/prompt_registry.py
+++ b/backend/src/airas/mcp/prompt_registry.py
@@ -66,7 +66,10 @@ from airas.usecases.generators.generate_queries_subgraph.prompt.generate_queries
 from airas.usecases.publication.generate_latex_subgraph.prompts.convert_to_latex_prompt import (
     convert_to_latex_prompt,
 )
-from airas.usecases.writers.write_subgraph.nodes.generate_note import generate_note
+from airas.usecases.writers.write_subgraph.nodes.generate_note import (
+    generate_note,
+    unmatched_citation_titles,
+)
 from airas.usecases.writers.write_subgraph.prompts.section_tips_prompt import (
     section_tips_prompt,
 )
@@ -226,7 +229,7 @@ def _paper_writing(inputs: _PaperWritingInputs) -> dict[str, Any]:
         references_bib=inputs.references_bib,
     )
     prompt = _render(write_prompt, {"note": note, "tips_dict": section_tips_prompt})
-    return {
+    result: dict[str, Any] = {
         "prompt": prompt,
         "output_json_schema": PaperContent.model_json_schema(),
         "flow": (
@@ -235,6 +238,22 @@ def _paper_writing(inputs: _PaperWritingInputs) -> dict[str, Any]:
             "as paper_content."
         ),
     }
+    # The prompt tells the writer not to cite these, and says so nowhere the
+    # caller can see. Unattended, that finishes a paper with the citations
+    # quietly missing.
+    unmatched = unmatched_citation_titles(
+        inputs.research_study_list, inputs.references_bib
+    )
+    if unmatched:
+        result["warnings"] = [
+            f"{len(unmatched)} of {len(inputs.research_study_list)} studies have "
+            "no entry in references_bib, so the prompt marks them 'do not cite' "
+            "and they will be missing from the paper: "
+            + "; ".join(unmatched)
+            + ". Titles are matched by title, so pass generate_bibfile's output "
+            "verbatim rather than a shortened version."
+        ]
+    return result
 
 
 def _latex_conversion(inputs: _LatexConversionInputs) -> dict[str, Any]:

--- a/backend/src/airas/mcp/prompt_registry.py
+++ b/backend/src/airas/mcp/prompt_registry.py
@@ -68,6 +68,7 @@ from airas.usecases.publication.generate_latex_subgraph.prompts.convert_to_latex
 )
 from airas.usecases.writers.write_subgraph.nodes.generate_note import (
     generate_note,
+    map_studies_to_bibtex,
     unmatched_citation_titles,
 )
 from airas.usecases.writers.write_subgraph.prompts.section_tips_prompt import (
@@ -221,12 +222,18 @@ def _experiment_analysis(inputs: _ExperimentAnalysisInputs) -> dict[str, Any]:
 
 
 def _paper_writing(inputs: _PaperWritingInputs) -> dict[str, Any]:
+    # Built once and handed to both readers: the note renders it, and the
+    # warning below reports what it could not resolve.
+    mapped_studies = map_studies_to_bibtex(
+        inputs.research_study_list, inputs.references_bib
+    )
     note = generate_note(
         research_hypothesis=inputs.research_hypothesis,
         experiment_history=inputs.experiment_history,
         experiment_code=inputs.experiment_code,
         research_study_list=inputs.research_study_list,
         references_bib=inputs.references_bib,
+        mapped_studies=mapped_studies,
     )
     prompt = _render(write_prompt, {"note": note, "tips_dict": section_tips_prompt})
     result: dict[str, Any] = {
@@ -241,9 +248,7 @@ def _paper_writing(inputs: _PaperWritingInputs) -> dict[str, Any]:
     # The prompt tells the writer not to cite these, and says so nowhere the
     # caller can see. Unattended, that finishes a paper with the citations
     # quietly missing.
-    unmatched = unmatched_citation_titles(
-        inputs.research_study_list, inputs.references_bib
-    )
+    unmatched = unmatched_citation_titles(mapped_studies)
     if unmatched:
         result["warnings"] = [
             f"{len(unmatched)} of {len(inputs.research_study_list)} studies have "

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -848,6 +848,8 @@ async def prepare_repository(
 
     Sets up the repository (from the AIRAS experiment template) and the
     working branch. Run this once before `dispatch_code_generation`.
+    Returns `html_url` and `clone_url` alongside the readiness flags, so the
+    next step — cloning it locally — needs nothing reconstructed by hand.
     Requires GH_PERSONAL_ACCESS_TOKEN.
     """
     config = GitHubConfig(
@@ -866,6 +868,8 @@ async def prepare_repository(
     return {
         "is_repository_ready": result["is_repository_ready"],
         "is_branch_ready": result["is_branch_ready"],
+        "html_url": result["html_url"],
+        "clone_url": result["clone_url"],
     }
 
 
@@ -883,6 +887,7 @@ async def dispatch_experiment(
     inputs_from_runs: list[str] | None = None,
     time_limit: str | None = None,
     resource_count: int | None = None,
+    required_env_vars: list[str] | None = None,
 ) -> dict[str, Any]:
     """Start an experiment run (asynchronous). The code must already be pushed.
 
@@ -902,11 +907,16 @@ async def dispatch_experiment(
       you registered, "byo:<uuid>" from the Seyval MCP server's
       `list_computes`; it defaults to SEYVAL_COMPUTE_ID, and without either the
       run goes to Seyval-managed compute. `compute_type` sets the resource
-      request in both cases (e.g. "cpu-general", "gpu-a10"). The W&B API key
-      must be registered as an env var on the Seyval side. Seyval keeps the run's
+      request in both cases (e.g. "cpu-general", "gpu-a10"). Seyval keeps the run's
       results on its own side, so call `import_run_outputs` once the run
       finishes — before `fetch_experiment_results`, which reads the
       repository.
+
+    `required_env_vars` lists the env vars Seyval must have registered before
+    it will start the run, and defaults to `["WANDB_API_KEY"]`. Seyval
+    rejects the run outright when one is missing, so pass `[]` for an
+    experiment that does not use Weights & Biases rather than registering a
+    dummy key.
 
     `inputs_from_runs`, `time_limit` and `resource_count` apply to "seyval"
     only. `inputs_from_runs` takes `execution_id`s of earlier completed runs
@@ -939,6 +949,7 @@ async def dispatch_experiment(
                 inputs_from_runs=inputs_from_runs,
                 time_limit=time_limit,
                 resource_count=resource_count,
+                required_env_vars=required_env_vars,
             )
             .build_graph()
             .ainvoke(

--- a/backend/src/airas/usecases/analyzers/analyze_experiment_subgraph/prompts/analyze_experiment_prompt.py
+++ b/backend/src/airas/usecases/analyzers/analyze_experiment_subgraph/prompts/analyze_experiment_prompt.py
@@ -11,7 +11,35 @@ Your task is to analyze the experimental results and generate a comprehensive an
 5. Summarize the overall strengths and weaknesses of the proposed method based on the above analysis.
 
 # Research Hypothesis
+{% if research_hypothesis.open_problems %}
+## Open Problems
+{{ research_hypothesis.open_problems }}
+{% endif %}
+
+## Method
 {{ research_hypothesis.method }}
+
+{% if research_hypothesis.primary_metric %}
+## Primary Metric
+{{ research_hypothesis.primary_metric }}
+{% endif %}
+
+{% if research_hypothesis.supporting_metrics %}
+## Supporting Metrics
+{% for metric in research_hypothesis.supporting_metrics %}
+- {{ metric }}
+{% endfor %}
+{% endif %}
+
+{% if research_hypothesis.expected_result %}
+## Expected Result
+{{ research_hypothesis.expected_result }}
+{% endif %}
+
+{% if research_hypothesis.expected_conclusion %}
+## Expected Conclusion
+{{ research_hypothesis.expected_conclusion }}
+{% endif %}
 
 {% if experimental_design %}
 # Experimental Design
@@ -74,8 +102,36 @@ Your task is to analyze the experimental results and generate a comprehensive an
 {% if experimental_results.metrics_data %}
 ## Metrics Data
 {{ experimental_results.metrics_data | tojson(indent=2) }}
+{% else %}
+## Metrics Data
+NONE PROVIDED. No numeric results reached this prompt. Do not invent any:
+state in the report that the metrics are unavailable, and base whatever
+analysis you can write on the run output below.
 {% endif %}
 
+{% if experimental_results.result_figures %}
+## Result Figures
+{% for figure in experimental_results.result_figures %}
+- {{ figure }}
+{% endfor %}
+{% endif %}
+
+{% if experimental_results.diagram_figures %}
+## Method Diagrams
+{% for figure in experimental_results.diagram_figures %}
+- {{ figure }}
+{% endfor %}
+{% endif %}
+
+{% if experimental_results.stdout %}
+## Run Output (stdout)
+{{ experimental_results.stdout }}
+{% endif %}
+
+{% if experimental_results.stderr %}
+## Run Errors (stderr)
+{{ experimental_results.stderr }}
+{% endif %}
 {% else %}
 No experimental results available yet.
 {% endif %}

--- a/backend/src/airas/usecases/analyzers/analyze_experiment_subgraph/prompts/analyze_experiment_prompt.py
+++ b/backend/src/airas/usecases/analyzers/analyze_experiment_subgraph/prompts/analyze_experiment_prompt.py
@@ -124,13 +124,13 @@ analysis you can write on the run output below.
 {% endif %}
 
 {% if experimental_results.stdout %}
-## Run Output (stdout)
-{{ experimental_results.stdout }}
+## Run Output (stdout, last 2000 characters)
+{{ experimental_results.stdout[-2000:] }}
 {% endif %}
 
 {% if experimental_results.stderr %}
-## Run Errors (stderr)
-{{ experimental_results.stderr }}
+## Run Errors (stderr, last 2000 characters)
+{{ experimental_results.stderr[-2000:] }}
 {% endif %}
 {% else %}
 No experimental results available yet.

--- a/backend/src/airas/usecases/generators/generate_experimental_design_subgraph/prompts/generate_experimental_design_prompt.py
+++ b/backend/src/airas/usecases/generators/generate_experimental_design_subgraph/prompts/generate_experimental_design_prompt.py
@@ -6,6 +6,8 @@ You are an AI researcher. You will conduct experiments to demonstrate the superi
 {% if compute_environment %}
 {%- if compute_environment.os %}OS: {{ compute_environment.os }}
 {% endif %}
+{%- if compute_environment.arch %}CPU architecture: {{ compute_environment.arch }} (a dependency without a wheel for this architecture cannot be installed, however well it resolves elsewhere)
+{% endif %}
 {%- if compute_environment.cpu_cores %}CPU: {{ compute_environment.cpu_cores }} cores
 {% endif %}
 {%- if compute_environment.ram_gb %}RAM: {{ compute_environment.ram_gb }} GB
@@ -46,15 +48,20 @@ You are an AI researcher. You will conduct experiments to demonstrate the superi
       - Relevant visualizations: ONLY figures appropriate for this metric type (e.g., confusion matrix for classification, error distribution for regression, learning curves, etc.)
   - Ensure metrics are appropriate for the task - avoid exact string matching for numerical/generation tasks, and avoid classification metrics for non-classification tasks
   - The primary metric specified in the hypothesis ({{ research_hypothesis.primary_metric }}) MUST be included with the EXACT same name.
+{%- if research_hypothesis.supporting_metrics %}
+  - The hypothesis also names these supporting metrics, which MUST each be included with the EXACT same name: {{ research_hypothesis.supporting_metrics | join(", ") }}. They are reported alongside the primary metric, not combined with it.
+{%- endif %}
 - models_to_use：
   - Select exactly {{ num_models_to_use }} deep learning or machine learning models to be used in the experiment and output them in a list format.
   - Each model name should clearly indicate its number of parameters.
   - Refer to the provided "# MODEL LIST" for guidance, although models not included in the list are also acceptable.
-  - Return an empty list ONLY if the research's PRIMARY PURPOSE is proposing a completely new model architecture itself (not just a training method, optimizer, or augmentation technique). Otherwise, you MUST select existing models.
+  - If the requested count above is 0, return an empty list. A count of 0 is a deliberate instruction (for example, research that evaluates an existing artifact rather than training anything); do not override it by selecting models anyway.
+  - If the requested count is nonzero, you MUST select existing models, with one exception: return an empty list if the research's PRIMARY PURPOSE is proposing a completely new model architecture itself (not just a training method, optimizer, or augmentation technique).
 - datasets_to_use：
   - Select exactly {{ num_datasets_to_use }} datasets to be used in the experiment and output them in a list format.
   - Refer to the provided "# DATASET LIST" for guidance, although datasets not included in the list are also acceptable.
-  - Return an empty list ONLY if the research's PRIMARY PURPOSE is proposing a completely new dataset itself. Otherwise, you MUST select existing datasets.
+  - If the requested count above is 0, return an empty list. A count of 0 is a deliberate instruction; do not override it by selecting datasets anyway.
+  - If the requested count is nonzero, you MUST select existing datasets, with one exception: return an empty list if the research's PRIMARY PURPOSE is proposing a completely new dataset itself.
 - proposed_method：
   - Output a MethodConfig object with the following fields:
     * method_name: Name of the proposed method (e.g., "Adaptive Diffusion Sampler")

--- a/backend/src/airas/usecases/generators/generate_hypothesis_subgraph/prompts/generate_simple_hypothesis_prompt.py
+++ b/backend/src/airas/usecases/generators/generate_hypothesis_subgraph/prompts/generate_simple_hypothesis_prompt.py
@@ -1,49 +1,63 @@
 generate_simple_hypothesis_prompt = """\
-You are a researcher in machine learning. Based on the instructions below, please generate a simple new research method with minimal modifications to existing approaches.
+You are a researcher. Based on the instructions below, please generate a simple new research proposal that advances prior work through a minimal modification.
 
 # Instructions:
 - Read the research objective described below:
     {{ research_topic }}
 - A list of related prior studies is provided. Each entry contains a summary of its title, main contributions, methodologies, results, and limitations:
     {{ research_study_list }}
-- Identify the most promising existing method that can be improved with minimal modifications to its objective function or core algorithm.
-- Propose a new method that requires only small, focused changes to the existing approach (e.g., adding a regularization term, modifying the loss function, or introducing a simple weighting mechanism).
-- Ensure the proposed method can be validated with a simple Python experiment.
+- Identify the most promising existing work that can be improved with a minimal, focused modification.
+- Propose a change that requires only small, focused modifications to that prior work.
+- Let the research objective decide WHAT KIND of contribution this is. Do NOT assume the contribution must be a change to a model or to how it is trained. A minimal modification may be, for example:
+    * a change to a method's objective function or core algorithm (e.g., adding a regularization term, modifying the loss function, or introducing a simple weighting mechanism);
+    * a change to an evaluation or aggregation procedure (e.g., scoring or ranking results differently, or reporting stratified results where they were previously pooled);
+    * a change to how a dataset or benchmark is constructed, filtered, or split (e.g., a stricter held-out split, a different negative-sampling rule, or an added subset);
+    * a change to a system's decision rule or pipeline step (e.g., a different acceptance threshold, a reordering of stages, or an added filtering step).
+  These are illustrations, not an exhaustive list. If the research objective calls for a benchmark, an evaluation methodology, a dataset, or a system as the contribution, propose that, not a method modification.
+- Whatever its kind, the change must stay small and clearly attributable, so that its effect can be isolated by comparing against the unmodified prior work.
+- Ensure the proposal can be validated with a simple Python experiment.
 
 # Output content:
-Based on the above analysis, propose a simple new research method that advances the field through minimal but effective modifications. Your output should include:
+Based on the above analysis, propose a simple new research proposal that advances the field through a minimal but effective modification. Your output should include:
 
 - open_problems
-    - Identify the key limitation in existing methods that can be addressed with minimal modifications.
-    - Focus on problems that can be solved through simple changes to objective functions or algorithms.
+    - Identify the key limitation in existing work that can be addressed with a minimal modification.
+    - Focus on problems that can be solved through a simple, well-scoped change, whatever part of the prior work that change touches.
 
 - method
-    - Describe the minimal modification to the existing method (e.g., adding regularization, modifying loss function).
-    - Explain the theoretical motivation for this change.
+    - Describe the minimal modification to the prior work, and state clearly which part of it the change touches (its algorithm, its evaluation procedure, its data, or its system behavior).
+    - Explain the motivation for this change.
     - Keep the modification simple and focused on the identified problem.
 
 - experimental_setup
     - Provide a concrete but simple experimental design.
-    - Specify which datasets and evaluation metrics will be used.
-    - Design a straightforward comparison with the base method.
+    - Specify what will be evaluated (datasets, benchmarks, or existing artifacts) and which evaluation metrics will be used.
+    - Design a straightforward comparison against the unmodified prior work.
 
 - primary_metric
-    - Specify the single most important evaluation metric that will be used to assess the effectiveness of the proposed method.
-    - This metric will be used for calculating the performance gap (GAP) between the proposed method and baselines.
-    - Choose a metric that best represents the success of addressing the identified problem (e.g., "accuracy", "f1_score", "bleu", "perplexity").
+    - Specify the single most important evaluation metric that will be used to assess the effectiveness of the proposal.
+    - This metric will be used for calculating the performance gap (GAP) between the proposal and baselines, so it MUST be exactly one metric name.
+    - Choose a metric that best represents the success of addressing the identified problem (e.g., "accuracy", "f1_score", "bleu", "perplexity", "spearman_r", "success_rate").
     - Use a clear, standard metric name that can be directly extracted from experimental results.
     - Do NOT include explanations or additional descriptions here. Save those for expected_result.
 
+- supporting_metrics
+    - Optional. A list of additional standard metric names that should be reported alongside the primary metric.
+    - Use this when a single number does not capture the claim (for example, when the point of the research is that the primary metric alone is insufficient, or when performance must be read across several axes).
+    - Each entry must follow the same rules as primary_metric: one clear, standard, directly extractable name, with no explanation attached.
+    - These metrics are REPORTED separately; they are NOT aggregated into the primary metric and are NOT used for the GAP calculation. Do not repeat the primary metric here.
+    - Leave this list empty if the primary metric alone is sufficient.
+
 - experimental_code
-    - Output the core Python code implementing the proposed modification.
-    - Focus only on the key changes to the base method.
-    - Keep the code concise and readable.
+    - Optional. A short Python sketch that illustrates the idea, e.g. the key change expressed as a few lines.
+    - This is an ILLUSTRATION, NOT the implementation. The actual experiment is implemented later against a real repository, data, and code template that you have not seen, and this sketch will be rewritten. Do not attempt a runnable or complete program.
+    - Leave this field empty if you cannot write a sketch that faithfully reflects the proposed change.
 
 - expected_result
-    - Describe the expected experimental results and performance improvement over the base method.
-    - Include specific quantitative predictions for the primary metric and other key evaluation metrics.
+    - Describe the expected experimental results and the improvement over the unmodified prior work.
+    - Include specific quantitative predictions for the primary metric and for any supporting metrics.
     - These predictions help determine whether higher or lower metric values indicate better performance.
 
 - expected_conclusion
     - Summarize the practical value of the minimal modification.
-    - Explain why this simple change leads to meaningful improvement."""
+    - Explain why this simple change leads to a meaningful improvement."""

--- a/backend/src/airas/usecases/github/prepare_repository_subgraph/prepare_repository_subgraph.py
+++ b/backend/src/airas/usecases/github/prepare_repository_subgraph/prepare_repository_subgraph.py
@@ -146,7 +146,7 @@ class PrepareRepositorySubgraph:
         return {"is_branch_created": is_branch_created}
 
     @record_execution_time
-    def _finalize_state(self, state: PrepareRepositoryState) -> dict[str, object]:
+    def _finalize_state(self, state: PrepareRepositoryState) -> dict[str, bool | str]:
         is_repository_ready = state.get("is_repository_from_template", False)
         is_branch_ready = state.get("is_branch_already_exists", False) or state.get(
             "is_branch_created", False

--- a/backend/src/airas/usecases/github/prepare_repository_subgraph/prepare_repository_subgraph.py
+++ b/backend/src/airas/usecases/github/prepare_repository_subgraph/prepare_repository_subgraph.py
@@ -39,6 +39,8 @@ class PrepareRepositoryInputState(TypedDict):
 class PrepareRepositoryOutputState(ExecutionTimeState):
     is_repository_ready: bool
     is_branch_ready: bool
+    html_url: str
+    clone_url: str
 
 
 class PrepareRepositoryState(PrepareRepositoryInputState, PrepareRepositoryOutputState):
@@ -144,14 +146,21 @@ class PrepareRepositorySubgraph:
         return {"is_branch_created": is_branch_created}
 
     @record_execution_time
-    def _finalize_state(self, state: PrepareRepositoryState) -> dict[str, bool]:
+    def _finalize_state(self, state: PrepareRepositoryState) -> dict[str, object]:
         is_repository_ready = state.get("is_repository_from_template", False)
         is_branch_ready = state.get("is_branch_already_exists", False) or state.get(
             "is_branch_created", False
         )
+        github_config = state["github_config"]
+        repository = f"{github_config.github_owner}/{github_config.repository_name}"
         return {
             "is_repository_ready": is_repository_ready,
             "is_branch_ready": is_branch_ready,
+            # Returned so the caller does not have to reconstruct them: the
+            # next step in every flow is to clone this repository, and until
+            # now nothing told the caller where it is.
+            "html_url": f"https://github.com/{repository}",
+            "clone_url": f"https://github.com/{repository}.git",
         }
 
     def build_graph(self):

--- a/backend/src/airas/usecases/writers/generate_bibfile_subgraph/nodes/generate_bibfile.py
+++ b/backend/src/airas/usecases/writers/generate_bibfile_subgraph/nodes/generate_bibfile.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from datetime import datetime
 
 import bibtexparser
 from bibtexparser.bibdatabase import BibDatabase
@@ -8,12 +9,38 @@ from airas.core.types.research_study import ResearchStudy
 
 logger = logging.getLogger(__name__)
 
+_EARLIEST_PLAUSIBLE_YEAR = 1800
+_DOI_PATTERN = re.compile(r"^10\.\d{4,9}/\S+$")
+_ARXIV_ID_IN_URL_PATTERN = re.compile(
+    r"arxiv\.org/(?:abs|pdf)/([^\s/?#]+)", re.IGNORECASE
+)
+_ARXIV_ID_IN_DOI_PATTERN = re.compile(r"^10\.48550/arxiv\.(\S+)$", re.IGNORECASE)
+
+
+def _normalize_arxiv_id(arxiv_id: str) -> str:
+    normalized = arxiv_id.strip().lower()
+    normalized = re.sub(r"^arxiv[:/]", "", normalized)
+    normalized = re.sub(r"\.pdf$", "", normalized)
+    normalized = re.sub(r"v\d+$", "", normalized)
+    return normalized
+
+
+def _extract_surname(author: str) -> str:
+    # Sources disagree on author formatting: OpenAlex/arXiv return
+    # "Ashish Vaswani" while Semantic Scholar can return "Vaswani, Ashish".
+    author = author.strip()
+    if "," in author:
+        surname = author.split(",", 1)[0]
+    else:
+        parts = author.split()
+        surname = parts[-1] if parts else ""
+    return surname.lower()
+
 
 def _generate_citation_key(title: str, authors: list[str], year) -> str:
     first_author = ""
     if authors:
-        author_parts = authors[0].split()
-        first_author = author_parts[-1].lower() if author_parts else "author"
+        first_author = _extract_surname(authors[0]) or "author"
     else:
         first_author = "author"
 
@@ -22,11 +49,87 @@ def _generate_citation_key(title: str, authors: list[str], year) -> str:
     title_words = re.findall(r"\b[a-zA-Z]{3,}\b", title.lower()) if title else []
     first_word = title_words[0] if title_words else "title"
 
-    first_author = re.sub(r"[^a-z0-9]", "", first_author)
-    first_word = re.sub(r"[^a-z0-9]", "", first_word)
+    first_author = re.sub(r"[^a-z0-9]", "", first_author) or "author"
+    first_word = re.sub(r"[^a-z0-9]", "", first_word) or "title"
 
     citation_key = f"{first_author}-{year_str}-{first_word}"
     return citation_key
+
+
+def _disambiguation_suffix(occurrence: int) -> str:
+    suffix = ""
+    while occurrence > 0:
+        occurrence, remainder = divmod(occurrence - 1, 26)
+        suffix = chr(ord("a") + remainder) + suffix
+    return suffix
+
+
+def _extract_year(published_date) -> str | None:
+    if not published_date:
+        return None
+    year_match = re.match(r"(\d{4})", str(published_date).strip())
+    return year_match.group(1) if year_match else None
+
+
+def _validate_research_study(
+    ref: ResearchStudy, title: str, authors: list[str], year: str | None
+) -> list[str]:
+    """Return human-readable descriptions of every inconsistency found.
+
+    Detection is deliberately limited to what can be checked from the record
+    itself; no network lookups are performed here.
+    """
+    problems: list[str] = []
+    meta_data = ref.meta_data
+
+    if year:
+        current_year = datetime.now().year
+        year_value = int(year)
+        if year_value < _EARLIEST_PLAUSIBLE_YEAR or year_value > current_year + 1:
+            problems.append(f"implausible publication year {year!r}")
+    elif meta_data.published_date:
+        problems.append(
+            f"published_date {meta_data.published_date!r} has no parsable year"
+        )
+
+    arxiv_id = meta_data.arxiv_id
+    if arxiv_id:
+        normalized_arxiv_id = _normalize_arxiv_id(arxiv_id)
+        for field_name, raw_value, pattern in (
+            ("pdf_url", meta_data.pdf_url, _ARXIV_ID_IN_URL_PATTERN),
+            ("doi", meta_data.doi, _ARXIV_ID_IN_DOI_PATTERN),
+        ):
+            if not raw_value:
+                continue
+            match = pattern.search(raw_value.strip())
+            if match and _normalize_arxiv_id(match.group(1)) != normalized_arxiv_id:
+                problems.append(
+                    f"arxiv_id {arxiv_id!r} disagrees with {field_name} {raw_value!r} "
+                    "(the record may merge two different papers)"
+                )
+
+    if meta_data.doi and not _DOI_PATTERN.match(meta_data.doi.strip()):
+        problems.append(f"doi {meta_data.doi!r} is not a well-formed DOI")
+
+    if meta_data.github_url and "github.com" not in meta_data.github_url.lower():
+        problems.append(f"github_url {meta_data.github_url!r} is not a GitHub URL")
+
+    if meta_data.authors and not authors:
+        problems.append("every author entry is blank")
+
+    if not title:
+        problems.append("title is empty")
+    elif not authors and not year:
+        problems.append("neither authors nor a publication year are available")
+
+    return problems
+
+
+def _is_emittable(title: str, authors: list[str], year: str | None) -> bool:
+    # A BibTeX entry without a title, or with neither author nor year, is
+    # rejected by most styles and can break the whole bibliography, so such a
+    # record is dropped rather than emitted.
+    return bool(title) and bool(authors or year)
 
 
 def generate_bibfile(
@@ -35,30 +138,60 @@ def generate_bibfile(
     if not research_study_list:
         return ""
 
-    seen_citation_keys = set()
+    seen_citation_keys: dict[str, str] = {}
     db_research = BibDatabase()
 
     for i, ref in enumerate(research_study_list):
         entry = _generate_bibfile_entry(ref, i)
-        citation_key = entry["ID"]
-        if citation_key not in seen_citation_keys:
-            db_research.entries.append(entry)
-            seen_citation_keys.add(citation_key)
+        if entry is None:
+            continue
+
+        base_key = entry["ID"]
+        title = entry.get("title", "")
+        if base_key in seen_citation_keys:
+            occurrence = 1
+            citation_key = f"{base_key}{_disambiguation_suffix(occurrence)}"
+            while citation_key in seen_citation_keys:
+                occurrence += 1
+                citation_key = f"{base_key}{_disambiguation_suffix(occurrence)}"
+            logger.warning(
+                f"Citation key collision on {base_key!r} between "
+                f"{seen_citation_keys[base_key]!r} and {title!r}; "
+                f"emitting the latter as {citation_key!r}."
+            )
+            entry["ID"] = citation_key
+        else:
+            citation_key = base_key
+
+        db_research.entries.append(entry)
+        seen_citation_keys[citation_key] = title
 
     return bibtexparser.dumps(db_research).strip()
 
 
-def _generate_bibfile_entry(ref: ResearchStudy, index: int) -> dict:
+def _generate_bibfile_entry(ref: ResearchStudy, index: int) -> dict | None:
     meta_data = ref.meta_data
 
-    title = ref.title or f"ref{index}"
-    authors = meta_data.authors or []
+    title = (ref.title or "").strip()
+    authors = [a.strip() for a in (meta_data.authors or []) if a and a.strip()]
     published_date = meta_data.published_date if meta_data is not None else None
 
-    year = None
-    if published_date:
-        year_match = re.match(r"(\d{4})", str(published_date))
-        year = year_match.group(1) if year_match else None
+    year = _extract_year(published_date)
+
+    problems = _validate_research_study(ref, title, authors, year)
+    study_label = title or f"<untitled study at index {index}>"
+    if problems:
+        logger.warning(
+            f"Inconsistent bibliography record for {study_label!r}: "
+            f"{'; '.join(problems)}."
+        )
+
+    if not _is_emittable(title, authors, year):
+        logger.warning(
+            f"Skipping bibliography entry for {study_label!r}: the record would "
+            "produce a malformed BibTeX entry."
+        )
+        return None
 
     citation_key = _generate_citation_key(title, authors, year)
 
@@ -67,14 +200,10 @@ def _generate_bibfile_entry(ref: ResearchStudy, index: int) -> dict:
         "ENTRYTYPE": "article",  # Default to article, could be made configurable
     }
 
-    if title:
-        entry["title"] = title
+    entry["title"] = title
 
     if authors:
-        if isinstance(authors, list):
-            entry["author"] = " and ".join(authors)
-        else:
-            entry["author"] = str(authors)
+        entry["author"] = " and ".join(authors)
 
     if year:
         entry["year"] = str(year)

--- a/backend/src/airas/usecases/writers/write_subgraph/nodes/generate_note.py
+++ b/backend/src/airas/usecases/writers/write_subgraph/nodes/generate_note.py
@@ -63,7 +63,7 @@ def _resolve_citation_key(title: str, bib_map: dict[str, str]) -> Optional[str]:
     return bib_map.get(_normalize(title)) or bib_map.get(_normalize(_main_title(title)))
 
 
-def _map_studies_to_bibtex(
+def map_studies_to_bibtex(
     research_study_list: list[ResearchStudy], references_bib: str
 ) -> list[dict[str, Any]]:
     bib_map = _build_bib_map(parse_bibtex_to_dict(references_bib))
@@ -90,15 +90,14 @@ def _map_studies_to_bibtex(
     return mapped
 
 
-def unmatched_citation_titles(
-    research_study_list: list[ResearchStudy], references_bib: str
-) -> list[str]:
-    """Studies the note will instruct the writer not to cite."""
-    return [
-        study["title"]
-        for study in _map_studies_to_bibtex(research_study_list, references_bib)
-        if not study["citation_key"]
-    ]
+def unmatched_citation_titles(mapped_studies: list[dict[str, Any]]) -> list[str]:
+    """Studies the note will instruct the writer not to cite.
+
+    Takes an already-built mapping rather than rebuilding one, so a caller
+    that also needs the note parses the bibliography once and logs the
+    mismatch once.
+    """
+    return [study["title"] for study in mapped_studies if not study["citation_key"]]
 
 
 def generate_note(
@@ -107,8 +106,10 @@ def generate_note(
     experiment_code: ExperimentCode,
     research_study_list: list[ResearchStudy],
     references_bib: str,
+    mapped_studies: list[dict[str, Any]] | None = None,
 ) -> str:
-    mapped_studies = _map_studies_to_bibtex(research_study_list, references_bib)
+    if mapped_studies is None:
+        mapped_studies = map_studies_to_bibtex(research_study_list, references_bib)
 
     # Find the final cycle (complete) for main results
     final_cycle = next(

--- a/backend/src/airas/usecases/writers/write_subgraph/nodes/generate_note.py
+++ b/backend/src/airas/usecases/writers/write_subgraph/nodes/generate_note.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import re
-from typing import Any
+from typing import Any, Optional
 
 from jinja2 import Template
 
@@ -25,25 +25,79 @@ def _normalize(text: str) -> str:
     return _NORMALIZE_RE.sub("", text).lower()
 
 
+# A study whose title does not match a bib entry is rendered as "do not
+# cite", so the same paper titled one way in the bib and another way in the
+# study drops a citation from the finished paper without a word. The one
+# mismatch worth resolving is the dropped subtitle — "DiffDock" for
+# "DiffDock: Diffusion Steps, Twists, and Turns for Molecular Docking" —
+# because "Name: what it does" is how these titles are written. Matching on
+# anything looser would cite the wrong paper, which is worse than not
+# citing it, so the short form has to name exactly one entry.
+_MIN_ALIAS_LENGTH = 4
+
+
+def _main_title(text: str) -> str:
+    return text.split(":", 1)[0]
+
+
+def _build_bib_map(parsed_references: dict[str, Any]) -> dict[str, str]:
+    """Normalized title (and unambiguous subtitle-free alias) -> citation key."""
+    bib_map: dict[str, str] = {}
+    aliases: dict[str, list[str]] = {}
+    for entry in parsed_references.values():
+        title, key = entry.get("title"), entry.get("ID")
+        if not title or not key:
+            continue
+        bib_map[_normalize(title)] = key
+        alias = _normalize(_main_title(title))
+        if len(alias) >= _MIN_ALIAS_LENGTH:
+            aliases.setdefault(alias, []).append(key)
+
+    for alias, keys in aliases.items():
+        if alias not in bib_map and len(set(keys)) == 1:
+            bib_map[alias] = keys[0]
+    return bib_map
+
+
+def _resolve_citation_key(title: str, bib_map: dict[str, str]) -> Optional[str]:
+    return bib_map.get(_normalize(title)) or bib_map.get(_normalize(_main_title(title)))
+
+
 def _map_studies_to_bibtex(
     research_study_list: list[ResearchStudy], references_bib: str
 ) -> list[dict[str, Any]]:
-    parsed_references = parse_bibtex_to_dict(references_bib)
+    bib_map = _build_bib_map(parse_bibtex_to_dict(references_bib))
 
-    # { normalized_title: citation_key }
-    bib_map = {
-        _normalize(entry.get("title", "")): entry.get("ID")
-        for entry in parsed_references.values()
-        if entry.get("title") and entry.get("ID")
-    }
-
-    return [
+    mapped = [
         {
             "title": study.title,
-            "citation_key": bib_map.get(_normalize(study.title)),
+            "citation_key": _resolve_citation_key(study.title, bib_map),
             "content": study.llm_extracted_info,
         }
         for study in research_study_list
+    ]
+
+    unmatched = [study["title"] for study in mapped if not study["citation_key"]]
+    if unmatched:
+        logger.warning(
+            "%d of %d studies have no matching entry in references.bib and "
+            "will be marked 'do not cite': %s. Pass generate_bibfile's output "
+            "verbatim as references_bib rather than a shortened version.",
+            len(unmatched),
+            len(mapped),
+            "; ".join(unmatched),
+        )
+    return mapped
+
+
+def unmatched_citation_titles(
+    research_study_list: list[ResearchStudy], references_bib: str
+) -> list[str]:
+    """Studies the note will instruct the writer not to cite."""
+    return [
+        study["title"]
+        for study in _map_studies_to_bibtex(research_study_list, references_bib)
+        if not study["citation_key"]
     ]
 
 

--- a/backend/tests/unit/dashboard/test_launcher_startup_wait.py
+++ b/backend/tests/unit/dashboard/test_launcher_startup_wait.py
@@ -1,0 +1,72 @@
+"""A slow start is not a failed start, and must not be killed like one.
+
+Two runs of `open_in_overleaf` failed with "Dashboard did not become
+healthy within 30.0s" while the log showed `Application startup complete`
+and `Uvicorn running on ...` for both. The server had started; the health
+check simply had not caught up, and the timeout then terminated it — so
+the next attempt paid the whole cold start again.
+"""
+
+import inspect
+
+import pytest
+
+from airas.dashboard import launcher
+
+
+class FakeProcess:
+    def __init__(self, pid: int = 4242, returncode: int | None = None):
+        self.pid = pid
+        self.returncode = returncode
+        self.terminated = False
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+
+
+@pytest.fixture
+def spawned(monkeypatch, tmp_path):
+    process = FakeProcess()
+    monkeypatch.setattr(launcher, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(launcher, "PID_FILE", tmp_path / "dashboard.json")
+    monkeypatch.setattr(launcher, "LOG_FILE", tmp_path / "dashboard.log")
+    monkeypatch.setattr(launcher.subprocess, "Popen", lambda *a, **k: process)
+    monkeypatch.setattr(launcher.time, "sleep", lambda _: None)
+    return process
+
+
+def test_a_process_that_is_still_starting_is_left_alone(spawned, monkeypatch):
+    monkeypatch.setattr(launcher, "is_dashboard_running", lambda port: False)
+
+    with pytest.raises(RuntimeError, match="still starting"):
+        launcher.start_dashboard(port=24727, timeout=0.01)
+
+    assert not spawned.terminated
+    # The pid file survives, so the next call finds this process instead of
+    # spawning a second one.
+    assert launcher.PID_FILE.is_file()
+
+
+def test_a_process_that_died_is_cleaned_up(spawned, monkeypatch):
+    spawned.returncode = 1
+    monkeypatch.setattr(launcher, "is_dashboard_running", lambda port: False)
+
+    with pytest.raises(RuntimeError, match="exited with code 1"):
+        launcher.start_dashboard(port=24727, timeout=0.01)
+
+    assert not launcher.PID_FILE.is_file()
+
+
+def test_a_healthy_start_returns_the_pid(spawned, monkeypatch):
+    monkeypatch.setattr(launcher, "is_dashboard_running", lambda port: True)
+
+    assert launcher.start_dashboard(port=24727, timeout=0.01) == spawned.pid
+
+
+def test_the_wait_is_long_enough_for_a_cold_start():
+    default = inspect.signature(launcher.start_dashboard).parameters["timeout"].default
+
+    assert default >= 60, "30s was not enough for an observed cold start"

--- a/backend/tests/unit/mcp/test_analysis_and_citation_gaps.py
+++ b/backend/tests/unit/mcp/test_analysis_and_citation_gaps.py
@@ -1,0 +1,121 @@
+"""Two ways the paper pipeline used to lose content without saying so.
+
+The analysis prompt rendered nothing at all when `experimental_results`
+carried no `metrics_data` — the outer `if` was true, so it did not even
+fall through to "No experimental results available yet", and the analyst
+was left writing a results section with no results in front of it. The
+paper prompt marks any study whose title misses `references.bib` as "do
+not cite", and told nobody, so citations vanished from the finished paper.
+"""
+
+from airas.core.types.research_hypothesis import ResearchHypothesis
+from airas.core.types.research_study import ResearchStudy
+from airas.mcp.prompt_registry import build_generation_prompt
+from airas.usecases.writers.write_subgraph.nodes.generate_note import (
+    unmatched_citation_titles,
+)
+
+HYPOTHESIS = ResearchHypothesis(
+    open_problems="Aggregation hides per-system failure.",
+    method="Report the components separately.",
+    experimental_setup="150 systems.",
+    primary_metric="lddt_pli",
+    supporting_metrics=["pb_valid"],
+    expected_result="The aggregate and the components disagree.",
+    expected_conclusion="Aggregate scores are not sufficient.",
+)
+
+DESIGN = {
+    "proposed_method": {
+        "method_name": "Component-wise reporting",
+        "description": "Report lDDT-PLI, PB-valid and coverage separately.",
+    }
+}
+
+BIB = """
+@article{diffdock2023,
+  title  = {DiffDock: Diffusion Steps, Twists, and Turns for Molecular Docking},
+  author = {Corso, Gabriele},
+  year   = {2023}
+}
+"""
+
+
+def _analysis_prompt(experimental_results: dict) -> str:
+    return build_generation_prompt(
+        "experiment_analysis",
+        {
+            "research_hypothesis": HYPOTHESIS.model_dump(),
+            "experimental_design": DESIGN,
+            "experiment_code": {"files": {"src/main.py": "print()"}},
+            "experimental_results": experimental_results,
+        },
+    )["prompt"]
+
+
+def test_results_without_metrics_data_say_so_instead_of_rendering_nothing():
+    prompt = _analysis_prompt({"stdout": "lddt_pli mean 0.648"})
+
+    assert "NONE PROVIDED" in prompt
+    assert "Do not invent" in prompt
+    # Whatever *was* passed still has to reach the analyst.
+    assert "lddt_pli mean 0.648" in prompt
+
+
+def test_metrics_data_is_rendered_when_present():
+    prompt = _analysis_prompt({"metrics_data": {"run-1": {"lddt_pli": 0.648}}})
+
+    assert "0.648" in prompt
+    assert "NONE PROVIDED" not in prompt
+
+
+def test_expected_result_reaches_the_prompt_that_asks_about_it():
+    prompt = _analysis_prompt({"metrics_data": {"run-1": {}}})
+
+    # Instruction 4 asks whether the results match the hypothesis; without
+    # the expectation there is nothing to compare them against.
+    assert "consistent with the research hypothesis" in prompt
+    assert "The aggregate and the components disagree." in prompt
+
+
+def test_a_shortened_title_still_finds_its_citation_key():
+    unmatched = unmatched_citation_titles([ResearchStudy(title="DiffDock")], BIB)
+
+    assert unmatched == []
+
+
+def test_a_study_missing_from_the_bibliography_is_reported():
+    studies = [ResearchStudy(title="PoseBusters"), ResearchStudy(title="DiffDock")]
+
+    assert unmatched_citation_titles(studies, BIB) == ["PoseBusters"]
+
+
+def test_the_paper_prompt_warns_about_studies_it_will_not_cite():
+    result = build_generation_prompt(
+        "paper_writing",
+        {
+            "research_hypothesis": HYPOTHESIS.model_dump(),
+            "experiment_history": {"cycles": []},
+            "experiment_code": {"files": {"src/main.py": "print()"}},
+            "research_study_list": [{"title": "PoseBusters"}],
+            "references_bib": BIB,
+        },
+    )
+
+    assert "Do not cite" in result["prompt"]
+    assert "PoseBusters" in result["warnings"][0]
+
+
+def test_no_warning_when_every_study_is_citable():
+    result = build_generation_prompt(
+        "paper_writing",
+        {
+            "research_hypothesis": HYPOTHESIS.model_dump(),
+            "experiment_history": {"cycles": []},
+            "experiment_code": {"files": {"src/main.py": "print()"}},
+            "research_study_list": [{"title": "DiffDock"}],
+            "references_bib": BIB,
+        },
+    )
+
+    assert "warnings" not in result

--- a/backend/tests/unit/mcp/test_analysis_and_citation_gaps.py
+++ b/backend/tests/unit/mcp/test_analysis_and_citation_gaps.py
@@ -12,6 +12,7 @@ from airas.core.types.research_hypothesis import ResearchHypothesis
 from airas.core.types.research_study import ResearchStudy
 from airas.mcp.prompt_registry import build_generation_prompt
 from airas.usecases.writers.write_subgraph.nodes.generate_note import (
+    map_studies_to_bibtex,
     unmatched_citation_titles,
 )
 
@@ -79,7 +80,9 @@ def test_expected_result_reaches_the_prompt_that_asks_about_it():
 
 
 def test_a_shortened_title_still_finds_its_citation_key():
-    unmatched = unmatched_citation_titles([ResearchStudy(title="DiffDock")], BIB)
+    unmatched = unmatched_citation_titles(
+        map_studies_to_bibtex([ResearchStudy(title="DiffDock")], BIB)
+    )
 
     assert unmatched == []
 
@@ -87,7 +90,9 @@ def test_a_shortened_title_still_finds_its_citation_key():
 def test_a_study_missing_from_the_bibliography_is_reported():
     studies = [ResearchStudy(title="PoseBusters"), ResearchStudy(title="DiffDock")]
 
-    assert unmatched_citation_titles(studies, BIB) == ["PoseBusters"]
+    assert unmatched_citation_titles(map_studies_to_bibtex(studies, BIB)) == [
+        "PoseBusters"
+    ]
 
 
 def test_the_paper_prompt_warns_about_studies_it_will_not_cite():
@@ -119,3 +124,20 @@ def test_no_warning_when_every_study_is_citable():
     )
 
     assert "warnings" not in result
+
+
+def test_a_long_run_log_does_not_take_over_the_prompt():
+    """A training run's stdout can dwarf everything else in the prompt.
+
+    The tail is what is kept rather than the head: a run prints its final
+    metrics at the end, and its dataset-download chatter at the start.
+    """
+    prompt = _analysis_prompt(
+        {
+            "metrics_data": {"run-1": {"lddt_pli": 0.648}},
+            "stdout": "downloading shard\n" * 5000 + "FINAL lddt_pli 0.648",
+        }
+    )
+
+    assert "FINAL lddt_pli 0.648" in prompt
+    assert prompt.count("downloading shard") < 200

--- a/backend/tests/unit/usecases/executors/test_dispatch_required_env_vars.py
+++ b/backend/tests/unit/usecases/executors/test_dispatch_required_env_vars.py
@@ -1,0 +1,37 @@
+"""An experiment that does not use W&B must be able to say so.
+
+`required_env_vars` defaults to `["WANDB_API_KEY"]` and Seyval refuses to
+start a run whose declared vars are not registered. The subgraph took the
+argument but the MCP tool did not expose it, so there was no way to
+override it — the only way through was to register a dummy key for an
+experiment that never calls wandb.
+
+The distinction that matters is `[]` versus `None`: "nothing is required"
+has to be expressible, and must not collapse into "unspecified".
+"""
+
+import pytest
+
+from airas.usecases.executors.dispatch_experiment_on_seyval_subgraph.dispatch_experiment_on_seyval_subgraph import (
+    DispatchExperimentOnSeyvalSubgraph,
+)
+
+
+def _subgraph(**kwargs) -> DispatchExperimentOnSeyvalSubgraph:
+    return DispatchExperimentOnSeyvalSubgraph(seyval_client=object(), **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("supplied", "expected"),
+    [
+        (None, ["WANDB_API_KEY"]),
+        ([], []),
+        (["HF_TOKEN"], ["HF_TOKEN"]),
+    ],
+)
+def test_an_empty_list_is_not_the_same_as_unspecified(supplied, expected):
+    assert _subgraph(required_env_vars=supplied).required_env_vars == expected
+
+
+def test_the_default_is_applied_when_the_argument_is_omitted():
+    assert _subgraph().required_env_vars == ["WANDB_API_KEY"]

--- a/backend/tests/unit/usecases/github/test_prepare_repository_location.py
+++ b/backend/tests/unit/usecases/github/test_prepare_repository_location.py
@@ -1,0 +1,42 @@
+"""The caller is told to clone the repository, so it has to be told where.
+
+`prepare_repository` returned `{"is_repository_ready": ..., "is_branch_ready":
+...}` and nothing else — no URL, no clone command — while the next step in
+every flow is `git clone`. The location had to be reassembled from the
+owner and name that were passed in.
+"""
+
+from airas.core.types.github import GitHubConfig
+from airas.usecases.github.prepare_repository_subgraph.prepare_repository_subgraph import (
+    PrepareRepositorySubgraph,
+)
+
+GITHUB_CONFIG = GitHubConfig(
+    github_owner="airas-org",
+    repository_name="experiment-repo",
+    branch_name="main",
+)
+
+
+def _finalize(**state) -> dict:
+    subgraph = PrepareRepositorySubgraph.__new__(PrepareRepositorySubgraph)
+    return subgraph._finalize_state({"github_config": GITHUB_CONFIG, **state})
+
+
+def test_the_repository_location_is_returned():
+    result = _finalize(is_repository_from_template=True, is_branch_created=True)
+
+    assert result["clone_url"] == "https://github.com/airas-org/experiment-repo.git"
+    assert result["html_url"] == "https://github.com/airas-org/experiment-repo"
+
+
+def test_readiness_is_still_reported():
+    ready = _finalize(is_repository_from_template=True, is_branch_already_exists=True)
+    assert ready["is_repository_ready"] and ready["is_branch_ready"]
+
+    unprepared = _finalize()
+    assert not unprepared["is_repository_ready"]
+    assert not unprepared["is_branch_ready"]
+    # The location is reported either way; it is where the repository would
+    # be, not a claim that it is ready.
+    assert unprepared["clone_url"].endswith("experiment-repo.git")


### PR DESCRIPTION
## 背景と目的

無停止運転で**成功として報告される失敗**が 4 つあります。いずれも例外にならず、戻り値も正常なので、後段の誰も気付きません。

- **`analyze_experiment` が実験結果を黙って捨てます。** `metrics_data` キーを持たない dict を渡すと、外側の条件が真なので `No experimental results available yet` にも落ちず、`# Experimental Results` 節が**完全に空**になります
  - 「渡し忘れた」より「渡したが形が違う」方が静かに壊れる、という最悪の形です
  - 影響は、**数値がゼロ件のまま「実験結果の分析レポート」を書かされる**ことです。LLM はプロンプトに結果が無いことに気付かず、もっともらしい分析を書きます
  - 同じプロンプトの `# Research Hypothesis` 節は `method` しか描画しません。指示 4 が「仮説と整合しているか評価せよ」と求めているのに、**比較対象である `expected_result` がプロンプトに載っていません**

- **`paper_writing` が引用を黙って落とします。** `references_bib` とタイトルが一致しない study は `*(No Citation Key - Do not cite)*` と記され、実測で 10 本中 4 本がこれに該当しました（PoseBusters / Masters / DiffDock / AlphaFold3）
  - 原因はこちらが bib のタイトルを短縮していたことですが、**ズレたときに警告が出ず「引用するな」と指示されるだけ**なので、自動運転では引用が 4 本消えたまま論文が完成します

- **`generate_bibfile` が引用キーの衝突時にエントリを捨てます。** 同じ姓・同じ年の文献が 2 本あると片方が消えます

- **`upload_research_history` / dashboard 起動 / 実験実行の取り回し**にも、成功に見える失敗や回避不能な制約があります
  - `prepare_repository` の戻り値は `{"is_repository_ready", "is_branch_ready"}` だけで、**URL もクローンコマンドもありません**。どのフローも次の手順は clone なのに、場所は自分で組み立てるしかありませんでした
  - `dispatch_experiment` に `required_env_vars` を渡す手段がなく（subgraph は引数を持つのに MCP 側が公開していない）、**W&B を使わない実験でも Seyval 側に鍵登録が必須**でした
  - `open_in_overleaf` が `Dashboard did not become healthy within 30.0s` で 2 回失敗しました。ところがログには**両方の試行で** `Application startup complete` と `Uvicorn running on ...` が出ています。起動には成功しており health check が間に合わなかっただけなのに、**タイムアウト後にプロセスごと落とされる**ので、次の試行が同じコールドスタートを繰り返します

加えて、生成プロンプト側に上記のうち 2 つを招いた前提があります。

- **仮説プロンプトが「ML 手法の損失関数いじり」に固定されています。** 本文は `You are a researcher in machine learning` で始まり、「既存手法の目的関数やコアアルゴリズムに最小限の変更を加えた新手法を提案せよ」と指示します。`research_topic` に何を入れてもこの型に押し込まれ、**評価指標の妥当性・データセット構築・システム論文は素直に書けません**
- **`primary_metric` が「標準的な指標名 1 つ」に固定**されています。GAP 計算のためですが、**多指標を併記しないと成立しない評価設計**と正面から衝突します
- **`experimental_code` が必須**です。リポジトリもデータもコードテンプレートも見ていない段階でコードを書かせる設計で、step 4 で書き直すため二度手間になり、かつ**後段の `paper_writing` が仮説を読むため、乖離するとメソッド節が誰も動かしていないコードを説明します**

## 変更内容

以下の機能が変更されました：

1. `analyze_experiment` プロンプトが、渡された実験結果と仮説を落とさないよう修正
2. `paper_writing` が引用しない study を呼び出し側に報告し、サブタイトル落ちを解決するよう修正
3. `generate_bibfile` の引用キー衝突を、破棄ではなく曖昧性解消で扱うよう修正
4. 仮説・実験計画プロンプトの分野固定と必須項目の見直し
5. `prepare_repository` / `dispatch_experiment` / dashboard 起動の取り回し修正

実装の詳細は以下の通りです：

<details>
<summary><code>1. analyze_experiment プロンプトが結果と仮説を落とさないようにする</code></summary>

**実装概要**

- **`# Experimental Results` 節**
  - `metrics_data` が無い場合に、空ではなく **`NONE PROVIDED. ... Do not invent any`** を明示的に出します。「数値が無い」ことがプロンプト上で見えるので、捏造ではなく「利用不可」と書かせられます
  - あわせて `result_figures` / `diagram_figures` / `stdout` / `stderr` も描画します。**渡したものが握り潰されない**ようになりました

- **`# Research Hypothesis` 節**
  - `method` のみから `open_problems` / `primary_metric` / `supporting_metrics` / **`expected_result`** / `expected_conclusion` まで拡張しました
  - 指示 4「仮説と整合しているか評価せよ」に対する比較対象がプロンプトに載ります

</details>

<details>
<summary><code>2. 引用が黙って消えないようにする</code></summary>

**実装概要**

- **サブタイトル落ちの解決**（`generate_note.py`）
  - `DiffDock` ⇄ `DiffDock: Diffusion Steps, Twists, and Turns for Molecular Docking` のように、コロン以前が一致する場合を解決します
  - **ちょうど 1 件を指すときだけ**マッチさせます。緩く当てると別論文を引用してしまい、**引用が消えるより悪い結果**になるためです
  - 前方一致ではなく「コロンで切った主題」を別名として持つ形にしています。`Name: what it does` はこの種のタイトルの実際の書式なので、任意の前方一致より根拠があります

- **不一致の報告**
  - `logger.warning` で件数とタイトルを出します
  - さらに **`get_generation_prompt("paper_writing", ...)` の戻り値に `warnings` を追加**しました。**ログは無停止運転では誰も見ないので、呼び出し側に返るのが本質的な修正**です

- **引用キーの衝突**（`generate_bibfile.py`）
  - 従来は衝突したエントリを黙って捨てていました。`a` / `b` / `c` の接尾辞で曖昧性を解消します
  - あわせて `"Vaswani, Ashish"` 形式の著者姓の抽出と arXiv ID の正規化を修正しました

</details>

<details>
<summary><code>3. 生成プロンプトの前提を外す</code></summary>

**実装概要**

- **仮説プロンプト**（`generate_simple_hypothesis_prompt.py`）
  - ML / 損失関数の決め打ちを除去しました。「正則化項の追加・損失関数の変更・重み付け機構の導入」という例示を落とし、評価手法・データセット構築・システム論文も同じ型で書けるようにしています

- **`ResearchHypothesis`**
  - `supporting_metrics: list[str]` を追加。GAP 計算は `primary_metric` ひとつのままで、併記が要る指標は別枠で持てます（**決して集約しない**旨を field description に明記）
  - `experimental_code` を必須から `str = ""` に変更。プロンプト側も「リポジトリもデータも見る前のスケッチであり、実装が置き換える。不正確なら空の方がまし」と書き換えました

- **実験計画プロンプト**（`generate_experimental_design_prompt.py`）
  - `num_models_to_use=0` を渡しても「新しいモデルアーキテクチャそのものを提案する場合のみ空リストにせよ」と指示され、引数と指示文が矛盾していた点を修正
  - 注入される MODEL LIST / DATASET LIST が**言語モデル向けの既定値でしかない**ことを明記し、他分野では `retrieve_models` / `retrieve_datasets` で引いた候補を使うよう指示しました

</details>

<details>
<summary><code>4. 実行まわりの取り回し</code></summary>

**実装概要**

- **`prepare_repository`**: 戻り値に `html_url` と `clone_url` を追加しました。準備できていない場合も返します（「ここにあるはず」であって「準備完了」の主張ではありません）

- **`dispatch_experiment`**: `required_env_vars: list[str] | None = None` を追加し subgraph へ渡します
  - subgraph 側は `None` を既定 `["WANDB_API_KEY"]` に読み替えるため、**`[]` と `None` が区別されます**。「何も要らない」が「未指定」に潰れないことが要点です

- **`dashboard/launcher.py`**: health 待ちを 30s → 120s にし、**タイムアウトしてもプロセスを terminate しない**よう変更しました
  - PID ファイルも残すので、再呼び出しが同じプロセスを拾います（`dashboard_status: already_running`）
  - エラー文も「起動中なので再試行せよ」に変更しました

</details>

5. テスト:
   - `backend/tests/unit/mcp/test_analysis_and_citation_gaps.py`（新規・7 件）
     - `metrics_data` が無いときに空ではなく明示のメッセージが出ること、渡した `stdout` が届くこと
     - `expected_result` が、それを問う指示と同じプロンプトに載ること
     - 短縮タイトルが引用キーに解決されること、解決できない study が `warnings` に出ること
   - `backend/tests/unit/usecases/github/test_prepare_repository_location.py`（新規・2 件）
   - `backend/tests/unit/dashboard/test_launcher_startup_wait.py`（新規・4 件）
     - **起動中のプロセスを terminate しないこと**と PID ファイルが残ること、死んだプロセスは掃除されること、既定待ち時間が 60s 以上であること
   - `backend/tests/unit/usecases/executors/test_dispatch_required_env_vars.py`（新規・4 件）
     - **`[]` が「未指定」に潰れないこと**
