### PR TITLE
skills: the CI-built PDF lands on the protected branch as paper.pdf

### DIFF
--- a/plugins/airas/skills/auto-research/SKILL.md
+++ b/plugins/airas/skills/auto-research/SKILL.md
@@ -29,8 +29,9 @@ Run these skills in order:
 - `analyze-results` — analysis and verifiable figures
 - `publish-paper` — numbers realized from declarations, compile +
   recompute + provenance checks until green locally, then push: CI
-  re-runs the verification and its artifact — the paper of record —
-  is handed to the user, state persisted
+  re-runs the verification, builds the PDF, commits it back onto the
+  protected branch as `paper.pdf` and uploads it as the artifact — the
+  paper of record — which is handed to the user, state persisted
 
 Execution platform references live in `_shared/references/` per
 platform.

--- a/plugins/airas/skills/publish-paper/SKILL.md
+++ b/plugins/airas/skills/publish-paper/SKILL.md
@@ -125,8 +125,19 @@ shortcut that settles the question.
    upload the PDF with its report. That ordering comes from the
    branch rule, not from one workflow waiting on another.
 
+   The workflow then commits the PDF it built, byte for byte, as
+   `.research/latex/{template}/paper.pdf` on the protected branch —
+   through the gate like any other commit (scratch ref, `Verify the
+   record` dispatched on it, fast-forward on green), under the
+   `github-actions[bot]` author. So the paper of record is in the
+   repository, not only in an expiring artifact, and it is never a
+   PDF built on the agent's machine: **do not commit a locally built
+   PDF**, and `git pull --ff-only origin main` before pushing anything
+   further, since main has moved by one commit.
+
    Give the user the commit sha, the `Publish Paper` run URL, and
-   its artifact — that trio is the citable, re-checkable result. A
+   its artifact (the same bytes as the committed `paper.pdf`) — that
+   trio is the citable, re-checkable result. A
    red gate is not published: return to the local stage, fix, push
    to the staging ref again. A red *publish* on a green gate is a
    rendering failure (a citation, a figure), not an integrity one;


### PR DESCRIPTION
## Summary

Companion to airas-template #37: Publish Paper now commits the PDF it built back onto the protected branch (through the gate, as `github-actions[bot]`). The `publish-paper` and `auto-research` skills say so, tell the agent never to commit a locally built PDF, and to `git pull --ff-only origin main` before pushing further since the branch moves by one commit.

## Test plan

- [x] Docs only; verified the described flow end to end on auto-res2/matsuzawa-20260903-zc-proxy-input-invariance (commit `b329435`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRzSXXGTSRrzqDCi9Kw65B