### PR TITLE
fix: give a reasoning model long enough to finish

### DIFF
--- a/backend/src/airas/infra/litellm_client.py
+++ b/backend/src/airas/infra/litellm_client.py
@@ -54,7 +54,40 @@ PROVIDER_REQUIRED_ENV_VARS: dict[LLMProvider, list[str]] = {
 # another's host.
 LITELLM_OPENAI_COMPATIBLE_PREFIX = "hosted_vllm/"
 
+# litellm's own 600s default is too short for the reasoning models served over
+# the Rikyu endpoint. Measured on `rikyu/kimi-k3`: a single call spent ~194s
+# emitting its reasoning trace before the first answer token and ~284s in
+# total, and that was for a prompt far smaller than the ones the generation
+# subgraphs send. Queueing on the shared endpoint has separately been observed
+# to add ~2min before the first token. Below this bound the call is killed
+# mid-reasoning and the work is simply lost, so the default is generous;
+# set AIRAS_LLM_TIMEOUT (seconds) to tighten or loosen it per deployment.
+LLM_TIMEOUT_ENV = "AIRAS_LLM_TIMEOUT"
+DEFAULT_LLM_TIMEOUT_SECONDS = 1800.0
+
 # TODO: Define LLMParams
+
+
+def resolve_llm_timeout() -> float:
+    """Seconds to allow one LLM call, from AIRAS_LLM_TIMEOUT or the default."""
+    raw = os.getenv(LLM_TIMEOUT_ENV, "").strip()
+    if not raw:
+        return DEFAULT_LLM_TIMEOUT_SECONDS
+    try:
+        timeout = float(raw)
+    except ValueError:
+        logger.warning(
+            f"{LLM_TIMEOUT_ENV}={raw!r} is not a number; "
+            f"using {DEFAULT_LLM_TIMEOUT_SECONDS}s."
+        )
+        return DEFAULT_LLM_TIMEOUT_SECONDS
+    if timeout <= 0:
+        logger.warning(
+            f"{LLM_TIMEOUT_ENV}={raw!r} must be positive; "
+            f"using {DEFAULT_LLM_TIMEOUT_SECONDS}s."
+        )
+        return DEFAULT_LLM_TIMEOUT_SECONDS
+    return timeout
 
 
 class LiteLLMClient:
@@ -103,6 +136,8 @@ class LiteLLMClient:
         web_search: bool = False,
     ) -> str:
         litellm_kwargs = params.copy() if params else {}
+        # setdefault so an explicit per-call timeout in `params` still wins.
+        litellm_kwargs.setdefault("timeout", resolve_llm_timeout())
         messages = [{"role": "user", "content": message}]
 
         if web_search:
@@ -131,7 +166,7 @@ class LiteLLMClient:
                 messages=messages,
                 **connection,
                 **litellm_kwargs,
-            )  # TODO: timeoutを延長する
+            )
             content = response.choices[0].message.content
 
             if content is None:
@@ -189,6 +224,8 @@ class LiteLLMClient:
             )
 
         litellm_kwargs = params.copy() if params else {}
+        # setdefault so an explicit per-call timeout in `params` still wins.
+        litellm_kwargs.setdefault("timeout", resolve_llm_timeout())
         messages = [{"role": "user", "content": message}]
 
         if web_search:
@@ -218,7 +255,7 @@ class LiteLLMClient:
                 response_format=data_model,
                 **connection,
                 **litellm_kwargs,
-            )  # TODO: timeoutを延長する
+            )
 
             content = response.choices[0].message.content
 

