### PR TITLE
docs: align the skills with the tools, and typeset papers in Japanese

### DIFF
--- a/plugins/airas/skills/auto-research-claude-code/SKILL.md
+++ b/plugins/airas/skills/auto-research-claude-code/SKILL.md
@@ -165,8 +165,7 @@ shape from a validation error. The two that catch people out:
 
 - Long-running tools return immediately; never block waiting. Poll between
   other work.
-- All repository writes go through your local clone and git; there are no
-  file-upload tools.
+- Most repository writes go through your local clone and git; the exception is `upload_research_history`, which commits `.research/research_history.json` via an MCP tool. There are no general-purpose file-upload tools.
 - When a step fails, go back only as far as the failure requires: a failed
   experiment run means fixing code and re-dispatching (step 5), not
   re-deriving the hypothesis. Re-run a generation step only when its

--- a/plugins/airas/skills/auto-research-claude-code/SKILL.md
+++ b/plugins/airas/skills/auto-research-claude-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: auto-research-claude-code
-description: Run an end-to-end automated ML research project with the AIRAS MCP tools where Claude Code itself authors the generation steps (hypothesis, experimental design, analysis, paper) using AIRAS's curated prompts via get_generation_prompt — no LLM provider API key required. Use when the user wants automated research with AIRAS but no LLM provider key (OPENAI_API_KEY etc.) is configured, or when they want you to write the research artifacts yourself. If backend LLM keys are configured and preferred, use the auto-research skill instead.
+description: Run an end-to-end automated research project with the AIRAS MCP tools where Claude Code itself authors the generation steps (hypothesis, experimental design, analysis, paper) using AIRAS's curated prompts via get_generation_prompt — no LLM provider API key required. Use when the user wants automated research with AIRAS but no LLM provider key (OPENAI_API_KEY etc.) is configured, when they want you to write the research artifacts yourself, or as a fallback when the backend generation tools are configured but failing or unreliable (timeouts on long-reasoning models, retrieval returning empty studies) — get_generation_prompt uses the same curated prompts, so switching modes loses nothing but the automation. If backend LLM keys are configured and working, use the auto-research skill instead.
 ---
 
 # AIRAS automated research (Claude Code authoring mode)
@@ -19,6 +19,7 @@ For each generation step, call
 
 - `prompt` — AIRAS's curated prompt, fully rendered from your inputs
   (the same template the backend LLM would use)
+- `input_json_schema` — the exact shape of `inputs` for that step
 - `output_json_schema` — exactly the data format to produce
 - `flow` — how the output feeds the next step
 
@@ -26,24 +27,62 @@ Follow the prompt and produce the output **in one pass**, matching the
 schema. Steps: `research_queries`, `hypothesis`, `experimental_design`,
 `experiment_analysis`, `paper_writing`, `latex_conversion`.
 
+Several inputs have to be assembled by hand in this mode. Call
+`get_input_schema(step)` before you build one rather than discovering its
+shape from a validation error. The two that catch people out:
+
+- `research_study_list` entries are `ResearchStudy` objects, which share no
+  key names with `search_papers` rows: a row's `authors`, `citations` and
+  `arxiv_id` belong under `meta_data`. Only `title` is required, so
+  `{"title": ..., "abstract": ...}` is a valid study — you never have to
+  invent a full text for a paper you did not read.
+- `compute_environment` is an object, not a string. Include `arch`
+  (`x86_64` / `aarch64`) whenever you know it; it decides whether a
+  dependency has an installable wheel at all.
+
 ## Flow
 
 1. **Discover**: author queries via
    `get_generation_prompt("research_queries", ...)` → `search_papers`
    (no key needed) → read papers with `fetch_paper_fulltext` (no key
-   needed) and extract the study details yourself. (`retrieve_papers`
-   needs a backend LLM key — do its extraction yourself in this mode.)
+   needed) and extract the study details yourself. Pass **both** the `doi`
+   and the `pdf_url` from the `search_papers` row when it gave you both:
+   a DOI alone returns only the abstract for anything outside Semantic
+   Scholar's open-access index, bioRxiv included. Full texts run to tens of
+   thousands of characters, so keep `max_chars` at its default and raise it
+   only for a paper you must read in full. (`retrieve_papers` needs a
+   backend LLM key — do its extraction yourself in this mode.)
 2. **Hypothesize & design**: author via
    `get_generation_prompt("hypothesis", ...)` then
-   `get_generation_prompt("experimental_design", ...)` (ask the user
-   about the compute environment; `retrieve_models` / `retrieve_datasets`
-   list curated candidates, no key needed).
-3. **Set up the experiment repository**: `prepare_repository`, then clone
-   it locally with git.
+   `get_generation_prompt("experimental_design", ...)`. Establish the
+   compute environment before designing — ask the user if the target is not
+   already known, and record `arch` along with the GPU. `retrieve_models` /
+   `retrieve_datasets` list curated candidates (no key needed); the design
+   prompt's built-in MODEL/DATASET lists are language-model defaults, so for
+   any other field pass the candidates you retrieved rather than following
+   those lists.
+3. **Set up the experiment repository**: `prepare_repository` — it returns
+   `clone_url` — then clone it locally with git. Write the hypothesis and
+   the experimental design to `.research/research_history.json` and push
+   before generating any code: the repository's own code-generation
+   workflows read the research context from that file, and it ships empty.
+   `upload_research_history` does this against the pushed branch.
 4. **Write the experiment code yourself** in the clone. Read its
-   `AGENTS.md` first — it defines the contract (allowed files, CLI shape,
-   `sanity` / `pilot` / `full` modes, validation verdict lines, W&B
-   conventions). For library-specific guidance (fine-tuning frameworks,
+   `AGENTS.md` first — it is the contract the runners hold you to, and it
+   is more specific than anything here: which files you may touch, the
+   exact CLI invocations, what each of `sanity` / `pilot` / `full` must
+   scale to, the machine-parsed `SANITY_VALIDATION: PASS` /
+   `PILOT_VALIDATION` verdict lines, the run-id naming rule, the W&B
+   namespaces, and what `src/evaluate.py` must write. The shape it fixes:
+
+   ```
+   uv run python -u -m src.main run={run_id} results_dir=.research/results mode={mode}
+   ```
+
+   The template ships `src/*.py` empty and a `pyproject.toml` that is a
+   single comment, so `uv sync` does not work until you write a real one —
+   budget for that before the first run.
+   For library-specific guidance (fine-tuning frameworks,
    distributed training, inference), `get_library_docs` (no key needed)
    returns each library's official docs and `llms.txt` endpoints — fetch
    those for current API usage instead of relying on memory. (The
@@ -52,11 +91,29 @@ schema. Steps: `research_queries`, `hypothesis`, `experimental_design`,
    `npx @orchestra-research/ai-research-skills`.) Run
    `mode=sanity` locally until it prints `SANITY_VALIDATION: PASS`, then
    commit and push.
+
+   Two things a local sanity run cannot tell you. It cannot catch an
+   architecture mismatch: if the target is arm64 and you are on x86, a
+   dependency can resolve locally and have no wheel for the target —
+   `--dry-run` resolving is not proof it installs, so check the wheels in
+   `uv.lock` against the target architecture. And the image is built from a
+   *regenerated* Dockerfile, not yours verbatim: instructions whose purpose
+   is legible survive, unexplained ones may be dropped, and undeclared
+   dependencies get invented unpinned. Comment *why* each Dockerfile
+   instruction is needed, pin dependencies in `pyproject.toml`, and commit
+   `uv.lock` — that leaves nothing to invent.
 5. **Run experiments**: `dispatch_experiment` (async;
    `backend="github_actions"` or `"seyval"` with a `compute_type`). Poll
    `get_workflow_runs` (GitHub Actions) or `get_experiment_run_status`
    (either backend; returns stdout/stderr tails for debugging). Fix code
-   locally and re-dispatch as needed.
+   locally and re-dispatch as needed. On Seyval, resolve the target with
+   `list_computes` rather than reusing an id from an earlier session — ids
+   are scoped per environment and workspace — and note that omitting
+   `compute_id` sends the run to Seyval-managed compute rather than a BYO
+   cluster. Results stay on Seyval's side, so `import_run_outputs` has to
+   run before `fetch_experiment_results`, which reads the repository. If
+   the experiment does not use Weights & Biases, pass `required_env_vars=[]`
+   rather than registering a dummy `WANDB_API_KEY`.
 6. **Analyze**: `fetch_experiment_results`, then author the analysis via
    `get_generation_prompt("experiment_analysis", ...)` (pass the code
    from your clone as `{"files": {"<path>": "<content>"}}`).
@@ -64,16 +121,29 @@ schema. Steps: `research_queries`, `hypothesis`, `experimental_design`,
 8. **Write the paper**: `generate_bibfile` (no key needed) → author via
    `get_generation_prompt("paper_writing", ...)` → convert via
    `get_generation_prompt("latex_conversion", ...)`, embed into
-   `template.tex` as its flow describes, save as
-   `.research/latex/{template}/main.tex` in the clone and push with git.
-9. **Publish**: use `open_in_overleaf` — it returns a link that creates an
-   editable Overleaf project (pass `local_path` to export the local
-   working tree without pushing; no GitHub token needed for that variant).
-   In this mode Overleaf is the primary exit: `compile_latex` runs a
-   LaTeX-fixing agent on GitHub Actions that requires an
-   `ANTHROPIC_API_KEY` repository secret, which key-free setups don't
-   have. Only suggest `compile_latex` if the user has set that secret.
-10. **Persist**: `upload_research_history` saves the state;
+   `template.tex` as its flow describes, and save **two** files in the
+   clone: the LaTeX as `.research/latex/{template}/main.tex`, and the
+   bibliography from `generate_bibfile` as
+   `.research/latex/{template}/references.bib`. The template ships a
+   `references.bib` containing one placeholder entry, so skipping the
+   second file makes every `\cite` render as `?`. Push both with git.
+9. **Verify before publishing**: `verify_latex` (pass `local_path` to check
+   the working tree with no push and no keys). It compiles the paper and
+   reports `ok`, `page_count`, `undefined_citations`, `undefined_references`
+   and `missing_figures`. Do not treat the paper as finished while `ok` is
+   false — a `?` citation and an absent figure both still produce a PDF, so
+   nothing else in the pipeline will notice them.
+10. **Publish**: use `open_in_overleaf` — it returns a link that creates an
+    editable Overleaf project (pass `local_path` to export the local
+    working tree without pushing; no GitHub token needed for that variant).
+    Overleaf is an **export**, not a loop: nothing reads a project back, and
+    each click creates a new one, so everything you want in the paper must
+    be right before this point. `compile_latex` runs a LaTeX-fixing agent on
+    GitHub Actions that requires an `ANTHROPIC_API_KEY` repository secret,
+    which key-free setups do not have; only suggest it if the user has set
+    that secret. It materializes the figures itself at build time, so they
+    only need to have been pushed.
+11. **Persist**: `upload_research_history` saves the state;
     `download_research_history` restores it in a later session.
 
 ## Figure conventions
@@ -84,14 +154,29 @@ schema. Steps: `research_queries`, `hypothesis`, `experimental_design`,
 - Method diagrams: write text notation (mermaid / graphviz / d2 / …) and
   `render_diagram` it to `.research/results/diagram/<name>.pdf`. Uses
   https://kroki.io by default; `KROKI_BASE_URL` switches to self-hosted.
-- Keep filenames unique, commit and push. `compile_latex` and
-  `open_in_overleaf` collect every PDF under `.research/results/` into the
-  paper's `images/` (structure preserved) — reference them in LaTeX as
-  `images/<path>`, e.g. `images/chart/loss.pdf`.
+- Commit and push. `compile_latex` and `open_in_overleaf` collect every PDF
+  under `.research/results/` into the paper's `images/` with the directory
+  structure preserved, and `fetch_experiment_results` reports figures by the
+  same relative path. Reference them in LaTeX as `images/<path>` — copy the
+  path you were given rather than reducing it to the bare filename, since
+  two runs can each produce `accuracy.pdf` and only the full path resolves.
 
-## Notes
+## Running unattended
 
 - Long-running tools return immediately; never block waiting. Poll between
   other work.
 - All repository writes go through your local clone and git; there are no
   file-upload tools.
+- When a step fails, go back only as far as the failure requires: a failed
+  experiment run means fixing code and re-dispatching (step 5), not
+  re-deriving the hypothesis. Re-run a generation step only when its
+  *inputs* changed.
+- Several tools report a problem instead of raising it, and those are the
+  ones that quietly produce a worthless paper. Check them rather than
+  assuming success: `search_papers` returns `search_errors` per source;
+  `fetch_paper_fulltext` returns `status` (`abstract_only` means you are
+  about to write about a paper you only skimmed) and `truncated`;
+  `verify_latex` returns `ok`.
+- Stop and ask the user when the research direction is genuinely
+  underdetermined, or when a step has failed the same way twice — repeating
+  it a third time rarely differs.

--- a/plugins/airas/skills/auto-research/SKILL.md
+++ b/plugins/airas/skills/auto-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: auto-research
-description: Run an end-to-end automated ML research project with the AIRAS MCP tools, using backend LLM API keys for the generation steps (hypothesis, experimental design, analysis, paper writing). Use when the user wants to start or continue automated research with AIRAS and LLM provider API keys (OPENAI_API_KEY etc.) are configured in ~/.airas/credentials.json. If no LLM provider key is available, use the auto-research-claude-code skill instead.
+description: Run an end-to-end automated research project with the AIRAS MCP tools, using backend LLM API keys for the generation steps (hypothesis, experimental design, analysis, paper writing). Use when the user wants to start or continue automated research with AIRAS and LLM provider API keys (OPENAI_API_KEY etc.) are configured in ~/.airas/credentials.json. If no LLM provider key is available, or the backend generation tools are configured but failing (timeouts, retrieval returning empty studies), use the auto-research-claude-code skill instead.
 ---
 
 # AIRAS automated research (backend-LLM mode)
@@ -21,42 +21,93 @@ You drive the research; AIRAS provides retrieval, curated generation steps
 ## Flow
 
 1. **Discover**: `generate_research_queries` → `search_papers` →
-   `retrieve_papers` (structured study data).
+   `retrieve_papers` (structured study data). `retrieve_papers` resolves
+   each title through an LLM web search, so check what came back: a study
+   whose `full_text` is empty and whose `llm_extracted_info` fields all read
+   `[Unavailable]` means resolution failed, and feeding it onward produces a
+   hypothesis with nothing behind it. When that happens, use
+   `fetch_paper_fulltext` with the identifiers `search_papers` gave you and
+   assemble the studies yourself.
 2. **Hypothesize & design**: `generate_hypothesis` →
    `generate_experimental_design` (pass `compute_environment` so the design
-   fits the hardware; `retrieve_models` / `retrieve_datasets` list curated
-   candidates).
-3. **Set up the experiment repository**: `prepare_repository`, then clone
-   it locally with git.
+   fits the hardware — include `arch`, which decides whether a dependency
+   has an installable wheel at all; `retrieve_models` / `retrieve_datasets`
+   list curated candidates).
+3. **Set up the experiment repository**: `prepare_repository` — it returns
+   `clone_url` — then clone it locally with git. Push the hypothesis and
+   experimental design to `.research/research_history.json` with
+   `upload_research_history` before generating any code: the repository's
+   own code-generation workflows read the research context from that file,
+   and it ships empty.
 4. **Write the experiment code yourself** in the clone. Read its
