### PR TITLE
feat(gate): the record gate covers the paper's numbers

### DIFF
--- a/backend/src/airas/cli.py
+++ b/backend/src/airas/cli.py
@@ -94,9 +94,15 @@ def _run_verify_record(args: "argparse.Namespace") -> None:
         )
     )
 
-    print(f"[{'PASS' if summary['ok'] else 'FAIL'}] record ({summary['stage']})")
+    papers = ", ".join(summary["papers"]) if summary["papers"] else "no paper"
+    print(
+        f"[{'PASS' if summary['ok'] else 'FAIL'}] record ({summary['stage']}; {papers})"
+    )
     for failure in summary["failures"]:
         print(f"  - {failure}")
+    for result in summary["results"]:
+        for claim in result["unverified"]:
+            print(f"  ! \\unverified for human review: {claim}")
     for claim_id in summary["unverified_claims"]:
         print(f"  ! unverified claim: {claim_id} (no verified run backs it yet)")
     for claim_id in summary["refuted_claims"]:

--- a/backend/src/airas/usecases/github/set_github_actions_secrets_subgraph/set_github_actions_secrets_subgraph.py
+++ b/backend/src/airas/usecases/github/set_github_actions_secrets_subgraph/set_github_actions_secrets_subgraph.py
@@ -55,7 +55,7 @@ class SetGithubActionsSecretsSubgraph:
             "GH_PERSONAL_ACCESS_TOKEN",
             "AWS_ACCESS_KEY_ID",
             "AWS_SECRET_ACCESS_KEY",
-            # The paper gate (verify_and_publish_paper.yml) reads Seyval's per-run
+            # The record gate (verify_record.yml) reads Seyval's per-run
             # storage for the provenance cross-check.
             "SEYVAL_API_KEY",
         ]

--- a/backend/src/airas/usecases/verification/ci_gate.py
+++ b/backend/src/airas/usecases/verification/ci_gate.py
@@ -199,41 +199,73 @@ async def run_record_gate(
 ) -> dict[str, Any]:
     """The check that guards the protected branch.
 
-    Everything the paper gate does except the parts that need a paper, so it
-    can be required on every commit — including the ones that build the
-    experiment code and import run outputs, which is exactly the window in
-    which an unguarded branch would matter most.
+    Everything the paper gate does except the compile, so it can be required
+    on every commit — including the ones that build the experiment code and
+    import run outputs, which is exactly the window in which an unguarded
+    branch would matter most. No LaTeX is installed for it.
 
-    A repository with no record.json passes: there is nothing to
-    contradict yet. `require_provenance` still applies once runs exist, so
-    the pass does not quietly widen into "results without provenance are
-    fine".
+    A repository with no record.json passes: there is nothing to contradict
+    yet. A repository with a paper is held to more — its numbers must match
+    the record, and it must *have* a record, since a paper without one has
+    no verifiable number in it. `require_provenance` applies once runs
+    exist, so the early pass does not quietly widen into "results without
+    provenance are fine".
     """
     out = Path(output_dir).expanduser().resolve()
     out.mkdir(parents=True, exist_ok=True)
+    # Turning the check off is a decision not to require it. Letting the two
+    # disagree only produces "the provenance check did not run" on a run
+    # that was told not to run it.
+    require_provenance = require_provenance and check_provenance
 
