### PR TITLE
fix(verify): stop holding airas-eval's inputs digest against the file hash

### DIFF
--- a/backend/src/airas/infra/github_client.py
+++ b/backend/src/airas/infra/github_client.py
@@ -1207,12 +1207,15 @@ class GithubClient(BaseHTTPClient):
         github_owner: str,
         repository_name: str,
         branch_name: str | None = None,
-        event: str = "workflow_dispatch",
+        event: str | None = "workflow_dispatch",
         status: str | None = None,
         per_page: int = 100,
     ) -> dict | None:
+        """List workflow runs; `event=None` lists runs from every trigger."""
         path = f"/repos/{github_owner}/{repository_name}/actions/runs"
-        params = {"event": event, "per_page": per_page}
+        params: dict[str, str | int] = {"per_page": per_page}
+        if event:
+            params["event"] = event
         if branch_name:
             params["branch"] = branch_name
         if status:

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -1324,24 +1324,33 @@ async def get_workflow_runs(
     repository_name: str,
     branch_name: str | None = None,
     limit: int = 5,
+    event: str | None = None,
 ) -> list[dict[str, Any]]:
     """Check the status of recent GitHub Actions runs in the experiment repository (non-blocking).
 
-    Returns the most recent dispatched workflow runs with their status and
-    conclusion. Use this to track runs started by `dispatch_experiment`
-    (backend "github_actions") — poll it between other work instead of
-    waiting. Requires GH_PERSONAL_ACCESS_TOKEN.
+    Returns the most recent workflow runs with their status, conclusion and
+    the commit they ran on, newest first. Runs from every trigger are
+    included, so this is also how the record gate (`Verify Record`, which
+    runs on push) and `Publish Paper` are read: pass `branch_name="verify"`
+    to follow the staging ref, and match `head_sha` against the sha you
+    pushed. Pass `event="workflow_dispatch"` to see only runs started by
+    `dispatch_experiment`. Poll it between other work instead of waiting.
+    Requires GH_PERSONAL_ACCESS_TOKEN.
     """
     response = await _github_client().alist_workflow_runs(
         github_owner=github_owner,
         repository_name=repository_name,
         branch_name=branch_name,
+        event=event,
     )
     runs = (response or {}).get("workflow_runs", [])[:limit]
     return [
         {
             "workflow_run_id": run.get("id"),
             "name": run.get("name"),
+            "event": run.get("event"),
+            "head_branch": run.get("head_branch"),
+            "head_sha": run.get("head_sha"),
             "status": run.get("status"),
             "conclusion": run.get("conclusion"),
             "created_at": run.get("created_at"),

--- a/backend/src/airas/usecases/publication/paper_values/verify.py
+++ b/backend/src/airas/usecases/publication/paper_values/verify.py
@@ -268,20 +268,14 @@ def result_problems(
                 "evaluator's report in the results directory"
             )
 
-        # The evaluator says which inputs it computed from. That must be the
-        # inputs the record hashed, or the metrics and the inputs describe
-        # two different experiments.
-        if (
-            result.eval_report is not None
-            and result.eval_inputs is not None
-            and result.eval_report.inputs_sha256
-            and result.eval_report.inputs_sha256 != result.eval_inputs.sha256
-        ):
-            problems.append(
-                f"run '{rid}': the evaluator reports inputs "
-                f"{result.eval_report.inputs_sha256[:12]} but the result's "
-                f"eval_inputs hash is {result.eval_inputs.sha256[:12]}"
-            )
+        # The evaluator's own `inputs_sha256` is deliberately not compared
+        # with `eval_inputs.sha256`. airas-eval hashes the *parsed* payload
+        # in a canonical JSON form (sorted keys, no whitespace, its own type
+        # coercion), while the record hashes the file's bytes, so the two
+        # digests differ for every honest run. The evaluator's digest is
+        # still carried verbatim — it names what the evaluator scored in the
+        # evaluator's own terms — and the file hash is what the provenance
+        # step holds against the platform's stored bytes.
     return problems
 
 

--- a/backend/tests/unit/usecases/verification/test_record_gate.py
+++ b/backend/tests/unit/usecases/verification/test_record_gate.py
@@ -316,9 +316,14 @@ def test_an_inputs_hash_that_is_not_the_file_fails(tmp_path: Path) -> None:
     assert any("eval_inputs hash" in m for m in report.mismatches)
 
 
-def test_an_evaluator_report_that_disagrees_with_its_inputs_fails(
+def test_the_evaluators_own_inputs_digest_is_not_held_against_the_file_hash(
     tmp_path: Path,
 ) -> None:
+    """airas-eval hashes the canonical parsed payload, the record the bytes.
+
+    The two digests never agree, even for an honest run, so comparing them
+    would fail every repository. The evaluator's digest is recorded as-is.
+    """
     _init(tmp_path)
     record = _record()
     save_record(str(tmp_path), record)
@@ -343,8 +348,10 @@ def test_an_evaluator_report_that_disagrees_with_its_inputs_fails(
     _commit(tmp_path, "realize")
 
     report = verify_record_only(str(tmp_path))
-    assert not report.ok
-    assert any("evaluator reports inputs" in m for m in report.mismatches)
+    assert report.ok, report.mismatches
+    run = record.hypotheses[0].claims[0].designs[0].runs[0]
+    assert run.results[-1].eval_report is not None
+    assert run.results[-1].eval_report.inputs_sha256 == "f" * 64
 
 
 def test_results_no_run_declares_fail(tmp_path: Path) -> None:

--- a/plugins/airas/skills/_shared/references/seyval.md
+++ b/plugins/airas/skills/_shared/references/seyval.md
@@ -140,6 +140,15 @@ bash に届く前に置換されるので使えない。`for f in $(find ...)` �
 
 **同時に走らせられる run は 5 本まで**（超えると 429）。
 
+**★ 同じイメージを初めて使う run を同時に複数投げない（2026-09-03 実証）。**
+BYO Slurm ではログインノードで `apptainer pull` が走り、SIF を共有キャッシュに
+作る。同一イメージの初回 pull が並走すると blob を取り合い、負けた側が
+`open .../.apptainer/cache/.../blobs/sha256/...: no such file or directory` で
+`failure_origin: "system"` として落ちる（5 本同時投入で 2 本が 3 秒差で死んだ）。
+新しいコミットの最初の run は 1 本だけ投げ、イメージが pull され終わって
+（`status` が `running` になって）から残りを投げる。落ちた run はイメージが
+キャッシュ済みなので、そのまま再投入すれば通る。
+
 ```python
 command_args=[
     "uv", "run", "--no-sync", "python", "-u", "-m", "src.main",

--- a/plugins/airas/skills/analyze-results/SKILL.md
+++ b/plugins/airas/skills/analyze-results/SKILL.md
@@ -40,6 +40,9 @@ Needs imported results under `.research/results/` in a clone.
    spec to `.research/record.json` as its declaration and commits both
    in the same step — verification re-renders every chart from its
    declared spec and fails on differences or undeclared chart files.
+   Render charts **before** `update_record`, or re-run `update_record`
+   afterwards: the chart declaration is a new record commit, and
+   `values.tex` must be rendered against the latest one.
 5. **Method diagrams**: write text notation (mermaid / graphviz / d2)
    and `render_diagram` to `.research/results/diagram/<name>.pdf`.
 6. Commit and push. Reference figures in LaTeX as `images/<path>` with

--- a/plugins/airas/skills/publish-paper/SKILL.md
+++ b/plugins/airas/skills/publish-paper/SKILL.md
@@ -33,6 +33,15 @@ local stage.
    record is append-only, and a claim that missed its criterion is
    reported as a negative result, not rewritten.
 
+   **Run `update_record` last, after every other change to the
+   record.** The links in `values.tex` pin the commit that last wrote
+   `record.json`, and the gate regenerates `values.tex` from that
+   commit — so a `render_chart` or `append_to_record` made *after*
+   `update_record` leaves `values.tex` pointing at a superseded commit
+   and the gate reports `values.tex differs from its regeneration`.
+   The tool is idempotent (a result already recorded is not appended
+   twice), so re-running it after a late chart or append is the fix.
+
    `\airasval` addresses one of two things, both writable before any
    run exists:
 
@@ -98,7 +107,10 @@ shortcut that settles the question.
    report is uploaded even when red, so a failure is readable rather
    than merely reported.
 
-5. **Confirm the gate is green** (`get_workflow_runs`), then
+5. **Confirm the gate is green** — `get_workflow_runs` with
+   `branch_name="verify"`, reading the run whose `head_sha` is the sha
+   you pushed (an older green run on the same ref proves nothing about
+   the new commit) — then
    fast-forward the same sha onto the protected branch
    (`git push origin main:main`) — **never squash or rebase**. Squash and rebase rewrite commits, and verification asks
    whether each run's recorded commit is an ancestor of HEAD; after a


### PR DESCRIPTION
## Summary

Found on the first live run of the record gate (auto-res2/matsuzawa-20260903-zc-proxy-input-invariance, staging ref `verify`): every honest run failed with `the evaluator reports inputs X but the result's eval_inputs hash is Y`.

- **Digest cross-check removed.** airas-eval hashes the *parsed* payload in canonical JSON (sorted keys, no whitespace, its own type coercion); the record hashes the file's bytes. Different functions of the same file, so they never agree and the check rejected every repository. The evaluator's digest is still recorded verbatim; the file hash is what provenance holds against Seyval's stored bytes.
- **`get_workflow_runs` lists every trigger.** It listed only `workflow_dispatch` runs, so the record gate (push-triggered) was invisible to the tool the skill told the agent to read. Now lists all triggers with `head_sha` / `head_branch` / `event`; `event=` narrows.
- **Skills:** `update_record` must run last (a chart rendered after it moved the record commit `values.tex` pins, and the gate reported a regeneration mismatch; the tool is idempotent so re-running is the fix); `seyval.md` notes the apptainer-cache race when several first runs of one image start together (2 of 5 died 3 s apart, `failure_origin: system`).

Everything else in that CI run was green: provenance byte-matched 8 dirs × 5 files, `parameters_match` true, chart re-render, `values.tex` regeneration, containment history.

## Test plan

- [x] `pytest tests/unit/usecases/verification/test_record_gate.py tests/unit/usecases/publication/test_paper_values.py` — 42 passed
- [ ] After merge: re-run the gate on the experiment repo's `verify` sha `3d4d9e5` (CI installs airas from `@main`), expect green, then fast-forward `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRzSXXGTSRrzqDCi9Kw65B