### PR TITLE
fix: grant release-drafter the contents:write it needs to draft releases

### DIFF
--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -5,9 +5,17 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   update-release-draft:
     runs-on: ubuntu-latest
+    permissions:
+      # Creating/updating the draft release needs write; the repository
+      # default token is read-only, which is what made drafting fail.
+      contents: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
The `Release Drafter` run after the merge to main failed with `Resource not accessible by integration` at release creation: the workflow declares no `permissions`, so it runs with the repository's read-only default `GITHUB_TOKEN`, which cannot create a (draft) release.

This scopes `contents: write` (+ `pull-requests: read` for reading merged PR labels) to the one job that needs it, keeping the workflow-level default at `contents: read`.

Notes, not addressed here:
- The run also warned about deprecated `categories[*].labels` / `version-resolver.*.labels` config fields (still functional on v7); migrating `.github/release-drafter.yml` to the `when` / `semver-increment` format can be done separately.
- With no prior release, the drafter resolves **v0.0.1** while `backend/pyproject.toml` is at 0.3.1. Consider publishing an initial `v0.3.1` release (or editing the draft's tag) once this lands, so subsequent increments track the real version line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015o8c3D7iXubdeQRQCp5oit