-    report = await record_full_report(
-        local_repo_path, check_provenance, seyval_client_factory
-    )
-    merged = merge_paper_values_report({"ok": report.ok}, report)
-    failures = gate_failures(
-        merged,
-        require_paper_values=False,
-        # Turning the check off is a decision not to require it. Letting the
-        # two disagree only produces "the provenance check did not run" on a
-        # run that was told not to run it.
-        require_provenance=require_provenance and check_provenance,
-        require_history=require_history,
-    )
-    summary = {
-        "ok": not failures,
-        "failures": failures,
-        "stage": report.stage,
-        "unverified_claims": report.unverified_claims,
-        "refuted_claims": report.refuted_claims,
-        "orphan_runs": report.orphan_runs,
-        "report": merged,
+    templates = detect_templates(local_repo_path)
+    # No paper: one pass over the record alone.
+    targets: list[str | None] = list(templates) or [None]
+    results: list[dict[str, Any]] = []
+    for template in targets:
+        report = await record_full_report(
+            local_repo_path,
+            check_provenance,
+            seyval_client_factory,
+            cast(LATEX_TEMPLATE_NAME, template) if template else None,
+        )
+        merged = merge_paper_values_report({"ok": report.ok}, report)
+        failures = gate_failures(
+            merged,
+            # A paper without a record has no verifiable number in it.
+            require_paper_values=template is not None,
+            require_provenance=require_provenance,
+            require_history=require_history,
+        )
+        results.append(
+            {
+                "template": template,
+                "ok": not failures,
+                "failures": failures,
+                "stage": report.stage,
+                "unverified_claims": report.unverified_claims,
+                "refuted_claims": report.refuted_claims,
+                "orphan_runs": report.orphan_runs,
+                "unverified": report.unverified,
+                "report": merged,
+            }
+        )
+
+    summary: dict[str, Any] = {
+        "ok": all(r["ok"] for r in results),
+        "papers": templates,
+        "results": results,
     }
+    # Flattened for a reader who wants the verdict without walking results.
+    summary["failures"] = [
+        (f"{r['template']}: {f}" if r["template"] else f)
+        for r in results
+        for f in r["failures"]
+    ]
+    summary["stage"] = results[0]["stage"]
+    summary["unverified_claims"] = results[0]["unverified_claims"]
+    summary["refuted_claims"] = results[0]["refuted_claims"]
+    summary["orphan_runs"] = results[0]["orphan_runs"]
     (out / RECORD_REPORT_FILENAME).write_text(
         json.dumps(summary, indent=2, ensure_ascii=False, default=str) + "\n",
         encoding="utf-8",

--- a/backend/src/airas/usecases/verification/record_gate.py
+++ b/backend/src/airas/usecases/verification/record_gate.py
@@ -24,6 +24,7 @@ from typing import Any, Callable
 from pydantic import ValidationError
 
 from airas.core.research_paths import RECORD_PATH
+from airas.core.types.latex import LATEX_TEMPLATE_NAME
 from airas.core.types.paper_values import (
     ClaimStatus,
     PaperValuesVerificationReport,
@@ -47,6 +48,7 @@ from airas.usecases.publication.paper_values.verify import (
     apply_provenance_result,
     claim_evaluation_drift,
     referenced_result_dirs,
+    verify_paper_record,
 )
 from airas.usecases.verification.record_history import (
     compute_claim_status,
@@ -198,9 +200,23 @@ async def record_full_report(
     local_path: str,
     check_provenance: bool,
     seyval_client_factory: Callable[[], SeyvalClient],
+    latex_template_name: LATEX_TEMPLATE_NAME | None = None,
 ) -> PaperValuesVerificationReport:
-    """`verify_record_only` plus the cross-check against the platform."""
-    report = await asyncio.to_thread(verify_record_only, local_path)
+    """The record's checks, plus the paper's numbers when a paper exists.
+
+    With a template, the paper's value checks — values.tex against its
+    regeneration, declared tables, every `\\airasval` key declared — are
+    included, because "the numbers in the paper are the numbers in the
+    record" is integrity, not rendering, and belongs in the gate that
+    decides what lands. None of it needs LaTeX installed; the compile is
+    the publish step's concern. Then the cross-check against the platform.
+    """
+    if latex_template_name is None:
+        report = await asyncio.to_thread(verify_record_only, local_path)
+    else:
+        report = await asyncio.to_thread(
+            verify_paper_record, local_path, latex_template_name
+        )
     if not check_provenance:
         return report
 

--- a/backend/tests/unit/mcp/test_repository_setup.py
+++ b/backend/tests/unit/mcp/test_repository_setup.py
@@ -60,7 +60,7 @@ def recorder(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
 
 
 async def test_setup_configures_secrets_and_protection(recorder: _Recorder) -> None:
-    result = await server.prepare_repository.fn("o", "r")
+    result = await server.prepare_repository("o", "r")
 
     assert result["secrets_set"] is True
     assert result["branch_protected"] is True
@@ -76,7 +76,7 @@ async def test_setup_configures_secrets_and_protection(recorder: _Recorder) -> N
 async def test_the_protected_branch_can_differ_from_the_working_branch(
     recorder: _Recorder,
 ) -> None:
-    await server.prepare_repository.fn(
+    await server.prepare_repository(
         "o", "r", branch_name="research", protected_branch="main"
     )
     assert recorder.secrets == [("o", "r", "research")]
@@ -90,7 +90,7 @@ async def test_failed_protection_is_reported_but_does_not_lose_the_repository(
         raise RuntimeError("403 admin rights required")
 
     monkeypatch.setattr(server, "_apply_branch_protection", _boom)
-    result = await server.prepare_repository.fn("o", "r")
+    result = await server.prepare_repository("o", "r")
 
     # The repository was created; throwing that away would help nobody.
     assert result["is_repository_ready"] is True
@@ -111,7 +111,7 @@ async def test_failed_secrets_warn_that_the_check_will_look_green(
         raise RuntimeError("no token")
 
     monkeypatch.setattr(server, "_apply_secrets", _boom)
-    result = await server.prepare_repository.fn("o", "r")
+    result = await server.prepare_repository("o", "r")
 
     assert result["secrets_set"] is False
     assert any("skipped rather than fail" in w for w in result["warnings"])
@@ -120,7 +120,7 @@ async def test_failed_secrets_warn_that_the_check_will_look_green(
 
 
 async def test_configure_ci_can_be_declined(recorder: _Recorder) -> None:
-    result = await server.prepare_repository.fn("o", "r", configure_ci=False)
+    result = await server.prepare_repository("o", "r", configure_ci=False)
 
     assert result["secrets_set"] is False
     assert result["branch_protected"] is False
@@ -131,10 +131,10 @@ async def test_configure_ci_can_be_declined(recorder: _Recorder) -> None:
 
 async def test_standalone_tools_reach_the_same_code(recorder: _Recorder) -> None:
     """The repair path and the setup path must not drift apart."""
-    assert (await server.set_github_actions_secrets.fn("o", "r"))["secrets_set"]
+    assert (await server.set_github_actions_secrets("o", "r"))["secrets_set"]
     assert recorder.secrets == [("o", "r", "main")]
 
-    protect = await server.protect_branch.fn("o", "r")
+    protect = await server.protect_branch("o", "r")
     assert protect["branch_protected"] is True
     assert protect["required_checks"] == [server.RECORD_GATE_CHECK_NAME]
     assert recorder.protection[0][3] == [server.RECORD_GATE_CHECK_NAME]

--- a/backend/tests/unit/usecases/verification/test_record_gate.py
+++ b/backend/tests/unit/usecases/verification/test_record_gate.py
@@ -31,10 +31,17 @@ from airas.core.types.run_provenance import (
     ResultsDirProvenance,
     RunProvenanceManifest,
 )
-from airas.usecases.publication.paper_values.compute import load_metrics_data
+from airas.usecases.publication.paper_values.compute import (
+    load_metrics_data,
+    resolve_paper_values,
+)
+from airas.usecases.publication.paper_values.latex import render_values_tex
 from airas.usecases.publication.paper_values.realize import realize_record
 from airas.usecases.publication.paper_values.record import save_record
-from airas.usecases.publication.paper_values.verify import paper_values_configured
+from airas.usecases.publication.paper_values.verify import (
+    _scan_main_tex,
+    paper_values_configured,
+)
 from airas.usecases.verification.ci_gate import (
     RECORD_REPORT_FILENAME,
     run_record_gate,
@@ -396,7 +403,7 @@ async def test_gate_writes_its_report_when_red(tmp_path: Path) -> None:
     assert written["ok"] is False
     assert any(
         "criterion.min" in p
-        for p in written["report"]["paper_values"]["append_only_problems"]
+        for p in written["results"][0]["report"]["paper_values"]["append_only_problems"]
     )
 
 
@@ -453,3 +460,93 @@ async def test_a_shallow_clone_fails_rather_than_passing_quietly(
     )
     assert not summary["ok"]
     assert any("fetch-depth" in f for f in summary["failures"])
+
+
+# ---------------------------------------------- a paper, once one exists
+
+
+MAIN_TEX = "\n".join(
+    [
+        r"\documentclass{article}",
+        r"\input{values.tex}",
+        r"\begin{document}",
+        r"The gain is \airasval{c1.value}.",
+        r"\end{document}",
+        "",
+    ]
+)
+
+
+def _write_paper(repo: Path, record: ResearchRecord) -> Path:
+    latex_dir = repo / ".research" / "latex" / "mdpi"
+    latex_dir.mkdir(parents=True)
+    (latex_dir / "main.tex").write_text(MAIN_TEX)
+    metrics_data = load_metrics_data(str(repo))
+    values, _ = resolve_paper_values(record, metrics_data, _scan_main_tex(MAIN_TEX)[1])
+    (latex_dir / "values.tex").write_text(render_values_tex(values, None))
+    return latex_dir
+
+
+async def test_a_paper_whose_numbers_match_the_record_passes(tmp_path: Path) -> None:
+    repo, record = _realized_repo(tmp_path)
+    _write_paper(repo, record)
+    _commit(repo, "paper")
+
+    summary = await run_record_gate(
+        str(repo), str(repo / "out"), check_provenance=False
+    )
+    assert summary["ok"], summary["failures"]
+    assert summary["papers"] == ["mdpi"]
+
+
+async def test_a_hand_edited_values_tex_is_caught_by_the_gate(tmp_path: Path) -> None:
+    """The paper's numbers are integrity, not rendering.
+
+    Caught here, before the sha can land — not at publish time, when it
+    would already be on the protected branch.
+    """
+    repo, record = _realized_repo(tmp_path)
+    latex_dir = _write_paper(repo, record)
+    _commit(repo, "paper")
+    values_tex = latex_dir / "values.tex"
+    values_tex.write_text(values_tex.read_text().replace("3.6", "9.9"))
+
+    summary = await run_record_gate(
+        str(repo), str(repo / "out"), check_provenance=False
+    )
+    assert not summary["ok"]
+    assert any("values.tex" in f or "ok=false" in f for f in summary["failures"])
+    report = summary["results"][0]["report"]["paper_values"]
+    assert report["values_tex_match"] is False
+
+
+async def test_a_paper_without_a_record_fails(tmp_path: Path) -> None:
+    """A repository may have no record. A paper may not: none of its
+    numbers would be verifiable."""
+    _init(tmp_path)
+    latex_dir = tmp_path / ".research" / "latex" / "mdpi"
+    latex_dir.mkdir(parents=True)
+    (latex_dir / "main.tex").write_text(MAIN_TEX)
+    _commit(tmp_path, "paper with no record")
+
+    summary = await run_record_gate(
+        str(tmp_path), str(tmp_path / "out"), check_provenance=False
+    )
+    assert not summary["ok"]
+    assert any("record.json is missing" in f for f in summary["failures"])
+
+
+async def test_an_undeclared_airasval_key_fails(tmp_path: Path) -> None:
+    repo, record = _realized_repo(tmp_path)
+    latex_dir = _write_paper(repo, record)
+    (latex_dir / "main.tex").write_text(
+        MAIN_TEX.replace(r"\airasval{c1.value}", r"\airasval{c9.value}")
+    )
+    _commit(repo, "paper citing a claim that does not exist")
+
+    summary = await run_record_gate(
+        str(repo), str(repo / "out"), check_provenance=False
+    )
+    assert not summary["ok"]
+    report = summary["results"][0]["report"]["paper_values"]
+    assert report["undefined_keys"] == ["c9.value"]

--- a/plugins/airas/skills/preregister-paper/SKILL.md
+++ b/plugins/airas/skills/preregister-paper/SKILL.md
@@ -126,9 +126,10 @@ changes *when* the paper is written and how Results are stated.
    compile" open an editing channel where narrative changes can hide.
    The local build is only the fast feedback loop — the local
    toolchain is in the agent's hands, so its PDF proves nothing. The
-   **official prereg PDF is the CI artifact**: the freeze push triggers
-   `verify_and_publish_paper.yml`, which re-verifies the record and rebuilds where
-   the agent cannot interfere, and that artifact is what a human
+   **official prereg PDF is the CI artifact**: once the freeze commit
+   passes `Verify Record` on the staging ref and is fast-forwarded onto
+   the protected branch, `Publish Paper` builds it there, where the
+   agent cannot interfere, and that artifact is what a human
    reviews at freeze time (are the criteria reasonable? are the
    intervals narrow enough to miss? are the claims falsifiable?) and
    what a reader compares the final paper against.

--- a/plugins/airas/skills/publish-paper/SKILL.md
+++ b/plugins/airas/skills/publish-paper/SKILL.md
@@ -90,12 +90,15 @@ shortcut that settles the question.
 ## Official: CI verifies, its artifact is the record
 
 4. **Commit the main.tex edits and push to the staging ref** — not to
-   the protected branch (`git push origin main:verify`). Two jobs
-   run: `verify-record` (the required
-   check: recomputation, containment history, provenance
-   cross-check) and `build-paper`, which needs it and compiles the
-   PDF. Both upload their report even when red, so a failure is
-   readable rather than merely reported.
+   the protected branch (`git push origin main:verify`). The required
+   check, `Verify Record`, runs there. It is the whole integrity
+   verdict: the record's checks (recomputation, containment history,
+   provenance cross-check) **and the paper's numbers** — values.tex
+   against its regeneration, declared tables, every `\airasval` key
+   declared. None of that needs LaTeX, so it is fast, and a
+   hand-edited number is caught here, before the sha can land. The
+   report is uploaded even when red, so a failure is readable rather
+   than merely reported.
 
 5. **Confirm the gate is green** (`get_workflow_runs`), then
    fast-forward the same sha onto the protected branch
@@ -106,10 +109,18 @@ shortcut that settles the question.
    CI judged. (`prepare_repository` disables both merge methods, so
    normally the attempt simply fails — do not work around it.)
 
-   Give the user the commit sha, the workflow-run URL, and the
-   artifact — that trio is the citable, re-checkable result. A red
-   gate is not published: return to the local stage, fix, push to the
-   staging ref again.
+   Landing on the protected branch is what publishes. `Publish
+   Paper` runs there and nowhere else — every sha on that branch has
+   already passed the gate, so all that is left is to compile and
+   upload the PDF with its report. That ordering comes from the
+   branch rule, not from one workflow waiting on another.
+
+   Give the user the commit sha, the `Publish Paper` run URL, and
+   its artifact — that trio is the citable, re-checkable result. A
+   red gate is not published: return to the local stage, fix, push
+   to the staging ref again. A red *publish* on a green gate is a
+   rendering failure (a citation, a figure), not an integrity one;
+   fix it the same way.
 
 6. **Persist**: `upload_research_history`, so a later session can
    restore with `download_research_history`.


### PR DESCRIPTION
Follow-up to #1001. Pairs with [airas-template#36](https://github.com/airas-org/airas-template/pull/36), which renames the paper workflow to `publish_paper.yml` and runs it on the protected branch only.

Targets `main` directly: `develop` is currently behind `main` (it lacks #1001's commits), so a PR against it would carry three already-merged commits.

## What changes

`airas verify-record` now detects a paper and, when one exists, runs the paper's value checks alongside the record's:

- values.tex against its regeneration
- declared tables
- every `\airasval` key declared

None of that needs LaTeX, so the required check stays fast. And "the numbers in the paper are the numbers in the record" is integrity, not rendering — it belongs in the gate that decides what lands, not in the publish step, which runs after the sha already has. A paper without a record fails the gate: none of its numbers would be verifiable.

No new checking logic: the existing `verify_paper_record` does exactly this without the compile, so the gate calls it per detected template instead of `verify_record_only`. The compile stays with `verify-paper`.

## Why this shape and not `workflow_run`

The first proposal for "verify green, then publish" was a `workflow_run` trigger. It was withdrawn: it re-introduces the ordering that #1001 removed as non-load-bearing, through a mechanism with three GitHub-specific traps (checkout defaults to the default branch, path filters are ignored, the file must already be on `main`). Branch protection already guarantees the ordering — every sha on the protected branch has passed `Verify the record` — so `publish_paper.yml` simply runs on pushes to `main`. What this PR adds is the strengthening that makes that division clean: with the paper's numbers checked in the gate, publish has nothing left to verify.

## Also

- `run_record_gate` folds `check_provenance=False` into `require_provenance`. The CLI already computed this; the API did not, and produced "the provenance check did not run" on a run that was told not to run it.
- Tests: a paper whose values match passes; a hand-edited values.tex fails at the gate; a paper without a record fails; an undeclared `\airasval` key fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRzSXXGTSRrzqDCi9Kw65B