### PR TITLE
feat: write and typeset the research artifacts in Japanese

### DIFF
--- a/backend/src/airas/core/types/latex.py
+++ b/backend/src/airas/core/types/latex.py
@@ -38,6 +38,14 @@ class LatexBuildReport(BaseModel):
         default_factory=list,
         description="Figure paths the document includes but the project lacks",
     )
+    pdf_path: Optional[str] = Field(
+        default=None,
+        description=(
+            "Where the built PDF was written, when an output path was "
+            "requested. The build directory is temporary, so without one "
+            "the PDF is discarded after the report is produced"
+        ),
+    )
     errors: list[str] = Field(
         default_factory=list, description="LaTeX errors, in the order emitted"
     )

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -1673,6 +1673,7 @@ async def verify_latex(
     branch_name: str = "",
     latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
     local_path: str | None = None,
+    output_path: str | None = None,
 ) -> dict[str, Any]:
     """Compile the paper locally and report whether it is actually sound.
 
@@ -1700,8 +1701,17 @@ async def verify_latex(
     Pass `local_path` — the absolute path of your local clone — to check the
     working tree with no push and no API keys. Otherwise pass
     `github_owner`/`repository_name`/`branch_name` to check what was pushed
-    (requires GH_PERSONAL_ACCESS_TOKEN). Requires a local TeX distribution;
-    `pdflatex` must be on PATH.
+    (requires GH_PERSONAL_ACCESS_TOKEN).
+
+    Pass `output_path` to keep the PDF this build produced — the build
+    directory is temporary otherwise, and `pdf_path` in the result says
+    where it landed. For a Japanese paper that is the only way to get a PDF
+    at all: `compile_latex` runs pdflatex on GitHub Actions, which cannot
+    typeset CJK.
+
+    Requires a local TeX distribution. A Japanese document is built with
+    lualatex (`texlive-luatex`, `texlive-lang-japanese`); everything else
+    with pdflatex.
     """
     refresh_environment()
 
@@ -1726,7 +1736,9 @@ async def verify_latex(
             _github_client(),
         )
 
-    report = await asyncio.to_thread(verify_latex_build, latex_files)
+    report = await asyncio.to_thread(
+        verify_latex_build, latex_files, "main.tex", output_path
+    )
     return report.model_dump()
 
 

--- a/backend/src/airas/usecases/publication/nodes/verify_latex_build.py
+++ b/backend/src/airas/usecases/publication/nodes/verify_latex_build.py
@@ -52,6 +52,18 @@ _PDFLATEX_TIMEOUT_SECONDS = 180.0
 _BIBTEX_TIMEOUT_SECONDS = 60.0
 _LOG_TAIL_CHARS = 4000
 
+# pdflatex has no way to typeset CJK: every Japanese character raises
+# `LaTeX Error: Unicode character` and the PDF comes out with the text
+# missing. LuaTeX handles it natively, so the engine follows the document
+# rather than the other way round — a paper drafted in Japanese should not
+# have to be rewritten to be checkable.
+_LUALATEX_ENGINE = "lualatex"
+_PDFLATEX_ENGINE = "pdflatex"
+
+# CJK ideographs, hiragana, katakana, and the fullwidth punctuation that
+# comes with them. Latin text with a stray “ or — stays on pdflatex.
+_CJK = re.compile(r"[぀-ヿ㐀-䶿一-鿿＀-ﾟ]")
+
 _UNDEFINED_CITATION = re.compile(r"Citation [`'\"]([^`'\"]+)['\"] on page")
 _UNDEFINED_REFERENCE = re.compile(r"Reference [`'\"]([^`'\"]+)['\"] on page")
 _MISSING_FILE = re.compile(r"File [`'\"]([^`'\"]+)['\"] not found")
@@ -123,23 +135,28 @@ def _page_count(pdf_path: Path) -> int | None:
         return None
 
 
