### PR TITLE
fix: repair the timeout test file that blocks all test collection

### DIFF
--- a/backend/src/airas/infra/litellm_client.py
+++ b/backend/src/airas/infra/litellm_client.py
@@ -11,6 +11,7 @@ To view available models in your environment, run:
 
 import json
 import logging
+import math
 import os
 from collections.abc import Callable
 from functools import lru_cache
@@ -81,10 +82,14 @@ def resolve_llm_timeout() -> float:
             f"using {DEFAULT_LLM_TIMEOUT_SECONDS}s."
         )
         return DEFAULT_LLM_TIMEOUT_SECONDS
-    if timeout <= 0:
+    # float() accepts "inf" and "nan", and both slip past a `<= 0` test:
+    # inf disables the timeout the caller asked for, and nan makes every
+    # comparison false further down. Neither is what someone setting this
+    # variable meant, so treat them like any other unusable value.
+    if not math.isfinite(timeout) or timeout <= 0:
         logger.warning(
-            f"{LLM_TIMEOUT_ENV}={raw!r} must be positive; "
-            f"using {DEFAULT_LLM_TIMEOUT_SECONDS}s."
+            f"{LLM_TIMEOUT_ENV}={raw!r} must be a positive, finite number of "
+            f"seconds; using {DEFAULT_LLM_TIMEOUT_SECONDS}s."
         )
         return DEFAULT_LLM_TIMEOUT_SECONDS
     return timeout

--- a/backend/tests/unit/test_litellm_client_openai_compatible.py
+++ b/backend/tests/unit/test_litellm_client_openai_compatible.py
@@ -90,7 +90,9 @@ class TestLLMTimeout:
 
         assert resolve_llm_timeout() == 90.0
 
-@pytest.mark.parametrize("value", ["", "   ", "soon", "0", "-1", "nan", "inf", "-inf"])
+    @pytest.mark.parametrize(
+        "value", ["", "   ", "soon", "0", "-1", "nan", "inf", "-inf"]
+    )
     def test_an_unusable_value_falls_back_rather_than_failing(self, value, monkeypatch):
         """A bad env var must not take down every LLM call in the process."""
         monkeypatch.setenv(LLM_TIMEOUT_ENV, value)


### PR DESCRIPTION
## 背景と目的

**develop で `pytest` が 1 件も実行できません。**

https://github.com/airas-org/airas/pull/983 のマージ時にレビュー提案が適用された際、`@pytest.mark.parametrize` デコレータのインデントが失われました。

```python
    def test_a_deployment_can_tighten_it(self, monkeypatch):
        ...

@pytest.mark.parametrize("value", ["", "   ", "soon", "0", "-1", "nan", "inf", "-inf"])
    def test_an_unusable_value_falls_back_rather_than_failing(self, value, monkeypatch):
```

結果として `IndentationError: unexpected indent` になり、**収集の時点で pytest が止まるため、リポジトリ全体のテストが走りません。**

なお、その提案の**中身自体は正しい指摘**でした。`"nan"` と `"inf"` を「使えない値」のケースに追加していますが、現在の実装はどちらも通してしまいます。

- `float("inf")` も `float("nan")` も `ValueError` にならない
- `timeout <= 0` は inf で偽、nan でも偽（nan との比較は常に偽）

つまり `AIRAS_LLM_TIMEOUT=inf` と書いた運用者は、**この変数が設定するはずのタイムアウトを無効化**することになり、`nan` なら以降の比較がすべて偽になります。

## 変更内容

以下の機能が変更されました：

1. デコータのインデントを復旧し、テスト収集を回復
2. `resolve_llm_timeout()` が有限値のみを受理するよう修正

実装の詳細は以下の通りです：

<details>
<summary><code>1. インデントの復旧</code></summary>

**実装概要**

`@pytest.mark.parametrize` をクラス本体のインデントに戻しました。引数が長いため、行幅に収まるよう折り返しています。

これで develop のテスト収集が回復します（`tests/unit` 134 件が通ることを確認）。

</details>

<details>
<summary><code>2. 非有限値の拒否</code></summary>

**実装概要**

`resolve_llm_timeout()` の検査を `timeout <= 0` から `not math.isfinite(timeout) or timeout <= 0` に変更しました。

- `inf` / `nan` は「数値として解釈できるが、この変数の用途では無意味」なので、他の不正値と同じくフォールバックさせます
- 警告文も「positive」から「positive, finite」に更新しました
- `-inf` は元から `<= 0` で弾かれていました

</details>

3. テスト:
   - 提案が追加した `"nan"` / `"inf"` / `"-inf"` のケースがそのまま通るようになりました（`tests/unit` 134 passed）