--- a/backend/tests/unit/test_litellm_client_openai_compatible.py
+++ b/backend/tests/unit/test_litellm_client_openai_compatible.py
@@ -6,9 +6,14 @@ These tests pin that mapping, since getting it wrong sends research traffic
 to the wrong host — or to a vendor default with the wrong key.
 """
 
+import pytest
+
 from airas.infra.litellm_client import (
+    DEFAULT_LLM_TIMEOUT_SECONDS,
     LITELLM_OPENAI_COMPATIBLE_PREFIX,
+    LLM_TIMEOUT_ENV,
     LiteLLMClient,
+    resolve_llm_timeout,
 )
 from airas.infra.llm_provider_resolver import (
     RIKYU_BASE_URL_ENV,
@@ -62,3 +67,32 @@ def test_key_falls_back_to_the_environment(monkeypatch) -> None:
     _, connection = client._resolve_call_target("rikyu/kimi-k3")
 
     assert connection["api_key"] == "sk-from-env"
+
+
+class TestLLMTimeout:
+    """litellm's 600s default kills a reasoning model mid-thought.
+
+    Measured on `rikyu/kimi-k3`: one call spent ~194s emitting its reasoning
+    trace before the first answer token and ~284s in total, for a prompt far
+    smaller than the generation subgraphs send. Queueing on the shared
+    endpoint has separately added ~2min before the first token. There is no
+    partial result to keep when the call is cut, so the work is simply lost.
+    """
+
+    def test_the_default_survives_a_long_reasoning_trace(self, monkeypatch):
+        monkeypatch.delenv(LLM_TIMEOUT_ENV, raising=False)
+
+        assert resolve_llm_timeout() == DEFAULT_LLM_TIMEOUT_SECONDS
+        assert DEFAULT_LLM_TIMEOUT_SECONDS > 600, "litellm's own default"
+
+    def test_a_deployment_can_tighten_it(self, monkeypatch):
+        monkeypatch.setenv(LLM_TIMEOUT_ENV, "90")
+
+        assert resolve_llm_timeout() == 90.0
+
+    @pytest.mark.parametrize("value", ["", "   ", "soon", "0", "-1"])
+    def test_an_unusable_value_falls_back_rather_than_failing(self, value, monkeypatch):
+        """A bad env var must not take down every LLM call in the process."""
+        monkeypatch.setenv(LLM_TIMEOUT_ENV, value)
+
+        assert resolve_llm_timeout() == DEFAULT_LLM_TIMEOUT_SECONDS

--- a/backend/tests/unit/test_litellm_client_openai_compatible.py
+++ b/backend/tests/unit/test_litellm_client_openai_compatible.py
@@ -90,7 +90,7 @@ class TestLLMTimeout:
 
         assert resolve_llm_timeout() == 90.0
 
-    @pytest.mark.parametrize("value", ["", "   ", "soon", "0", "-1"])
+@pytest.mark.parametrize("value", ["", "   ", "soon", "0", "-1", "nan", "inf", "-inf"])
     def test_an_unusable_value_falls_back_rather_than_failing(self, value, monkeypatch):
         """A bad env var must not take down every LLM call in the process."""
         monkeypatch.setenv(LLM_TIMEOUT_ENV, value)


### PR DESCRIPTION
## 背景と目的

litellm の既定タイムアウトは 600 秒で、**成功するはずの呼び出しを打ち切ります。**

`rikyu/kimi-k3` で実測したところ、1 回の呼び出しが**最初の回答トークンまでに約 194 秒**を推論トレースの出力に費やし、**合計で約 284 秒**かかりました。しかもこれは生成サブグラフが送るプロンプトより遥かに小さい入力です。共有エンドポイントのキューイングで**最初のトークンまでにさらに約 2 分**かかる事象も別途観測しています。

打ち切られたときに**部分的な結果は残りません**。呼び出しが丸ごと失われ、最初からやり直しになるので、このタイムアウトは節約する以上のコストを払っています。

`litellm_client.py` には該当箇所 2 つに `# TODO: timeoutを延長する` が残ったままでした。

## 変更内容

以下の機能が変更されました：

1. すべての LLM 呼び出しに明示的なタイムアウトを設定
2. `AIRAS_LLM_TIMEOUT` によるデプロイ単位の上書き

実装の詳細は以下の通りです：

<details>
<summary><code>1. タイムアウトの設定と解決</code></summary>

**実装概要**

- **既定 1800 秒**（`DEFAULT_LLM_TIMEOUT_SECONDS`）
  - 上の実測（284 秒 + キュー約 2 分）に対して余裕を持たせています。打ち切りの損失が非対称に大きいため、既定は寛容側に倒しました

- **`resolve_llm_timeout()`**: `AIRAS_LLM_TIMEOUT`（秒）を読み、無ければ既定値を返します
  - 数値でない値・0 以下の値は**警告を出して既定にフォールバック**します。環境変数の書き間違いでプロセス内の全 LLM 呼び出しが落ちるのは割に合いません

- **`setdefault` で設定**しているので、呼び出し側が `params` で明示したタイムアウトが優先されます

</details>

2. テスト:
   - `backend/tests/unit/test_litellm_client_openai_compatible.py` に 4 件追加
     - 既定値が litellm 自身の 600 秒より大きいこと
     - `AIRAS_LLM_TIMEOUT` で締められること
     - 空文字・空白・非数値・`0`・負値のいずれでも**落ちずに既定へフォールバック**すること