+def select_engine(main_tex: str) -> str:
+    """The TeX engine that can typeset this document.
+
+    Chosen from the source rather than configured, because getting it wrong
+    is not a preference but a failure: pdflatex turns every Japanese
+    character into `LaTeX Error: Unicode character` and drops it from the
+    PDF, and asking the author to declare the engine just moves the
+    mistake somewhere it is easier to forget.
+    """
+    return _LUALATEX_ENGINE if _CJK.search(main_tex) else _PDFLATEX_ENGINE
+
+
 def verify_latex_build(
     latex_files: dict[str, bytes],
     main_tex_name: str = "main.tex",
 ) -> LatexBuildReport:
     """Build `latex_files` in a scratch directory and report the result.
 
-    Runs the same pdflatex/bibtex/pdflatex/pdflatex sequence the CI LaTeX
-    agent uses, so the findings match what that agent would see.
+    Runs the same engine/bibtex/engine/engine sequence the CI LaTeX agent
+    uses, so the findings match what that agent would see. The engine is
+    lualatex for a document containing CJK and pdflatex otherwise.
     """
-    if shutil.which("pdflatex") is None:
-        raise LatexToolchainMissingError(
-            "pdflatex was not found on PATH. Install a TeX distribution "
-            "(e.g. `apt-get install texlive-latex-recommended "
-            "texlive-latex-extra texlive-fonts-recommended texlive-science`) "
-            "to verify the paper locally, or push and use compile_latex."
-        )
-
     stem = Path(main_tex_name).stem
 
     with tempfile.TemporaryDirectory(prefix="airas-latex-") as tmp:
