### PR TITLE
build: install LaTeX in the devcontainer so verify_latex can run

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -27,6 +27,28 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && corepack enable \
     && rm -rf /var/lib/apt/lists/*
 
+# LaTeX, for verify_latex. Without it the tool refuses to run rather than
+# reporting a paper as sound without having built it, so a container that
+# skips this layer simply cannot check a paper before it is published.
+#
+# texlive-latex-extra and texlive-science carry what the bundled templates
+# load (mdpi in particular pulls in a long list). texlive-luatex and
+# texlive-lang-japanese are what a Japanese paper needs: pdflatex raises
+# `LaTeX Error: Unicode character` for every CJK character and drops it
+# from the PDF, so verify_latex builds those with lualatex instead. The
+# IPAex fonts the preamble asks for ship with the language package.
+#
+# This is the largest layer in the image by some margin (~2 GB installed).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    texlive-latex-recommended \
+    texlive-latex-extra \
+    texlive-fonts-recommended \
+    texlive-science \
+    texlive-luatex \
+    texlive-lang-japanese \
+    texlive-binaries \
+    && rm -rf /var/lib/apt/lists/*
+
 # ttyd
 RUN DPKG_ARCH=$(dpkg --print-architecture) && \
     if [ "$DPKG_ARCH" = "amd64" ]; then TTYD_ARCH="x86_64"; else TTYD_ARCH="aarch64"; fi && \

--- a/plugins/airas/skills/auto-research-claude-code/SKILL.md
+++ b/plugins/airas/skills/auto-research-claude-code/SKILL.md
@@ -60,10 +60,13 @@ be configured, but the preamble is yours to write. Start `main.tex` with:
 
 ```latex
 \documentclass[11pt]{article}
-\usepackage{luatexja-fontspec}
-\setmainjfont{IPAexMincho}
-\setsansjfont{IPAexGothic}
+\usepackage{luatexja}
 ```
+
+That one package is enough — it brings its own Japanese fonts, so there
+is nothing to name and nothing to install beyond the TeX packages below.
+Reach for `luatexja-fontspec` and `\setmainjfont` only if a specific
+typeface is actually wanted.
 
 If `verify_latex` reports that lualatex is missing, install it:
 `apt-get install texlive-luatex texlive-lang-japanese`.

--- a/plugins/airas/skills/auto-research/SKILL.md
+++ b/plugins/airas/skills/auto-research/SKILL.md
@@ -41,10 +41,13 @@ be configured, but the preamble is yours to write. Start `main.tex` with:
 
 ```latex
 \documentclass[11pt]{article}
-\usepackage{luatexja-fontspec}
-\setmainjfont{IPAexMincho}
-\setsansjfont{IPAexGothic}
+\usepackage{luatexja}
 ```
+
+That one package is enough — it brings its own Japanese fonts, so there
+is nothing to name and nothing to install beyond the TeX packages below.
+Reach for `luatexja-fontspec` and `\setmainjfont` only if a specific
+typeface is actually wanted.
 
 If `verify_latex` reports that lualatex is missing, install it:
 `apt-get install texlive-luatex texlive-lang-japanese`.


### PR DESCRIPTION
## 背景と目的

**devcontainer に TeX が一切入っていません。**

そのため `verify_latex` は新しいコンテナでは動きません。このツールは「検証していないのに検証したつもり」を避けるため、toolchain が無ければ実行を拒否する作りです。つまり**手で TeX を入れた人以外は、論文を publish する前の唯一のチェックを使えない**状態でした。

https://github.com/airas-org/airas/pull/987 で日本語論文に対応しましたが、必要なパッケージが環境に無ければ意味がありません。

あわせて、スキルが案内しているプリアンブルが必要以上に複雑でした。

## 変更内容

以下の機能が変更されました：

1. `dev.Dockerfile` に LaTeX 一式を追加
2. スキルの日本語プリアンブルを 1 行に簡素化

実装の詳細は以下の通りです：

<details>
<summary><code>1. dev.Dockerfile への LaTeX 追加</code></summary>

**実装概要**

| パッケージ | 理由 |
|---|---|
| `texlive-latex-recommended` / `texlive-latex-extra` / `texlive-fonts-recommended` / `texlive-science` | 同梱テンプレートが読み込む一式（特に mdpi が長い依存を持つ） |
| `texlive-binaries` | `bibtex`。無いと健全な参考文献でも全引用が未定義として報告される |
| `texlive-luatex` / `texlive-lang-japanese` | 日本語論文に必要。pdflatex は CJK を組めず、1 文字ごとにエラーを出して本文を落とす |

- **IPAex フォントは `texlive-lang-japanese` の Depends** なので、`--no-install-recommends` でも入ります（Recommends ではありません）
- **`fontconfig` は追加していません。** 不要であることを確認済みです — 先の検証はいずれも fontconfig が未導入のコンテナで成功しており、luaotfload が TeX ツリー内のフォントを自前の索引で解決していました
- **イメージ中で最大のレイヤーです（インストール後 ~2 GB）。** その旨を Dockerfile のコメントに明記しました

</details>

<details>
<summary><code>2. プリアンブルの簡素化</code></summary>

**実装概要**

```diff
-\documentclass[11pt]{article}
-\usepackage{luatexja-fontspec}
-\setmainjfont{IPAexMincho}
-\setsansjfont{IPAexGothic}
+\documentclass[11pt]{article}
+\usepackage{luatexja}
```

`luatexja` は日本語フォントを自前で持つため、**フォント名を書く必要がありません。** 名前を間違える余地と fontconfig への依存が同時に消えます。特定の書体を使いたい場合のために `luatexja-fontspec` も案内は残しています。

タイトル・著者・abstract・番号付き節を含む日本語論文が、この 1 行のプリアンブルで `ok` かつ 1 ページの PDF になり、テキスト抽出も正常であることを確認しました。

</details>

3. 補足:
   - 既存の開発環境には手動で同じパッケージを導入済みです（コンテナの作り直しは不要）
