### PR TITLE
feat: typeset Japanese papers by choosing the engine from the document

### DIFF
--- a/backend/src/airas/usecases/publication/nodes/verify_latex_build.py
+++ b/backend/src/airas/usecases/publication/nodes/verify_latex_build.py
@@ -52,6 +52,18 @@ _PDFLATEX_TIMEOUT_SECONDS = 180.0
 _BIBTEX_TIMEOUT_SECONDS = 60.0
 _LOG_TAIL_CHARS = 4000
 
+# pdflatex has no way to typeset CJK: every Japanese character raises
+# `LaTeX Error: Unicode character` and the PDF comes out with the text
+# missing. LuaTeX handles it natively, so the engine follows the document
+# rather than the other way round — a paper drafted in Japanese should not
+# have to be rewritten to be checkable.
+_LUALATEX_ENGINE = "lualatex"
+_PDFLATEX_ENGINE = "pdflatex"
+
+# CJK ideographs, hiragana, katakana, and the fullwidth punctuation that
+# comes with them. Latin text with a stray “ or — stays on pdflatex.
+_CJK = re.compile(r"[぀-ヿ㐀-䶿一-鿿＀-ﾟ]")
+
 _UNDEFINED_CITATION = re.compile(r"Citation [`'\"]([^`'\"]+)['\"] on page")
 _UNDEFINED_REFERENCE = re.compile(r"Reference [`'\"]([^`'\"]+)['\"] on page")
 _MISSING_FILE = re.compile(r"File [`'\"]([^`'\"]+)['\"] not found")
@@ -123,23 +135,28 @@ def _page_count(pdf_path: Path) -> int | None:
         return None
 
 
+def select_engine(main_tex: str) -> str:
+    """The TeX engine that can typeset this document.
+
+    Chosen from the source rather than configured, because getting it wrong
+    is not a preference but a failure: pdflatex turns every Japanese
+    character into `LaTeX Error: Unicode character` and drops it from the
+    PDF, and asking the author to declare the engine just moves the
+    mistake somewhere it is easier to forget.
+    """
+    return _LUALATEX_ENGINE if _CJK.search(main_tex) else _PDFLATEX_ENGINE
+
+
 def verify_latex_build(
     latex_files: dict[str, bytes],
     main_tex_name: str = "main.tex",
 ) -> LatexBuildReport:
     """Build `latex_files` in a scratch directory and report the result.
 
-    Runs the same pdflatex/bibtex/pdflatex/pdflatex sequence the CI LaTeX
-    agent uses, so the findings match what that agent would see.
+    Runs the same engine/bibtex/engine/engine sequence the CI LaTeX agent
+    uses, so the findings match what that agent would see. The engine is
+    lualatex for a document containing CJK and pdflatex otherwise.
     """
-    if shutil.which("pdflatex") is None:
-        raise LatexToolchainMissingError(
-            "pdflatex was not found on PATH. Install a TeX distribution "
-            "(e.g. `apt-get install texlive-latex-recommended "
-            "texlive-latex-extra texlive-fonts-recommended texlive-science`) "
-            "to verify the paper locally, or push and use compile_latex."
-        )
-
     stem = Path(main_tex_name).stem
 
     with tempfile.TemporaryDirectory(prefix="airas-latex-") as tmp:
