### PR TITLE
fix: two defects the end-to-end paper run surfaced in the gate

### DIFF
--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -1521,14 +1521,17 @@ async def render_chart(
     chart equivalent: a number that no run produced does not belong in a
     result figure.
 
-    Save charts as PDF under `.research/results/chart/` in the clone,
-    then commit and push — the LaTeX build collects every `*.pdf` under
-    `.research/results/`. The unresolved spec is written next to the
-    chart as `<file>.chartspec.json`; `verify_paper_values` re-resolves
-    and re-renders it and byte-compares, so keep the sidecar committed
-    with the chart. `output_path` must end with .pdf, .svg, or .png.
-    Rendering runs in-process (vl-convert); no data leaves the machine
-    and no API keys are required.
+    Save charts as **PNG** under `.research/results/chart/` in the clone,
+    then commit and push — the LaTeX build collects figure PDFs and PNGs
+    under `.research/results/`. PDF chart output is refused: vl-convert's
+    PDF bytes are not deterministic across processes, so a PDF chart
+    could never be verified against a re-render. The unresolved spec is
+    written next to the chart as `<file>.chartspec.json`;
+    `verify_paper_values` re-resolves and re-renders it and
+    byte-compares, so keep the sidecar committed with the chart.
+    `output_path` must end with .png or .svg. Rendering runs in-process
+    (vl-convert); no data leaves the machine and no API keys are
+    required.
     """
     path, suffix = _resolve_render_output(output_path)
 

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -1534,6 +1534,12 @@ async def render_chart(
     required.
     """
     path, suffix = _resolve_render_output(output_path)
+    if suffix == "pdf":
+        raise ValueError(
+            "output_path must end with .png or .svg: pdf charts cannot be "
+            "verified (vl-convert's PDF bytes are not deterministic across "
+            "processes), and LaTeX includes png directly"
+        )
 
     def _render() -> bytes:
         metrics_data = load_metrics_data(local_path)

--- a/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
+++ b/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
@@ -163,9 +163,14 @@ def collect_latex_project_files_local(
         figure_root = root / source_dir.rstrip("/")
         if not figure_root.is_dir():
             continue
-        for path in sorted(figure_root.rglob("*")):
-            if path.suffix.lower() not in _FIGURE_SUFFIXES:
-                continue
+        # Filter before sorting: these directories can hold many large
+        # experiment artifacts that are not figures.
+        figure_paths = (
+            path
+            for path in figure_root.rglob("*")
+            if path.suffix.lower() in _FIGURE_SUFFIXES
+        )
+        for path in sorted(figure_paths):
             if not _is_safe_local_file(path, figure_root):
                 continue
             repo_path = source_dir + path.relative_to(figure_root).as_posix()

--- a/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
+++ b/backend/src/airas/usecases/publication/open_in_overleaf_subgraph/nodes/collect_latex_project_files.py
@@ -22,6 +22,11 @@ _EXCLUDED_FILES = {"template.tex", "template.pdf"}
 # major release (see issue #913).
 _FIGURE_SOURCE_DIRS = (f"{RESULTS_DIR}/", f"{LEGACY_DIAGRAM_DIR}/")
 
+# PDF for run-generated and diagram figures; PNG because verified charts
+# are rendered as png (vl-convert's PDF output is not byte-deterministic,
+# so the chart pipeline cannot use it).
+_FIGURE_SUFFIXES = (".pdf", ".png")
+
 # Overleaf drives the build with latexmk and defaults it to pdfLaTeX, which
 # cannot typeset CJK — a Japanese paper would arrive there and come out with
 # its text missing. latexmk reads this file, so shipping it means the export
@@ -66,7 +71,7 @@ def _is_unsafe_relative_path(relative_path: str) -> bool:
 def _merge_figure(
     latex_files: dict[str, bytes], repo_path: str, content: bytes
 ) -> None:
-    if not repo_path.lower().endswith(".pdf"):
+    if not repo_path.lower().endswith(_FIGURE_SUFFIXES):
         return
     for source_dir in _FIGURE_SOURCE_DIRS:
         if repo_path.startswith(source_dir):
@@ -110,8 +115,8 @@ def collect_latex_project_files(
                 latex_files[relative_path] = archive.read(info)
             elif repo_path.startswith(
                 _FIGURE_SOURCE_DIRS
-            ) and repo_path.lower().endswith(".pdf"):
-                # Only figure PDFs are read: these directories can also hold
+            ) and repo_path.lower().endswith(_FIGURE_SUFFIXES):
+                # Only figure files are read: these directories can also hold
                 # large experiment artifacts that must not be loaded here.
                 if _is_unsafe_relative_path(repo_path):
                     logger.warning(
@@ -158,7 +163,9 @@ def collect_latex_project_files_local(
         figure_root = root / source_dir.rstrip("/")
         if not figure_root.is_dir():
             continue
-        for path in sorted(figure_root.rglob("*.pdf")):
+        for path in sorted(figure_root.rglob("*")):
+            if path.suffix.lower() not in _FIGURE_SUFFIXES:
+                continue
             if not _is_safe_local_file(path, figure_root):
                 continue
             repo_path = source_dir + path.relative_to(figure_root).as_posix()

--- a/backend/src/airas/usecases/publication/paper_values/charts.py
+++ b/backend/src/airas/usecases/publication/paper_values/charts.py
@@ -25,7 +25,15 @@ import vl_convert as vlc
 METRIC_REF_PREFIX = "metric:"
 CHART_DIR = ".research/results/chart"
 CHART_SPEC_SUFFIX = ".chartspec.json"
+# Every chart-like file under CHART_DIR is scanned (a smuggled PDF must
+# not escape), but only svg and png can actually be verified: vl-convert's
+# PDF writer emits hash-ordered dictionaries, so PDF bytes differ across
+# processes even for identical input and can never match a re-render.
 CHART_SUFFIXES = (".pdf", ".svg", ".png")
+VERIFIABLE_CHART_FORMATS = ("svg", "png")
+# Fixed render scale for png charts: part of the deterministic contract,
+# and high enough for print.
+PNG_SCALE = 3.0
 
 
 def substitute_chart_refs(
@@ -99,18 +107,20 @@ def substitute_chart_refs(
 
 def render_chart_bytes(resolved_spec: dict[str, Any], suffix: str) -> bytes:
     """Render a resolved spec with vl-convert (deterministic per version)."""
-    if suffix == "pdf":
-        return vlc.vegalite_to_pdf(resolved_spec)
     if suffix == "svg":
         svg: str = vlc.vegalite_to_svg(resolved_spec)
         return svg.encode("utf-8")
     if suffix == "png":
-        return vlc.vegalite_to_png(resolved_spec)
+        return vlc.vegalite_to_png(resolved_spec, scale=PNG_SCALE)
+    if suffix == "pdf":
+        raise ValueError(
+            "pdf charts cannot be verified: vl-convert's PDF output is not "
+            "byte-deterministic across processes, so a re-render never "
+            "matches. Render the chart as png (LaTeX includes it directly)."
+        )
     # A verifier passes the sidecar's recorded format here, so an
     # unexpected value must fail rather than silently render as PNG.
-    raise ValueError(
-        f"unsupported chart format {suffix!r} (expected 'pdf', 'svg', or 'png')"
-    )
+    raise ValueError(f"unsupported chart format {suffix!r} (expected 'svg' or 'png')")
 
 
 def renderer_version() -> str:

--- a/backend/src/airas/usecases/verification/ci_gate.py
+++ b/backend/src/airas/usecases/verification/ci_gate.py
@@ -25,6 +25,8 @@ import logging
 from pathlib import Path
 from typing import Any, Callable, cast, get_args
 
+import httpx
+
 from airas.core.types.latex import LATEX_TEMPLATE_NAME
 from airas.infra.seyval_client import SeyvalClient
 from airas.usecases.publication.nodes.verify_latex_build import verify_latex_build
@@ -37,6 +39,23 @@ from airas.usecases.verification.paper_verification import paper_values_full_rep
 logger = logging.getLogger(__name__)
 
 REPORT_FILENAME = "verification-report.json"
+
+_seyval_client: SeyvalClient | None = None
+
+
+def _default_seyval_client() -> SeyvalClient:
+    """A process-lifetime Seyval client for the CLI gate.
+
+    SeyvalClient requires its HTTP session by injection; the MCP server
+    supplies its own, and this is the CLI's. Cached because the factory
+    is called per template and the sessions are reusable.
+    """
+    global _seyval_client
+    if _seyval_client is None:
+        _seyval_client = SeyvalClient(
+            async_session=httpx.AsyncClient(timeout=60.0, follow_redirects=True)
+        )
+    return _seyval_client
 
 
 def detect_templates(local_repo_path: str) -> list[str]:
@@ -145,7 +164,7 @@ async def run_paper_gate(
     check_provenance: bool = True,
     require_paper_values: bool = True,
     require_provenance: bool = True,
-    seyval_client_factory: Callable[[], SeyvalClient] = SeyvalClient,
+    seyval_client_factory: Callable[[], SeyvalClient] = _default_seyval_client,
 ) -> dict[str, Any]:
     """Gate every written template; write PDFs and the report to `output_dir`.
 

--- a/backend/src/airas/usecases/verification/ci_gate.py
+++ b/backend/src/airas/usecases/verification/ci_gate.py
@@ -20,6 +20,7 @@ since an unverifiable paper and an unverified paper must not ship.
 from __future__ import annotations
 
 import asyncio
+import atexit
 import json
 import logging
 from pathlib import Path
@@ -43,18 +44,30 @@ REPORT_FILENAME = "verification-report.json"
 _seyval_client: SeyvalClient | None = None
 
 
+def _close_seyval_client() -> None:
+    # atexit runs after every event loop is gone, so a fresh one is fine;
+    # never let cleanup turn a finished gate run into a failure.
+    if _seyval_client is not None:
+        try:
+            asyncio.run(_seyval_client.aclose())
+        except Exception:  # pragma: no cover - best-effort cleanup
+            pass
+
+
 def _default_seyval_client() -> SeyvalClient:
     """A process-lifetime Seyval client for the CLI gate.
 
     SeyvalClient requires its HTTP session by injection; the MCP server
     supplies its own, and this is the CLI's. Cached because the factory
-    is called per template and the sessions are reusable.
+    is called per template and the sessions are reusable; closed at
+    process exit so the connection pool does not leak.
     """
     global _seyval_client
     if _seyval_client is None:
         _seyval_client = SeyvalClient(
             async_session=httpx.AsyncClient(timeout=60.0, follow_redirects=True)
         )
+        atexit.register(_close_seyval_client)
     return _seyval_client
 
 

--- a/backend/tests/unit/usecases/publication/test_paper_tables_charts.py
+++ b/backend/tests/unit/usecases/publication/test_paper_tables_charts.py
@@ -275,3 +275,20 @@ def test_chart_result_dirs_sees_nested_sidecars(tmp_path: Path) -> None:
     write_chart_sidecar(chart_path, CHART_SPEC, "svg")
     assert chart_result_dirs(str(tmp_path), METRICS_DATA) == {"run_1", "run_2"}
     assert verify_charts(str(tmp_path), METRICS_DATA) == []
+
+
+def test_render_chart_bytes_refuses_pdf() -> None:
+    # vl-convert's PDF writer emits hash-ordered dictionaries, so PDF
+    # bytes cannot be verified against a re-render.
+    with pytest.raises(ValueError, match="pdf charts cannot be verified"):
+        render_chart_bytes({}, "pdf")
+
+
+def test_png_charts_render_and_verify(tmp_path: Path) -> None:
+    chart_dir = tmp_path / CHART_DIR
+    chart_dir.mkdir(parents=True)
+    resolved, _ = substitute_chart_refs(CHART_SPEC, METRICS_DATA)
+    chart_path = chart_dir / "accuracy.png"
+    chart_path.write_bytes(render_chart_bytes(resolved, "png"))
+    write_chart_sidecar(chart_path, CHART_SPEC, "png")
+    assert verify_charts(str(tmp_path), METRICS_DATA) == []

--- a/plugins/airas/skills/auto-research-claude-code/SKILL.md
+++ b/plugins/airas/skills/auto-research-claude-code/SKILL.md
@@ -227,13 +227,15 @@ rewrite, since no claim, number or citation should change on the way.
 ## Figure conventions
 
 - Result charts: build a Vega-Lite spec and `render_chart` it (pass the
-  clone as `local_path`) to `.research/results/chart/<name>.pdf`. Data
-  numbers must be metric references (`"metric:run_1.accuracy"`), never
-  literals — the tool resolves them from `.research/results/` itself, so
-  a plotted point cannot be invented. Commit the chart **and** its
-  `.chartspec.json` sidecar; `verify_paper_values` re-renders every
-  chart from its sidecar and fails on any difference or missing sidecar.
-  Rendering is fully local; no API keys.
+  clone as `local_path`) to `.research/results/chart/<name>.png` (PNG,
+  not PDF — PDF chart output is refused because it cannot be verified
+  against a re-render). Data numbers must be metric references
+  (`"metric:run_1.accuracy"`), never literals — the tool resolves them
+  from `.research/results/` itself, so a plotted point cannot be
+  invented. Commit the chart **and** its `.chartspec.json` sidecar;
+  `verify_paper_values` re-renders every chart from its sidecar and
+  fails on any difference or missing sidecar. Rendering is fully local;
+  no API keys.
 - Method diagrams: write text notation (mermaid / graphviz / d2 / …) and
   `render_diagram` it to `.research/results/diagram/<name>.pdf`. Uses
   https://kroki.io by default; `KROKI_BASE_URL` switches to self-hosted.


### PR DESCRIPTION
Note: `develop` does not currently exist on the remote, so this targets `main`; happy to retarget if develop is recreated.

Running the full pipeline for real (experiment repo → seyval BYO run → `import_run_outputs` with manifest → declared values/tables/chart → paper → `airas verify-paper`) surfaced two defects that made the merged gate unable to go green:

1. **The CLI gate could never do the provenance cross-check.** `SeyvalClient` requires an injected HTTP session; `run_paper_gate`'s default factory passed the bare class, so construction raised and every gate run degraded to provenance `unavailable` — which the gate (rightly) fails. The default factory now builds a process-lifetime client with its own `httpx.AsyncClient`.

2. **PDF charts can never verify.** vl-convert's PDF writer emits hash-ordered dictionaries (`/fo0`/`/fo1` swap order across processes), so PDF bytes differ for identical input and the re-render byte-comparison always mismatched. Empirically, **png and svg are byte-deterministic across processes**; pdf is not. Chart rendering now refuses `pdf` with an explanation, renders `png` at a fixed scale (part of the deterministic contract), and the figure collectors (local + GitHub zip + merge) accept `.png` alongside `.pdf` so png charts reach the LaTeX build and the Overleaf export.

With these fixes the full local gate on the e2e repository (auto-res2/matsuzawa-20260831-integrity-gate-e2e) passes end to end: values recompute, table regeneration, chart re-render, **provenance `verified` against the declared Seyval run**, PDF built — with `\unverified{1969}` correctly surfaced as the only review item.

The CI gate (`verify_paper.yml` installs `airas@main`) starts working for real repositories once this lands on `main`; until then their gates fail on provenance `unavailable`.

Tests: 75 pass in publication/verification suites (new: pdf refusal, png render+verify). ruff + mypy clean via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015o8c3D7iXubdeQRQCp5oit