-   `AGENTS.md` first — it defines the contract (allowed files, CLI shape,
-   `sanity` / `pilot` / `full` modes, validation verdict lines, W&B
-   conventions). For library-specific guidance (fine-tuning frameworks,
-   distributed training, inference), `get_library_docs` returns each library's
-   official docs and `llms.txt` endpoints — fetch those for current API
-   usage instead of relying on memory. (The AI-Research-SKILLs library,
-   which the template's code-generation workflows install on their
+   `AGENTS.md` first — it is the contract the runners hold you to: which
+   files you may touch, the exact CLI invocations, what each of `sanity` /
+   `pilot` / `full` must scale to, the machine-parsed
+   `SANITY_VALIDATION: PASS` / `PILOT_VALIDATION` verdict lines, the
+   run-id naming rule, the W&B namespaces, and what `src/evaluate.py` must
+   write. The shape it fixes:
+
+   ```
+   uv run python -u -m src.main run={run_id} results_dir=.research/results mode={mode}
+   ```
+
+   The template ships `src/*.py` empty and a `pyproject.toml` that is a
+   single comment, so `uv sync` does not work until you write a real one.
+   For library-specific guidance (fine-tuning
+   frameworks, distributed training, inference), `get_library_docs` returns
+   each library's official docs and `llms.txt` endpoints — fetch those for
+   current API usage instead of relying on memory. (The AI-Research-SKILLs
+   library, which the template's code-generation workflows install on their
    runners, can also be installed locally:
    `npx @orchestra-research/ai-research-skills`.) Run
    `mode=sanity` locally until it prints `SANITY_VALIDATION: PASS`, then
    commit and push.
+
+   Two things a local sanity run cannot tell you. It cannot catch an
+   architecture mismatch: if the target is arm64 and you are on x86, a
+   dependency can resolve locally and have no wheel for the target —
+   `--dry-run` resolving is not proof it installs. And the image is built
+   from a *regenerated* Dockerfile, not yours verbatim: instructions whose
+   purpose is legible survive, unexplained ones may be dropped, and
+   undeclared dependencies get invented unpinned. Comment *why* each
+   Dockerfile instruction is needed, pin dependencies in `pyproject.toml`,
+   and commit `uv.lock`.
 5. **Run experiments**: `dispatch_experiment` (async;
    `backend="github_actions"` or `"seyval"` with a `compute_type`). Poll
    `get_workflow_runs` (GitHub Actions) or `get_experiment_run_status`
    (either backend; returns stdout/stderr tails for debugging). Fix code
-   locally and re-dispatch as needed.
+   locally and re-dispatch as needed. On Seyval, resolve the target with
+   `list_computes` rather than reusing an id from an earlier session — ids
+   are scoped per environment and workspace — and note that omitting
+   `compute_id` sends the run to Seyval-managed compute rather than a BYO
+   cluster. Results stay on Seyval's side, so `import_run_outputs` has to
+   run before `fetch_experiment_results`, which reads the repository. If
+   the experiment does not use Weights & Biases, pass `required_env_vars=[]`
+   rather than registering a dummy `WANDB_API_KEY`.
 6. **Analyze**: `fetch_experiment_results` → `analyze_experiment`
    (pass the experiment code from your clone as
    `{"files": {"<path>": "<content>"}}`).
 7. **Figures** (see conventions below).
 8. **Write the paper**: `generate_bibfile` → `generate_paper` →
-   `generate_latex`. Write the returned LaTeX to
-   `.research/latex/{template}/main.tex` in the clone and push with git.
-9. **Publish (two independent exits, use either or both)**:
-   `compile_latex` builds the PDF on GitHub Actions; `open_in_overleaf`
-   returns a link that creates an editable Overleaf project (pass
-   `local_path` to export the local working tree without pushing).
-10. **Persist**: `upload_research_history` saves the state;
+   `generate_latex`. Save **two** files in the clone: the returned LaTeX as
+   `.research/latex/{template}/main.tex`, and the bibliography from
+   `generate_bibfile` as `.research/latex/{template}/references.bib`. The
+   template ships a `references.bib` containing one placeholder entry, so
+   skipping the second file makes every `\cite` render as `?`. Push both
+   with git.
+9. **Verify before publishing**: `verify_latex` (pass `local_path` to check
+   the working tree without pushing). It compiles the paper and reports
+   `ok`, `page_count`, `undefined_citations`, `undefined_references` and
+   `missing_figures`. Do not treat the paper as finished while `ok` is
+   false — a `?` citation and an absent figure both still produce a PDF.
+10. **Publish (two independent exits, use either or both)**:
+    `compile_latex` builds the PDF on GitHub Actions — it materializes the
+    pushed figures itself, and its return value is a dispatch receipt
+    rather than a build result. `open_in_overleaf` returns a link that creates an editable
+    Overleaf project (pass `local_path` to export the local working tree
+    without pushing); it is an export, not a loop — nothing reads a project
+    back, and each click creates a new one.
+11. **Persist**: `upload_research_history` saves the state;
     `download_research_history` restores it in a later session.
 
 ## Figure conventions
@@ -67,10 +118,12 @@ You drive the research; AIRAS provides retrieval, curated generation steps
 - Method diagrams: write text notation (mermaid / graphviz / d2 / …) and
   `render_diagram` it to `.research/results/diagram/<name>.pdf`. Uses
   https://kroki.io by default; `KROKI_BASE_URL` switches to self-hosted.
-- Keep filenames unique, commit and push. `compile_latex` and
-  `open_in_overleaf` collect every PDF under `.research/results/` into the
-  paper's `images/` (structure preserved) — reference them in LaTeX as
-  `images/<path>`, e.g. `images/chart/loss.pdf`.
+- Commit and push. `compile_latex` and `open_in_overleaf` collect every PDF
+  under `.research/results/` into the paper's `images/` with the directory
+  structure preserved, and `fetch_experiment_results` reports figures by the
+  same relative path. Reference them in LaTeX as `images/<path>` — use the
+  path you were given rather than the bare filename, since two runs can each
+  produce `accuracy.pdf` and only the full path resolves.
 
 ## Notes
 
@@ -78,3 +131,9 @@ You drive the research; AIRAS provides retrieval, curated generation steps
   other work.
 - All repository writes go through your local clone and git; there are no
   file-upload tools.
+- Several tools report a problem instead of raising it, and those are the
+  ones that quietly produce a worthless paper. Check them rather than
+  assuming success: `search_papers` returns `search_errors` per source;
+  `retrieve_papers` returns `[Unavailable]` fields on failure;
+  `fetch_paper_fulltext` returns `status` and `truncated`; `verify_latex`
+  returns `ok`.

--- a/plugins/airas/skills/auto-research/SKILL.md
+++ b/plugins/airas/skills/auto-research/SKILL.md
@@ -129,8 +129,7 @@ You drive the research; AIRAS provides retrieval, curated generation steps
 
 - Long-running tools return immediately; never block waiting. Poll between
   other work.
-- All repository writes go through your local clone and git; there are no
-  file-upload tools.
+- Most repository writes go through your local clone and git; the exception is `upload_research_history`, which commits `.research/research_history.json` via an MCP tool. There are no general-purpose file-upload tools.
 - Several tools report a problem instead of raising it, and those are the
   ones that quietly produce a worthless paper. Check them rather than
   assuming success: `search_papers` returns `search_errors` per source;


### PR DESCRIPTION
## 背景と目的

一連の修正はいずれも**スキルが主張している内容そのもの**を変えました。ところがスキルは、それらを掘り当てた 2026-08-05 の実走当時のパイプラインを説明したままです。

さらに、実走で判明した**スキル自体の欠落**が残っています。

- **`references.bib` を push する手順がありません。** step 8 は `main.tex` の保存にしか言及していないため、テンプレート同梱のプレースホルダ 1 件が残り、**論文中の `\cite` が全て `?` になります**
- **コンパイル結果を検証する手順がありません。** フローは「push して Overleaf リンクを出す」で終わりです。PDF が出たか、図が出ているか、`?` が残っていないかを誰も見ません。人が PDF を開く前提の設計です
- **`.research/research_history.json` を誰も書きません。** リポジトリの `AGENTS.md` は冒頭で「これを最初に読め」と指示していますが、`prepare_repository` 直後のこのファイルは 0 バイトです。手順にも書く指示がありません
- **無停止運転の作法が「Poll between other work」以上に書かれていません。** 失敗時にどこまで自力で戻るかが未定義です
- **Seyval が `backend="seyval"` の一言だけ**で、compute の解決や `import_run_outputs` の必要性に触れていません

加えて、実装と食い違っている記述があります。

- 手で組むことが前提の入力（`research_study_list` / `compute_environment`）について、形の引き方に触れていません
- `fetch_paper_fulltext` を「`arxiv_id` / `doi` / `pdf_url` を渡す」と並列に書いているため、**doi を選ぶと中身の薄い abstract だけで論文を書き始めます**
- `compile_latex` について「図を配置しないので `prepare_images_for_latex` を先に回す必要がある」と書いていますが、**現在のテンプレートは compile 時に自前で構造保持コピーをします**（airas-template#15 で修正済み）

## 変更内容

以下の機能が変更されました：

1. 無停止運転で成立させるための手順を追加（`references.bib`、`verify_latex`、`research_history.json`、失敗時の戻り方）
2. 実装と食い違っていた記述の訂正
3. Seyval の最低限の契約を step 5 に追記

実装の詳細は以下の通りです：

<details>
<summary><code>1. 無停止運転で成立させるための手順</code></summary>

**実装概要**

- **step 3: `research_history.json` を先に書く**
  - 「hypothesis と experimental design を `.research/research_history.json` に書いて push してから、コードを生成せよ」を追加
  - リポジトリ側のコード生成ワークフローはこのファイルから研究文脈を読みますが、**空で出荷されます**。順序を逆にすると文脈なしでコードが生成されます

- **step 8: `references.bib` も保存する**
  - `main.tex` と `references.bib` の **2 ファイル**を保存して push、と明記
  - テンプレート同梱の bib はプレースホルダ 1 件なので、上書きしないと全ての `\cite` が `?` になります

- **step 9（新設）: `verify_latex` で検証する**
  - `ok` / `page_count` / `undefined_citations` / `undefined_references` / `missing_figures` を確認し、**`ok` が偽のうちは完成扱いにしない**
  - `?` の引用も欠けた図も **PDF は生成される**ので、ここを飛ばすと後段の誰も気付きません

- **「Running unattended」節（新設、`auto-research-claude-code`）**
  - **どこまで戻るか**: 実験の失敗はコードを直して再 dispatch（step 5）であって、仮説の再導出ではありません。生成ステップの再実行は**入力が変わったときだけ**
  - **黙って壊れるツールの一覧**: `search_papers` の `search_errors`、`fetch_paper_fulltext` の `status`（`abstract_only` は「斜め読みした論文について書こうとしている」の意）と `truncated`、`verify_latex` の `ok`
  - **同じ失敗を 2 回したら人に聞く**。3 回目が違う結果になることは稀です

</details>

<details>
<summary><code>2. 実装と食い違っていた記述の訂正</code></summary>

**実装概要**

- **入力の形の引き方**: `get_input_schema(step)` を、手で組む必要がある入力の直前に案内しました
  - **`research_study_list`**: `search_papers` の行とキー名がひとつも一致しません（`authors` / `citations` / `arxiv_id` は `meta_data` 側）。`title` だけが必須なので `{"title": ..., "abstract": ...}` が有効な study であることも明記し、**読んでいない論文の全文を捏造する必要がない**ことを示しました
  - **`compute_environment`**: 文字列ではなくオブジェクトであること、分かるなら必ず `arch` を入れること

- **`fetch_paper_fulltext`**: `search_papers` が `doi` と `pdf_url` の両方を返したなら**両方渡す**、と明記
  - doi だけでは Semantic Scholar の open-access インデックスに無い論文（bioRxiv 含む）で abstract しか返りません
  - `max_chars` は既定のままにし、全文が要る論文だけ引き上げる

- **`compile_latex`**: 「図を配置しない」という記述を撤回しました。現在は**ワークフローが構造保持で配置する**ので、push さえされていれば足ります

- **`prepare_repository`**: `clone_url` が返るのでそれを clone する、と修正

- **`dispatch_experiment`**: W&B を使わない実験では `required_env_vars=[]` を渡す（ダミーキーを登録しない）

- **step 4 の警告 2 つ**: ローカルの sanity run では分からないこと
  - **アーキテクチャ不一致**: `--dry-run` が解決できることは wheel が入る証明になりません。`uv.lock` の wheel を対象アーキと突き合わせること
  - **Dockerfile は再生成される**: 目的が読める命令は残り、理由の書かれていない命令は落とされ、宣言されていない依存はピン無しで捏造されます。だから why をコメントで書き、`pyproject.toml` でピンし、`uv.lock` をコミットする
  - あわせて、テンプレートは `src/*.py` が空で `pyproject.toml` がコメント 1 行なので **`uv sync` すら通らない**（airas-org/airas-template#24）ことを明記

- **Overleaf は export であって loop ではない**: 誰もプロジェクトを読み返さず、クリックごとに新規プロジェクトが作られます。**渡す前に全てが正しくなっている必要があります**

- **`AGENTS.md`**: テンプレートに実在するので参照を維持しています（airas-template#14 で追加済み）。CLI 契約・許可ファイル・3 モードの規模・`SANITY_VALIDATION` の判定行・run_id 命名・W&B 名前空間まで、ここに書き写すより網羅的です

</details>

<details>
<summary><code>3. Seyval の最低限の契約</code></summary>

**実装概要**

step 5 に、実走で踏んだ 3 点だけを直接書きました。

- **compute の解決は毎回 `list_computes` で行う。** BYO の ID は環境（prod/dev）とワークスペース単位でスコープされるため、**過去のセッションの ID を再利用しない**
- **`compute_id` を省略すると managed compute に飛ぶ。** BYO クラスタで回したいなら明示する
- **結果は Seyval 側に残る。** リポジトリを読む `fetch_experiment_results` の前に `import_run_outputs` が要る

</details>


---

## 追記: 研究成果物を日本語で出す

### 背景と目的

**成果物を確認する人が、その分野の専門家とは限りません。** タンパク質-リガンドのスコアリングのような話で、もっともらしい誤りをその場で見抜くのは、読んで理解できて初めて可能になります。

ところが**日本語で書いた時点で検証が機能しませんでした。** `verify_latex_build` は `pdflatex` を決め打ちで実行しますが、pdflatex は CJK を組めません。日本語を含む `main.tex` を渡すと **1 文字ごとに** `LaTeX Error: Unicode character` が出て、その文字は PDF から脱落します。

```
ok: False | compiled: True | pages: 1
errors: ['LaTeX Error: Unicode character は (U+306F)',
         'LaTeX Error: Unicode character じ (U+3058)', ...]
```

PDF 自体は出るので、**検証を挟まなければ本文が空のまま「成功」になります。**

### 変更内容

<details>
<summary><code>5. LaTeX エンジンを文書の内容から決定する</code></summary>

**実装概要**

`backend/src/airas/usecases/publication/nodes/verify_latex_build.py` に `select_engine()` を追加しました。

- **CJK（漢字・ひらがな・カタカナ・全角記号）を含めば `lualatex`、それ以外は `pdflatex`**
  - 引用符 `“ ”` やダッシュ `—` は CJK ではないので、欧文はこれまでどおり pdflatex

- **設定項目にせず、ソースから導出しました。** 選択を誤ったときの結果が「好みが違う」ではなく**本文の欠落**であり、しかも PDF は出てしまうためです。エンジンを宣言させる方式は、言語を変えたときに更新を忘れる箇所を 1 つ増やすだけになります

- **toolchain の確認をエンジン決定の後ろに移動**しました。従来は `pdflatex` の有無だけを見ていたので、日本語文書でも「ある」と判定して先へ進み、あとで失敗していました。lualatex が無い場合は何を入れればよいか（`texlive-luatex` / `texlive-lang-japanese`）を名指しします

**動作確認**: タイトル・著者・abstract・番号付き節・数式を含む日本語論文が 1 ページの PDF になり、テキスト抽出も正常であることを確認しました。和文フォント（IPAex）は上記パッケージに同梱されます。

</details>

<details>
<summary><code>6. スキルへの言語指示</code></summary>

**実装概要**

- **人が確認する成果物はすべて日本語**（仮説・実験計画・分析レポート・論文、PDF まで）
- **英語のままにするもの**: `primary_metric` / `supporting_metrics`（後段が GAP 計算のためにパースする）と BibTeX の引用キー。これらは散文ではなく識別子です
- **同梱テンプレート 3 種は使いません。** 英語会議用で CJK 非対応なので、`luatexja` のプリアンブルを自前で書きます

  ```latex
  \documentclass[11pt]{article}
  \usepackage{luatexja-fontspec}
  \setmainjfont{IPAexMincho}
  \setsansjfont{IPAexGothic}
  ```

- **`auto-research`（バックエンド LLM モード）では、プロンプトが英語で書かれているため自動では日本語になりません。** その旨を明記し、言語を自分で選べる authoring モードを案内しています

</details>

7. 追加テスト:
   - `test_verify_latex_build.py` に 3 件（計 11 件）
     - 日本語が `lualatex` を選ぶこと
     - **欧文の約物（`“ ”` / `—`）でエンジンが切り替わらないこと**
     - 日本語論文が実際にコンパイルされ `ok` になること（lualatex / luatexja が無い環境ではスキップ）

8. 補足:
   - 日本語テンプレートを `airas-template` に追加するかは別途。現状はプリアンブルをスキルに書く形で、追加なしに動きます