@@ -150,15 +167,31 @@ def verify_latex_build(
         if not main_tex_path.is_file():
             raise ValueError(f"{main_tex_name} is not present in the collected project")
 
+        source = main_tex_path.read_text(errors="replace")
+        engine = select_engine(source)
+        if shutil.which(engine) is None:
+            raise LatexToolchainMissingError(
+                f"{engine} was not found on PATH. "
+                + (
+                    "This document contains Japanese, which needs LuaTeX: "
+                    "`apt-get install texlive-luatex texlive-lang-japanese`."
+                    if engine == _LUALATEX_ENGINE
+                    else "Install a TeX distribution (e.g. `apt-get install "
+                    "texlive-latex-recommended texlive-latex-extra "
+                    "texlive-fonts-recommended texlive-science`)."
+                )
+                + " Or push and use compile_latex."
+            )
+
         pdflatex = [
-            "pdflatex",
+            engine,
             "-interaction=nonstopmode",
             "-halt-on-error=0",
             "-no-shell-escape",
             main_tex_name,
         ]
 
-        needs_bibtex = _needs_bibtex(main_tex_path.read_text(errors="replace"))
+        needs_bibtex = _needs_bibtex(source)
         if needs_bibtex and shutil.which("bibtex") is None:
             raise LatexToolchainMissingError(
                 "The document has a bibliography but bibtex was not found on "

--- a/backend/tests/unit/usecases/publication/test_verify_latex_build.py
+++ b/backend/tests/unit/usecases/publication/test_verify_latex_build.py
@@ -12,13 +12,17 @@ from pathlib import Path
 
 import pytest
 
-from airas.usecases.publication.nodes.verify_latex_build import verify_latex_build
+from airas.usecases.publication.nodes.verify_latex_build import (
+    select_engine,
+    verify_latex_build,
+)
 
-# Every document here ends in \bibliography{references}, so bibtex runs too.
-pytestmark = pytest.mark.skipif(
+# Most documents here end in \bibliography{references}, so bibtex runs too.
+requires_tex = pytest.mark.skipif(
     shutil.which("pdflatex") is None or shutil.which("bibtex") is None,
     reason="requires a local TeX distribution (pdflatex and bibtex)",
 )
+pytestmark = requires_tex
 
 BIB = b"""
 @article{known2020,
@@ -188,3 +192,46 @@ def test_a_missing_package_is_an_error_not_a_missing_figure():
     assert report.missing_figures == []
     assert any("not found" in error for error in report.errors)
     assert not report.ok
+
+
+class TestEngineSelection:
+    """pdflatex cannot typeset Japanese, so the engine follows the document.
+
+    A paper drafted in Japanese is checked in Japanese — asking the author
+    to declare the engine would just move the mistake somewhere easier to
+    forget, and getting it wrong is not a preference but a silent loss:
+    pdflatex raises `LaTeX Error: Unicode character` per character and
+    leaves the text out of the PDF.
+    """
+
+    def test_japanese_selects_lualatex(self):
+        assert select_engine("\\section{はじめに}") == "lualatex"
+
+    def test_latin_stays_on_pdflatex(self):
+        # Curly quotes and dashes are not CJK; they must not switch engines.
+        assert select_engine("A “quoted” em—dash paper.") == "pdflatex"
+
+    @pytest.mark.skipif(
+        shutil.which("lualatex") is None
+        or subprocess.run(["kpsewhich", "luatexja.sty"], capture_output=True).returncode
+        != 0,
+        reason="requires texlive-luatex and texlive-lang-japanese",
+    )
+    def test_a_japanese_paper_compiles_and_is_reported_sound(self):
+        report = verify_latex_build(
+            {
+                "main.tex": (
+                    "\\documentclass[11pt]{article}\n"
+                    "\\usepackage{luatexja-fontspec}\n"
+                    "\\setmainjfont{IPAexMincho}\n"
+                    "\\title{集約スコアは系ごとの失敗を隠蔽する}\n"
+                    "\\begin{document}\\maketitle\n"
+                    "\\section{はじめに}本研究では、集約指標の妥当性を検証する。\n"
+                    "\\end{document}\n"
+                ).encode()
+            }
+        )
+
+        assert report.ok
+        assert report.page_count == 1
+        assert report.errors == []


### PR DESCRIPTION
## 背景と目的

**日本語で書いた論文が検証できません。**

`verify_latex_build` は `pdflatex` を決め打ちで実行しますが、pdflatex は CJK を組めません。日本語を含む `main.tex` を渡すと**1 文字ごとに** `LaTeX Error: Unicode character` が出て、その文字は PDF から脱落します。

実測:

```
ok: False | compiled: True | pages: 1
errors: ['LaTeX Error: Unicode character は (U+306F)',
         'LaTeX Error: Unicode character じ (U+3058)', ...]
```

PDF 自体は出るので、検証を挟まなければ**本文が空のまま「成功」になります**。

ドメイン知識を持たないレビュアーが内容を確認するには、成果物が日本語である必要があります。しかし現状では、日本語で書いた時点で検証が機能しません。

## 変更内容

以下の機能が変更されました：

1. LaTeX エンジンを、設定ではなく**文書の内容から決定**するよう変更

実装の詳細は以下の通りです：

<details>
<summary><code>1. select_engine() によるエンジン選択</code></summary>

**実装概要**

- **CJK（漢字・ひらがな・カタカナ・全角記号）を含めば `lualatex`、それ以外は `pdflatex`**
  - 引用符 `“ ”` やダッシュ `—` は CJK ではないので、欧文はこれまでどおり pdflatex のままです

- **設定項目にせず、ソースから導出しました。** 選択を誤ったときの結果が「好みが違う」ではなく**本文の欠落**であり、しかも PDF は出てしまうためです。エンジンを宣言させる方式にすると、言語を変えたときに宣言の更新を忘れる箇所が 1 つ増えるだけになります

- **toolchain の存在確認をエンジン決定の後ろに移動**しました
  - 従来は `pdflatex` の有無だけを見ていたため、日本語文書でも「pdflatex はある」と判定して先へ進み、あとで失敗していました
  - lualatex が無い場合は、何を入れればよいか（`texlive-luatex` / `texlive-lang-japanese`）を名指しします

</details>

2. テスト:
   - `backend/tests/unit/usecases/publication/test_verify_latex_build.py` に 3 件追加（計 11 件）
     - 日本語が `lualatex` を選ぶこと
     - **欧文の約物（`“ ”` / `—`）でエンジンが切り替わらないこと**
     - 日本語論文が実際にコンパイルされ、`ok` かつエラー無しで報告されること（`lualatex` と `luatexja` が無い環境ではスキップ）

3. 動作確認:
   - タイトル・著者・abstract・番号付き節・数式を含む日本語論文が 1 ページの PDF になり、テキスト抽出も正常であることを確認しました
   - 必要なのは `texlive-lang-japanese` と `texlive-luatex` の 2 つで、和文フォント（IPAex）は同梱されます

4. 関連:
   - スキル側の指示（日本語で書くこと、luatexja プリアンブル）は https://github.com/airas-org/airas/pull/982 に含めています
   - 同梱テンプレート（`iclr2024` / `mdpi` / `agents4science_2025`）は英語会議用で CJK 非対応のため、日本語論文はプリアンブルを自前で持ちます。日本語テンプレートを `airas-template` に追加するかは別途