@@ -150,15 +167,31 @@ def verify_latex_build(
         if not main_tex_path.is_file():
             raise ValueError(f"{main_tex_name} is not present in the collected project")
 
+        source = main_tex_path.read_text(errors="replace")
+        engine = select_engine(source)
+        if shutil.which(engine) is None:
+            raise LatexToolchainMissingError(
+                f"{engine} was not found on PATH. "
+                + (
+                    "This document contains Japanese, which needs LuaTeX: "
+                    "`apt-get install texlive-luatex texlive-lang-japanese`."
+                    if engine == _LUALATEX_ENGINE
+                    else "Install a TeX distribution (e.g. `apt-get install "
+                    "texlive-latex-recommended texlive-latex-extra "
+                    "texlive-fonts-recommended texlive-science`)."
+                )
+                + " Or push and use compile_latex."
+            )
+
         pdflatex = [
-            "pdflatex",
+            engine,
             "-interaction=nonstopmode",
             "-halt-on-error=0",
             "-no-shell-escape",
             main_tex_name,
         ]
 
-        needs_bibtex = _needs_bibtex(main_tex_path.read_text(errors="replace"))
+        needs_bibtex = _needs_bibtex(source)
         if needs_bibtex and shutil.which("bibtex") is None:
             raise LatexToolchainMissingError(
                 "The document has a bibliography but bibtex was not found on "

--- a/backend/src/airas/usecases/publication/nodes/verify_latex_build.py
+++ b/backend/src/airas/usecases/publication/nodes/verify_latex_build.py
@@ -125,6 +125,21 @@ def _parse_log(log: str) -> tuple[list[str], list[str], list[str], list[str]]:
     return citations, references, missing_files, errors
 
 
+def _save_pdf(pdf_path: Path, output_path: str | Path | None) -> str | None:
+    """Copy the built PDF out of the scratch directory, if asked."""
+    if output_path is None:
+        return None
+    destination = Path(output_path).expanduser()
+    # A directory is the natural thing to pass when checking several
+    # templates, so accept it and keep the document's own name.
+    if destination.is_dir() or not destination.suffix:
+        destination = destination / pdf_path.name
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(pdf_path, destination)
+    logger.info(f"Wrote the verified PDF to {destination}")
+    return str(destination)
+
+
 def _page_count(pdf_path: Path) -> int | None:
     try:
         from pypdf import PdfReader
@@ -150,12 +165,19 @@ def select_engine(main_tex: str) -> str:
 def verify_latex_build(
     latex_files: dict[str, bytes],
     main_tex_name: str = "main.tex",
+    output_path: str | Path | None = None,
 ) -> LatexBuildReport:
     """Build `latex_files` in a scratch directory and report the result.
 
     Runs the same engine/bibtex/engine/engine sequence the CI LaTeX agent
     uses, so the findings match what that agent would see. The engine is
     lualatex for a document containing CJK and pdflatex otherwise.
+
+    The build happens in a temporary directory that is deleted afterwards,
+    so pass `output_path` to keep the PDF. It is worth keeping: this is the
+    one build whose result has been inspected, and for a Japanese paper it
+    is currently the only way to get a PDF at all — the GitHub Actions
+    workflow runs pdflatex, which cannot typeset CJK.
     """
     stem = Path(main_tex_name).stem
 
@@ -229,6 +251,9 @@ def verify_latex_build(
         pdf_path = build_dir / f"{stem}.pdf"
         compiled = pdf_path.is_file()
         page_count = _page_count(pdf_path) if compiled else None
+        # Kept even when the report is not clean: a PDF with one unresolved
+        # citation is still the fastest way to see what is wrong with it.
+        saved_pdf = _save_pdf(pdf_path, output_path) if compiled else None
 
         # Three things to drop from the raw "File ... not found" list.
         # graphicx probes for a graphic under several extensions and names
@@ -259,6 +284,7 @@ def verify_latex_build(
         undefined_references=references,
         missing_figures=missing_figures,
         errors=errors,
+        pdf_path=saved_pdf,
         log_tail=log[-_LOG_TAIL_CHARS:],
     )
     logger.info(

--- a/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
+++ b/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
@@ -7,6 +7,7 @@ from airas.core.research_paths import LEGACY_DIAGRAM_DIR, RESULTS_DIR
 from airas.core.types.github import GitHubConfig
 from airas.core.types.latex import LATEX_TEMPLATE_NAME
 from airas.infra.github_client import GithubClient
+from airas.usecases.publication.nodes.verify_latex_build import select_engine
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,23 @@ _EXCLUDED_FILES = {"template.tex", "template.pdf"}
 # The legacy .research/diagrams/ entry is scheduled for removal in the next
 # major release (see issue #913).
 _FIGURE_SOURCE_DIRS = (f"{RESULTS_DIR}/", f"{LEGACY_DIAGRAM_DIR}/")
+
+# Overleaf drives the build with latexmk and defaults it to pdfLaTeX, which
+# cannot typeset CJK — a Japanese paper would arrive there and come out with
+# its text missing. latexmk reads this file, so shipping it means the export
+# compiles on arrival instead of requiring the reader to find the compiler
+# setting. `$pdf_mode = 4` is latexmk's own name for "use lualatex".
+_LATEXMKRC = "latexmkrc"
+_LUALATEX_LATEXMKRC = b"$pdf_mode = 4;\n"
+
+
+def _add_engine_hint(latex_files: dict[str, bytes]) -> None:
+    """Tell latexmk which engine this document needs, if it is not the default."""
+    main_tex = latex_files.get("main.tex")
+    if main_tex is None or _LATEXMKRC in latex_files:
+        return
+    if select_engine(main_tex.decode("utf-8", errors="replace")) == "lualatex":
+        latex_files[_LATEXMKRC] = _LUALATEX_LATEXMKRC
 
 
 def _is_safe_local_file(path: Path, containing_dir: Path) -> bool:
@@ -105,6 +123,7 @@ def collect_latex_project_files(
     for repo_path, content in figure_entries:
         _merge_figure(latex_files, repo_path, content)
 
+    _add_engine_hint(latex_files)
     _require_main_tex(latex_files, prefix, source=github_config.repository_name)
     logger.info(f"Collected {len(latex_files)} LaTeX project files from {prefix}")
     return latex_files
@@ -145,6 +164,7 @@ def collect_latex_project_files_local(
             repo_path = source_dir + path.relative_to(figure_root).as_posix()
             _merge_figure(latex_files, repo_path, path.read_bytes())
 
+    _add_engine_hint(latex_files)
     _require_main_tex(latex_files, prefix, source=str(root))
     logger.info(f"Collected {len(latex_files)} LaTeX project files from {latex_dir}")
     return latex_files

--- a/backend/tests/unit/usecases/publication/test_collect_latex_engine_hint.py
+++ b/backend/tests/unit/usecases/publication/test_collect_latex_engine_hint.py
@@ -1,0 +1,36 @@
+"""Overleaf builds with latexmk and defaults it to pdfLaTeX.
+
+A Japanese paper exported without a hint arrives there and compiles with
+its text missing — the reader has to find the compiler setting to see
+anything. latexmk reads `latexmkrc` from the project, so the export
+carries the answer with it.
+"""
+
+from airas.usecases.publication.open_in_overleaf_subgraph.nodes.collect_latex_project_files import (
+    _add_engine_hint,
+)
+
+
+def test_a_japanese_project_gets_a_lualatex_latexmkrc():
+    files = {"main.tex": "\\section{はじめに}".encode()}
+
+    _add_engine_hint(files)
+
+    assert files["latexmkrc"] == b"$pdf_mode = 4;\n"
+
+
+def test_an_english_project_is_left_alone():
+    files = {"main.tex": b"\\section{Introduction}"}
+
+    _add_engine_hint(files)
+
+    assert "latexmkrc" not in files
+
+
+def test_a_project_that_ships_its_own_latexmkrc_keeps_it():
+    own = b"$pdf_mode = 1;\n"
+    files = {"main.tex": "\\section{はじめに}".encode(), "latexmkrc": own}
+
+    _add_engine_hint(files)
+
+    assert files["latexmkrc"] == own

--- a/backend/tests/unit/usecases/publication/test_verify_latex_build.py
+++ b/backend/tests/unit/usecases/publication/test_verify_latex_build.py
@@ -235,3 +235,44 @@ class TestEngineSelection:
         assert report.ok
         assert report.page_count == 1
         assert report.errors == []
+
+
+class TestKeepingThePdf:
+    """The build directory is temporary, so the PDF has to be asked for.
+
+    For a Japanese paper this is the only way to get one: compile_latex
+    runs pdflatex on GitHub Actions, which cannot typeset CJK.
+    """
+
+    def test_the_pdf_is_discarded_unless_a_path_is_given(self):
+        report = verify_latex_build({"main.tex": _document("Text.")})
+
+        assert report.compiled
+        assert report.pdf_path is None
+
+    def test_an_explicit_path_receives_the_verified_build(self, tmp_path):
+        destination = tmp_path / "out" / "paper.pdf"
+
+        report = verify_latex_build(
+            {"main.tex": _document("Text.")}, output_path=destination
+        )
+
+        assert report.pdf_path == str(destination)
+        assert destination.is_file() and destination.stat().st_size > 0
+
+    def test_a_directory_keeps_the_document_name(self, tmp_path):
+        report = verify_latex_build(
+            {"main.tex": _document("Text.")}, output_path=tmp_path
+        )
+
+        assert report.pdf_path == str(tmp_path / "main.pdf")
+
+    def test_a_flawed_paper_still_yields_its_pdf(self, tmp_path):
+        """Seeing the '?' in place is faster than reading about it."""
+        report = verify_latex_build(
+            {"main.tex": _document("Cited \\cite{never_added}."), "references.bib": BIB},
+            output_path=tmp_path / "paper.pdf",
+        )
+
+        assert not report.ok
+        assert report.pdf_path is not None

--- a/backend/tests/unit/usecases/publication/test_verify_latex_build.py
+++ b/backend/tests/unit/usecases/publication/test_verify_latex_build.py
@@ -12,13 +12,17 @@ from pathlib import Path
 
 import pytest
 
-from airas.usecases.publication.nodes.verify_latex_build import verify_latex_build
+from airas.usecases.publication.nodes.verify_latex_build import (
+    select_engine,
+    verify_latex_build,
+)
 
-# Every document here ends in \bibliography{references}, so bibtex runs too.
-pytestmark = pytest.mark.skipif(
+# Most documents here end in \bibliography{references}, so bibtex runs too.
+requires_tex = pytest.mark.skipif(
     shutil.which("pdflatex") is None or shutil.which("bibtex") is None,
     reason="requires a local TeX distribution (pdflatex and bibtex)",
 )
+pytestmark = requires_tex
 
 BIB = b"""
 @article{known2020,
@@ -188,3 +192,46 @@ def test_a_missing_package_is_an_error_not_a_missing_figure():
     assert report.missing_figures == []
     assert any("not found" in error for error in report.errors)
     assert not report.ok
+
+
+class TestEngineSelection:
+    """pdflatex cannot typeset Japanese, so the engine follows the document.
+
+    A paper drafted in Japanese is checked in Japanese — asking the author
+    to declare the engine would just move the mistake somewhere easier to
+    forget, and getting it wrong is not a preference but a silent loss:
+    pdflatex raises `LaTeX Error: Unicode character` per character and
+    leaves the text out of the PDF.
+    """
+
+    def test_japanese_selects_lualatex(self):
+        assert select_engine("\\section{はじめに}") == "lualatex"
+
+    def test_latin_stays_on_pdflatex(self):
+        # Curly quotes and dashes are not CJK; they must not switch engines.
+        assert select_engine("A “quoted” em—dash paper.") == "pdflatex"
+
+    @pytest.mark.skipif(
+        shutil.which("lualatex") is None
+        or subprocess.run(["kpsewhich", "luatexja.sty"], capture_output=True).returncode
+        != 0,
+        reason="requires texlive-luatex and texlive-lang-japanese",
+    )
+    def test_a_japanese_paper_compiles_and_is_reported_sound(self):
+        report = verify_latex_build(
+            {
+                "main.tex": (
+                    "\\documentclass[11pt]{article}\n"
+                    "\\usepackage{luatexja-fontspec}\n"
+                    "\\setmainjfont{IPAexMincho}\n"
+                    "\\title{集約スコアは系ごとの失敗を隠蔽する}\n"
+                    "\\begin{document}\\maketitle\n"
+                    "\\section{はじめに}本研究では、集約指標の妥当性を検証する。\n"
+                    "\\end{document}\n"
+                ).encode()
+            }
+        )
+
+        assert report.ok
+        assert report.page_count == 1
+        assert report.errors == []

--- a/plugins/airas/skills/auto-research-claude-code/SKILL.md
+++ b/plugins/airas/skills/auto-research-claude-code/SKILL.md
@@ -40,6 +40,41 @@ shape from a validation error. The two that catch people out:
   (`x86_64` / `aarch64`) whenever you know it; it decides whether a
   dependency has an installable wheel at all.
 
+## Write in Japanese
+
+The people reviewing this work will not always have the domain knowledge
+to judge a claim — about protein-ligand scoring, say — on sight. A
+plausible-sounding mistake is only catchable if they can read it
+comfortably, so **write every artifact a human is meant to check in
+Japanese**: the hypothesis, the experimental design, the analysis report,
+and the paper itself, through to the PDF.
+
+Two things stay English because they are identifiers rather than prose:
+`primary_metric` / `supporting_metrics`, which are parsed downstream to
+compute the GAP, and BibTeX citation keys.
+
+A Japanese paper needs LuaTeX — pdflatex raises `LaTeX Error: Unicode
+character` for every Japanese character and leaves the text out of the
+PDF. `verify_latex` picks the engine from the document, so nothing has to
+be configured, but the preamble is yours to write. Start `main.tex` with:
+
+```latex
+\documentclass[11pt]{article}
+\usepackage{luatexja-fontspec}
+\setmainjfont{IPAexMincho}
+\setsansjfont{IPAexGothic}
+```
+
+If `verify_latex` reports that lualatex is missing, install it:
+`apt-get install texlive-luatex texlive-lang-japanese`.
+
+The bundled templates (`iclr2024`, `mdpi`, `agents4science_2025`) are
+English conference styles with no CJK support, so a Japanese paper does
+not use them — write your own preamble as above and keep the structure
+(title, abstract, numbered sections, figures, bibliography). Translate to
+English only when the user asks; treat that as a rendering rather than a
+rewrite, since no claim, number or citation should change on the way.
+
 ## Flow
 
 1. **Discover**: author queries via

--- a/plugins/airas/skills/auto-research/SKILL.md
+++ b/plugins/airas/skills/auto-research/SKILL.md
@@ -18,6 +18,44 @@ You drive the research; AIRAS provides retrieval, curated generation steps
   generation tools, and `GH_PERSONAL_ACCESS_TOKEN` for
   repository/experiment tools.
 
+## Write in Japanese
+
+The people reviewing this work will not always have the domain knowledge
+to judge a claim — about protein-ligand scoring, say — on sight. A
+plausible-sounding mistake is only catchable if they can read it
+comfortably, so **every artifact a human is meant to check should be
+Japanese**: the hypothesis, the experimental design, the analysis report,
+and the paper itself, through to the PDF. The backend generation prompts
+are written to produce English, so in this mode that means editing what
+comes back — or switching to `auto-research-claude-code`, where you author
+the artifacts yourself and the language is simply yours to choose.
+
+Two things stay English because they are identifiers rather than prose:
+`primary_metric` / `supporting_metrics`, which are parsed downstream to
+compute the GAP, and BibTeX citation keys.
+
+A Japanese paper needs LuaTeX — pdflatex raises `LaTeX Error: Unicode
+character` for every Japanese character and leaves the text out of the
+PDF. `verify_latex` picks the engine from the document, so nothing has to
+be configured, but the preamble is yours to write. Start `main.tex` with:
+
+```latex
+\documentclass[11pt]{article}
+\usepackage{luatexja-fontspec}
+\setmainjfont{IPAexMincho}
+\setsansjfont{IPAexGothic}
+```
+
+If `verify_latex` reports that lualatex is missing, install it:
+`apt-get install texlive-luatex texlive-lang-japanese`.
+
+The bundled templates (`iclr2024`, `mdpi`, `agents4science_2025`) are
+English conference styles with no CJK support, so a Japanese paper does
+not use them — write your own preamble as above and keep the structure
+(title, abstract, numbered sections, figures, bibliography). Translate to
+English only when the user asks; treat that as a rendering rather than a
+rewrite, since no claim, number or citation should change on the way.
+
 ## Flow
 
 1. **Discover**: `generate_research_queries` → `search_papers` →


### PR DESCRIPTION
## 背景と目的

**成果物を確認する人が、その分野の専門家とは限りません。** タンパク質-リガンドのスコアリングのような話で、もっともらしい誤りをその場で見抜くのは、読んで理解できて初めて可能になります。したがって、人が確認する成果物は日本語で出せる必要があります。

ところが**日本語で書いた時点で検証が機能しません。**

`verify_latex_build` は `pdflatex` を決め打ちで実行しますが、pdflatex は CJK を組めません。日本語を含む `main.tex` を渡すと **1 文字ごとに** `LaTeX Error: Unicode character` が出て、その文字は PDF から脱落します。実測:

```
ok: False | compiled: True | pages: 1
errors: ['LaTeX Error: Unicode character は (U+306F)',
         'LaTeX Error: Unicode character じ (U+3058)', ...]
```

**PDF 自体は出るので、検証を挟まなければ本文が空のまま「成功」になります。**

## 変更内容

以下の機能が変更されました：

1. LaTeX エンジンを、設定ではなく**文書の内容から決定**するよう変更
2. **検証したビルドの PDF を受け取れるように**（`output_path`）
3. Overleaf に**どのエンジンで組むかを伝える**（`latexmkrc`）
4. 研究成果物を日本語で書く指示を両スキルに追加

実装の詳細は以下の通りです：

<details>
<summary><code>1. select_engine() によるエンジン選択</code></summary>

**実装概要**

`backend/src/airas/usecases/publication/nodes/verify_latex_build.py` に `select_engine()` を追加しました。

- **CJK（漢字・ひらがな・カタカナ・全角記号）を含めば `lualatex`、それ以外は `pdflatex`**
  - 引用符 `“ ”` やダッシュ `—` は CJK ではないので、欧文はこれまでどおり pdflatex です

- **設定項目にせず、ソースから導出しました。** 選択を誤ったときの結果が「好みが違う」ではなく**本文の欠落**であり、しかも PDF は出てしまうためです。エンジンを宣言させる方式にすると、言語を変えたときに宣言の更新を忘れる箇所が 1 つ増えるだけになります

- **toolchain の存在確認をエンジン決定の後ろに移動**しました
  - 従来は `pdflatex` の有無だけを見ていたため、日本語文書でも「pdflatex はある」と判定して先へ進み、あとで失敗していました
  - lualatex が無い場合は、何を入れればよいか（`texlive-luatex` / `texlive-lang-japanese`）を名指しします

</details>

<details>
<summary><code>2. 検証したビルドの PDF を受け取る</code></summary>

**実装概要**

エンジンを選べるようにしただけでは、**日本語論文は検証できても入手できません。**
`verify_latex_build` は一時ディレクトリでビルドして削除するため、**成立を確認したばかりの PDF がそのまま捨てられていました。** しかも日本語論文には他の入手経路がありません（`compile_latex` は GitHub Actions で pdflatex、`open_in_overleaf` の既定コンパイラも pdfLaTeX）。

- `verify_latex(output_path=...)` で書き出し先を指定でき、結果の `pdf_path` に実際の出力先が入ります
- **`ok` が偽でも PDF は残します。** `?` が実際にどこに出ているかは、報告を読むより見た方が速いためです
- ファイル名だけでなく**ディレクトリも受け付けます**。複数テンプレートを確認するときに、いちいち出力名を決めるのが煩わしいためです

</details>

<details>
<summary><code>3. Overleaf に伝えるエンジン</code></summary>

**実装概要**

Overleaf は latexmk でビルドし、既定は pdfLaTeX です。日本語論文をそのまま export すると、**本文が消えた PDF ができます。**

- 文書に CJK が含まれる場合、export するファイル集合に `latexmkrc`（`$pdf_mode = 4` = lualatex）を含めます
- latexmk はプロジェクト内の `latexmkrc` を読むので、**受け取った側がコンパイラ設定を探さなくても通ります**。設定を探そうと思うのは「本文の無い PDF」を見た後になるので、その一往復をなくします
- プロジェクトが自前の `latexmkrc` を持っている場合は上書きしません

</details>

<details>
<summary><code>4. スキルへの言語指示</code></summary>

**実装概要**

- **人が確認する成果物はすべて日本語**にします（仮説・実験計画・分析レポート・論文、PDF まで）

- **英語のままにするもの**: `primary_metric` / `supporting_metrics`（後段が GAP 計算のためにパースする）と BibTeX の引用キー。これらは散文ではなく識別子だからです

- **同梱テンプレート 3 種（`iclr2024` / `mdpi` / `agents4science_2025`）は使いません。** 英語会議用のスタイルで CJK 非対応なので、`luatexja` のプリアンブルを自前で書きます

  ```latex
  \documentclass[11pt]{article}
  \usepackage{luatexja-fontspec}
  \setmainjfont{IPAexMincho}
  \setsansjfont{IPAexGothic}
  ```

- **`auto-research`（バックエンド LLM モード）では自動で日本語になりません。** 生成プロンプトが英語で書かれているためです。その事実を隠さずに書き、言語を自分で選べる authoring モードを案内しています

</details>

5. テスト:
   - `test_verify_latex_build.py` に 7 件追加（計 15 件）
     - 日本語が `lualatex` を選ぶこと
     - **欧文の約物（`“ ”` / `—`）でエンジンが切り替わらないこと**
     - 日本語論文が実際にコンパイルされ、`ok` かつエラー無しで報告されること（`lualatex` / `luatexja` が無い環境ではスキップ）
     - 指定が無ければ PDF は破棄され、`pdf_path` が `None` になること
     - 指定した先に PDF が書かれること、ディレクトリ指定なら文書名が使われること
     - **`ok` が偽の論文でも PDF が残ること**
   - `test_collect_latex_engine_hint.py` を新規追加（3 件）
     - 日本語プロジェクトに `latexmkrc` が付くこと、英語には付かないこと、自前の `latexmkrc` を上書きしないこと

6. 動作確認（エンドツーエンド）:
   - 作業ツリーから収集 → `latexmkrc` が付く → ビルドが `ok` → PDF が残る → **日本語のテキスト抽出が正常**、まで一連で確認しました
   - 必要なのは `texlive-lang-japanese` と `texlive-luatex` の 2 パッケージで、和文フォント（IPAex）は同梱されます

7. 補足:
   - **このブランチは develop の壊れたテストファイルを含みます。** https://github.com/airas-org/airas/pull/986 を先にマージしてください（`tests/unit/test_litellm_client_openai_compatible.py` が `IndentationError` で、リポジトリ全体のテスト収集が止まっています）。それを除けば 130 passed です
   - **`texlive-luatex` / `texlive-lang-japanese` は devcontainer に入っていません。** 未導入の環境では `verify_latex` が何を入れるべきかを明示して失敗します。devcontainer への追加は別 PR とします
   - 日本語テンプレートを `airas-template` に追加するかは別途の判断です。現状はプリアンブルをスキル側に書く形なので、テンプレート追加なしで動きます
   - `compile_latex`（GitHub Actions 経路）は airas-template 側が pdflatex を使うため、日本語論文には対応していません。ローカルの `verify_latex(output_path=...)` と `open_in_overleaf` で完結します
