### PR TITLE
feat(record): fork points — commit the agent's state with the research (#1015)

### DIFF
--- a/backend/src/airas/cli.py
+++ b/backend/src/airas/cli.py
@@ -13,12 +13,18 @@ from airas.usecases.recording.agent_state import (
     load_agent_state,
     neutral_messages,
     pointer_from_hook,
+    read_pointer,
     render_handoff,
     restore_claude_session,
     write_pointer,
 )
 from airas.usecases.recording.codex_hooks import install_codex_hooks
-from airas.usecases.recording.research_trace import write_derived_from
+from airas.usecases.recording.research_trace import (
+    capture,
+    is_experiment_repository,
+    record_step,
+    write_derived_from,
+)
 from airas.usecases.recording.verify_record import verify_record
 
 # "AIRAS" on a phone keypad (per ITU-T E.161); a high port to avoid the
@@ -96,7 +102,21 @@ def _run_hook(args: argparse.Namespace) -> None:
 
     payload = json.load(sys.stdin)
     payload.setdefault("plugin_root", os.environ.get("CLAUDE_PLUGIN_ROOT"))
-    write_pointer(pointer_from_hook(args.harness, payload))
+    fresh = pointer_from_hook(args.harness, payload)
+    if args.hook_command == "session-start":
+        write_pointer(fresh)
+        return
+    if not is_experiment_repository(fresh.cwd):
+        return
+    # The pointer from session-start carries model and plugin root; later
+    # events fall back to what they carry themselves.
+    pointer = read_pointer(fresh.cwd) or fresh
+    if args.hook_command == "step":
+        step = (payload.get("tool_input") or {}).get("skill")
+        if step:
+            record_step(fresh.cwd, pointer, step)
+    else:
+        capture(fresh.cwd, pointer)
 
 
 def _run_session(args: argparse.Namespace) -> None:
@@ -108,6 +128,8 @@ def _run_session(args: argparse.Namespace) -> None:
 
     if args.derived_from:
         repository, _, commit = args.derived_from.rpartition("@")
+        if not commit:
+            raise SystemExit("--derived-from must be [REPOSITORY@]COMMIT")
         write_derived_from(
             args.local_path,
             DerivedFromRepository(
@@ -141,11 +163,13 @@ def main() -> None:
         "hook", help="Harness hook entry points (Claude Code / Codex hooks.json)"
     )
     hook_commands = hook.add_subparsers(dest="hook_command", required=True)
-    session_start = hook_commands.add_parser(
-        "session-start",
-        help="SessionStart hook: record the live session for end_step (JSON on stdin)",
-    )
-    session_start.add_argument("--harness", choices=["claude", "codex"], required=True)
+    for name, help_text in (
+        ("session-start", "SessionStart: record where the live session is"),
+        ("step", "PostToolUse(Skill): record the step the agent entered"),
+        ("capture", "Stop: capture the agent state and commit a fork point"),
+    ):
+        sub = hook_commands.add_parser(name, help=f"{help_text} (hook JSON on stdin)")
+        sub.add_argument("--harness", choices=["claude", "codex"], required=True)
     hook_commands.add_parser(
         "install", help="Write ~/.codex/hooks.json and enable Codex hooks"
     )

--- a/backend/src/airas/cli.py
+++ b/backend/src/airas/cli.py
@@ -1,12 +1,24 @@
 import argparse
 import asyncio
 import json
+import os
 import sys
 import threading
 import webbrowser
 from pathlib import Path
 
+from airas.core.types.research_trace import DerivedFromRepository
 from airas.usecases.publication.verify_paper import detect_templates, verify_paper
+from airas.usecases.recording.agent_state import (
+    load_agent_state,
+    neutral_messages,
+    pointer_from_hook,
+    render_handoff,
+    restore_claude_session,
+    write_pointer,
+)
+from airas.usecases.recording.codex_hooks import install_codex_hooks
+from airas.usecases.recording.research_trace import write_derived_from
 from airas.usecases.recording.verify_record import verify_record
 
 # "AIRAS" on a phone keypad (per ITU-T E.161); a high port to avoid the
@@ -77,12 +89,92 @@ def _run_verify_record(args: argparse.Namespace) -> None:
     sys.exit(0 if record.ok else 1)
 
 
+def _run_hook(args: argparse.Namespace) -> None:
+    if args.hook_command == "install":
+        print(install_codex_hooks())
+        return
+
+    payload = json.load(sys.stdin)
+    payload.setdefault("plugin_root", os.environ.get("CLAUDE_PLUGIN_ROOT"))
+    write_pointer(pointer_from_hook(args.harness, payload))
+
+
+def _run_session(args: argparse.Namespace) -> None:
+    state, state_path = load_agent_state(args.local_path, args.session_id)
+    if args.session_command == "export":
+        messages = neutral_messages(args.local_path, state)
+        print(json.dumps(messages, indent=2, ensure_ascii=False))
+        return
+
+    if args.derived_from:
+        repository, _, commit = args.derived_from.rpartition("@")
+        write_derived_from(
+            args.local_path,
+            DerivedFromRepository(
+                repository=repository or None,
+                commit=commit,
+                session_id=state.session.session_id,
+            ),
+        )
+    if args.to == "claude":
+        session_id, project = restore_claude_session(args.local_path, state)
+        print(
+            f"restored {state_path.name} into {project}\n"
+            f"cd {Path(args.local_path).resolve()} && claude --resume {session_id}",
+        )
+    else:
+        handoff = Path(args.local_path) / ".research" / "sessions" / "handoff.md"
+        handoff.write_text(
+            render_handoff(state, neutral_messages(args.local_path, state))
+        )
+        print(f"wrote {handoff}\nstart the harness in the clone and give it this file")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="airas",
         description="AIRAS: automated AI research toolkit",
     )
     subparsers = parser.add_subparsers(dest="command")
+
+    hook = subparsers.add_parser(
+        "hook", help="Harness hook entry points (Claude Code / Codex hooks.json)"
+    )
+    hook_commands = hook.add_subparsers(dest="hook_command", required=True)
+    session_start = hook_commands.add_parser(
+        "session-start",
+        help="SessionStart hook: record the live session for end_step (JSON on stdin)",
+    )
+    session_start.add_argument("--harness", choices=["claude", "codex"], required=True)
+    hook_commands.add_parser(
+        "install", help="Write ~/.codex/hooks.json and enable Codex hooks"
+    )
+
+    session = subparsers.add_parser(
+        "session", help="Export or restore the agent state stored at a fork point"
+    )
+    session_commands = session.add_subparsers(dest="session_command", required=True)
+    for name, help_text in (
+        ("export", "Print the session as harness-neutral messages (JSON)"),
+        ("import", "Rebuild a resumable session from the clone's agent state"),
+    ):
+        sub = session_commands.add_parser(name, help=help_text)
+        sub.add_argument("--local-path", default=".", help="Clone of the fork point")
+        sub.add_argument(
+            "--session-id", help="Which stored session (default: the latest)"
+        )
+        if name == "import":
+            sub.add_argument(
+                "--to",
+                choices=["claude", "prompt"],
+                default="claude",
+                help="claude: resumable Claude Code session; prompt: handoff.md",
+            )
+            sub.add_argument(
+                "--derived-from",
+                metavar="[REPOSITORY@]COMMIT",
+                help="Record this clone as forked from that fork point",
+            )
 
     subparsers.add_parser("mcp", help="Run the MCP server on stdio (default)")
 
@@ -189,7 +281,11 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if args.command == "dashboard":
+    if args.command == "hook":
+        _run_hook(args)
+    elif args.command == "session":
+        _run_session(args)
+    elif args.command == "dashboard":
         _run_dashboard(args.host, args.port, open_browser=not args.no_browser)
     elif args.command == "verify-paper":
         _run_verify_paper(args)

--- a/backend/src/airas/core/research_paths.py
+++ b/backend/src/airas/core/research_paths.py
@@ -15,6 +15,13 @@ METRICS_FILENAME = "metrics.json"
 COMPARISON_KEY = "comparison"
 COMPARISON_METRICS_FILENAME = "aggregated_metrics.json"
 
+# The fork point: what an agent needs to resume the research from a commit.
+# One directory per harness session holding the raw transcript, its neutral
+# rendering and the harness configuration; one JSONL of step boundaries.
+SESSIONS_DIR = ".research/sessions"
+STEPS_PATH = ".research/trace/steps.jsonl"
+DERIVED_FROM_PATH = ".research/derived_from.json"
+
 # Method diagrams, by the current convention.
 DIAGRAM_DIR = f"{RESULTS_DIR}/diagram"
 

--- a/backend/src/airas/core/types/agent_state.py
+++ b/backend/src/airas/core/types/agent_state.py
@@ -50,8 +50,8 @@ class SessionState(BaseModel):
 
 
 # MCP サーバーに「今どのセッションから呼ばれているか」を知らせる橋渡し情報。
-# hook がセッション開始時に ~/.airas/sessions/ に書き、end_step がこれを
-# 読んで live session（cwd、transcript の場所など）を特定する。
+# SessionStart hook が ~/.airas/sessions/ に書き、Stop hook の capture が
+# これを読んで live session（cwd、transcript の場所など）を特定する。
 class SessionPointer(BaseModel):
     harness: Harness
     session_id: str

--- a/backend/src/airas/core/types/agent_state.py
+++ b/backend/src/airas/core/types/agent_state.py
@@ -1,0 +1,61 @@
+"""The agent side of a fork point.
+
+A fork point is a commit holding the experiment repository *and* the state
+of the agent that produced it, so anyone can clone that commit and continue
+from the same place — with the same agent, a different model or harness,
+or a different method. The agent's state is its harness (who is running)
+and its session (what it saw and did); both are stored under
+`.research/sessions/<harness>/<session_id>/`.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+Harness = Literal["claude", "codex"]
+
+
+class AgentState(BaseModel):
+    harness: HarnessState
+    session: SessionState
+
+
+class HarnessState(BaseModel):
+    kind: Harness
+    version: Optional[str] = None
+    model: Optional[str] = None
+    files: dict[str, str] = Field(
+        default_factory=dict,
+        description="Settings and instruction files by original path; secrets masked",
+    )
+    memory: dict[str, str] = Field(
+        default_factory=dict, description="Memory files by name"
+    )
+    plugin: Optional[PluginRef] = None
+
+
+class PluginRef(BaseModel):
+    root: str
+    version: Optional[str] = None
+    skills_sha256: str = Field(description="Hash of every file under skills/")
+
+
+class SessionState(BaseModel):
+    session_id: str
+    transcripts: list[str] = Field(
+        description="Raw transcript files copied verbatim, repo-relative"
+    )
+
+
+# MCP サーバーに「今どのセッションから呼ばれているか」を知らせる橋渡し情報。
+# hook がセッション開始時に ~/.airas/sessions/ に書き、end_step がこれを
+# 読んで live session（cwd、transcript の場所など）を特定する。
+class SessionPointer(BaseModel):
+    harness: Harness
+    session_id: str
+    cwd: str
+    transcript_path: Optional[str] = None
+    model: Optional[str] = None
+    plugin_root: Optional[str] = None

--- a/backend/src/airas/core/types/agent_state.py
+++ b/backend/src/airas/core/types/agent_state.py
@@ -10,9 +10,10 @@ and its session (what it saw and did); both are stored under
 
 from __future__ import annotations
 
+import re
 from typing import Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 Harness = Literal["claude", "codex"]
 
@@ -59,3 +60,15 @@ class SessionPointer(BaseModel):
     transcript_path: Optional[str] = None
     model: Optional[str] = None
     plugin_root: Optional[str] = None
+
+    @field_validator("session_id")
+    @classmethod
+    def _one_path_segment(cls, value: str) -> str:
+        # The id names a directory under .research/sessions/; hook input
+        # comes from stdin, so it must not carry separators or "..".
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", value) or value in (
+            ".",
+            "..",
+        ):
+            raise ValueError(f"session_id is not a plain name: {value!r}")
+        return value

--- a/backend/src/airas/core/types/research_trace.py
+++ b/backend/src/airas/core/types/research_trace.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+# commit と AgentState を「どの step / iteration / run だったか」と一緒に結ぶ、
+# 研究 workflow の trace の 1 行。step の begin と end で 1 行ずつ追記する。
+# .research/trace/steps.jsonl に追記されていく。
+class ResearchTraceEvent(BaseModel):
+    kind: Literal["begin", "end"]
+    step: str
+    iteration: int = Field(ge=1, description="How many times this step has begun")
+    timestamp: str
+    head: Optional[str] = Field(default=None, description="HEAD when the event fired")
+    run_ids: list[str] = Field(default_factory=list)
+    reason: Optional[str] = None
+    session_id: Optional[str] = None
+    agent_state: Optional[str] = Field(
+        default=None, description="Repo-relative path of the AgentState written"
+    )
+    intervention: Optional[dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "First step after a fork: how this agent differs from the one at "
+            "the fork point (agent side) and what was changed on purpose "
+            "(research side)"
+        ),
+    )
+
+
+# 派生リポジトリの系譜。今の repo が「どの元 repo・commit・session から
+# 派生したか」を 1 リンク分持ち、派生の派生はリンクを辿ってチェーンにする。
+class DerivedFromRepository(BaseModel):
+    repository: Optional[str] = None
+    commit: str
+    session_id: Optional[str] = None

--- a/backend/src/airas/core/types/research_trace.py
+++ b/backend/src/airas/core/types/research_trace.py
@@ -5,27 +5,27 @@ from typing import Any, Literal, Optional
 from pydantic import BaseModel, Field
 
 
-# commit と AgentState を「どの step / iteration / run だったか」と一緒に結ぶ、
-# 研究 workflow の trace の 1 行。step の begin と end で 1 行ずつ追記する。
-# .research/trace/steps.jsonl に追記されていく。
+# commit と AgentState を「どの step だったか」と一緒に結ぶ、研究 workflow の
+# trace の 1 行。ハーネスの hook が .research/trace/steps.jsonl に追記する:
+# step はスキルに入ったとき（Claude Code の Skill 呼び出し）、capture はターン
+# 終了ごとの AgentState の取り込みと commit。
 class ResearchTraceEvent(BaseModel):
-    kind: Literal["begin", "end"]
-    step: str
-    iteration: int = Field(ge=1, description="How many times this step has begun")
+    kind: Literal["step", "capture"]
     timestamp: str
+    session_id: str
     head: Optional[str] = Field(default=None, description="HEAD when the event fired")
-    run_ids: list[str] = Field(default_factory=list)
-    reason: Optional[str] = None
-    session_id: Optional[str] = None
+    step: Optional[str] = Field(default=None, description="Skill entered (kind=step)")
+    iteration: Optional[int] = Field(
+        default=None, ge=1, description="How many times this step has begun"
+    )
     agent_state: Optional[str] = Field(
         default=None, description="Repo-relative path of the AgentState written"
     )
     intervention: Optional[dict[str, Any]] = Field(
         default=None,
         description=(
-            "First step after a fork: how this agent differs from the one at "
-            "the fork point (agent side) and what was changed on purpose "
-            "(research side)"
+            "First capture after a fork: how this harness differs from the one "
+            "at the fork point"
         ),
     )
 

--- a/backend/src/airas/infra/local_git.py
+++ b/backend/src/airas/infra/local_git.py
@@ -32,6 +32,14 @@ def remote_origin_url(repo_root: Path) -> str | None:
     return _text(repo_root, "remote", "get-url", "origin")
 
 
+def head_commit(repo_root: Path) -> str | None:
+    return _text(repo_root, "rev-parse", "HEAD")
+
+
+def is_tracked(repo_root: Path, path: Path) -> bool:
+    return bool(_text(repo_root, "ls-files", "--", str(path)))
+
+
 def current_branch(repo_root: Path) -> str | None:
     branch = _text(repo_root, "rev-parse", "--abbrev-ref", "HEAD")
     return None if branch in (None, "HEAD") else branch  # HEAD = detached

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -170,8 +170,6 @@ from airas.usecases.publication.verify_paper import (
     verify_latex_build,
     verify_paper,
 )
-from airas.usecases.recording.research_trace import begin_step as trace_begin_step
-from airas.usecases.recording.research_trace import end_step as trace_end_step
 from airas.usecases.recording.update_or_load_record import (
     load_metrics_data,
     load_provenance_manifest,
@@ -2306,66 +2304,6 @@ async def append_to_record(
         }
 
     return await asyncio.to_thread(_run)
-
-
-@mcp.tool()
-async def begin_step(
-    local_path: str,
-    step: str,
-    run_ids: list[str] | None = None,
-    reason: str | None = None,
-) -> dict[str, Any]:
-    """Mark the start of a research step in the trace.
-
-    Call on entering a step skill (`setup-repository`, `discover-papers`,
-    `hypothesize-and-design`, `preregister-paper`, `write-experiment-code`,
-    `run-experiments`, `analyze-results`, `publish-paper`). `run_ids` are
-    the runs this pass works on; `reason` says why the step began again
-    when it is a repeat (a failed run, a gate rejection, an unsupported
-    result). One research is a single line of commits with steps repeated,
-    so the trace records iterations, not branches.
-
-    In a repository forked from a fork point (`.research/derived_from.json`
-    present), the first call also records the intervention: how the live
-    harness differs from the one the fork point was captured with, and the
-    `reason` as what the researcher changed on purpose.
-    """
-    event = await asyncio.to_thread(trace_begin_step, local_path, step, run_ids, reason)
-    return event.model_dump(exclude_defaults=True)
-
-
-@mcp.tool()
-async def end_step(
-    local_path: str,
-    step: str,
-    reason: str | None = None,
-) -> dict[str, Any]:
-    """Close a research step: capture the agent's state and commit a fork point.
-
-    Copies the live harness session (raw transcripts, subagents included)
-    and the harness configuration (model, version, settings, instructions,
-    memory, plugin) into `.research/sessions/<harness>/<session_id>/`, appends
-    the boundary to `.research/trace/steps.jsonl`, and commits the whole
-    working tree. The returned `commit` is the fork point: anyone can clone
-    it and continue from this step with `airas session import`, with the
-    same agent, another model or harness, or another method.
-
-    The live session is known only when the harness's SessionStart hook has
-    run (the airas plugin installs it for Claude Code; `airas hook install
-    codex` for Codex). Without it the step is still traced and committed,
-    with no agent state. Push after this call so the fork point is shared.
-    """
-    event, commit = await asyncio.to_thread(trace_end_step, local_path, step, reason)
-    if commit is None:
-        raise ValueError(
-            "the step was traced but git commit failed — the clone needs a "
-            "commit identity configured"
-        )
-    return {
-        **event.model_dump(exclude_defaults=True),
-        "commit": commit,
-        "next": "push, then `airas session import` restores this fork point elsewhere",
-    }
 
 
 @mcp.tool()

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -170,6 +170,8 @@ from airas.usecases.publication.verify_paper import (
     verify_latex_build,
     verify_paper,
 )
+from airas.usecases.recording.research_trace import begin_step as trace_begin_step
+from airas.usecases.recording.research_trace import end_step as trace_end_step
 from airas.usecases.recording.update_or_load_record import (
     load_metrics_data,
     load_provenance_manifest,
@@ -2304,6 +2306,66 @@ async def append_to_record(
         }
 
     return await asyncio.to_thread(_run)
+
+
+@mcp.tool()
+async def begin_step(
+    local_path: str,
+    step: str,
+    run_ids: list[str] | None = None,
+    reason: str | None = None,
+) -> dict[str, Any]:
+    """Mark the start of a research step in the trace.
+
+    Call on entering a step skill (`setup-repository`, `discover-papers`,
+    `hypothesize-and-design`, `preregister-paper`, `write-experiment-code`,
+    `run-experiments`, `analyze-results`, `publish-paper`). `run_ids` are
+    the runs this pass works on; `reason` says why the step began again
+    when it is a repeat (a failed run, a gate rejection, an unsupported
+    result). One research is a single line of commits with steps repeated,
+    so the trace records iterations, not branches.
+
+    In a repository forked from a fork point (`.research/derived_from.json`
+    present), the first call also records the intervention: how the live
+    harness differs from the one the fork point was captured with, and the
+    `reason` as what the researcher changed on purpose.
+    """
+    event = await asyncio.to_thread(trace_begin_step, local_path, step, run_ids, reason)
+    return event.model_dump(exclude_defaults=True)
+
+
+@mcp.tool()
+async def end_step(
+    local_path: str,
+    step: str,
+    reason: str | None = None,
+) -> dict[str, Any]:
+    """Close a research step: capture the agent's state and commit a fork point.
+
+    Copies the live harness session (raw transcripts, subagents included)
+    and the harness configuration (model, version, settings, instructions,
+    memory, plugin) into `.research/sessions/<harness>/<session_id>/`, appends
+    the boundary to `.research/trace/steps.jsonl`, and commits the whole
+    working tree. The returned `commit` is the fork point: anyone can clone
+    it and continue from this step with `airas session import`, with the
+    same agent, another model or harness, or another method.
+
+    The live session is known only when the harness's SessionStart hook has
+    run (the airas plugin installs it for Claude Code; `airas hook install
+    codex` for Codex). Without it the step is still traced and committed,
+    with no agent state. Push after this call so the fork point is shared.
+    """
+    event, commit = await asyncio.to_thread(trace_end_step, local_path, step, reason)
+    if commit is None:
+        raise ValueError(
+            "the step was traced but git commit failed — the clone needs a "
+            "commit identity configured"
+        )
+    return {
+        **event.model_dump(exclude_defaults=True),
+        "commit": commit,
+        "next": "push, then `airas session import` restores this fork point elsewhere",
+    }
 
 
 @mcp.tool()

--- a/backend/src/airas/usecases/recording/agent_state.py
+++ b/backend/src/airas/usecases/recording/agent_state.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any
+
+from airas.core.research_paths import SESSIONS_DIR
+from airas.core.types.agent_state import (
+    AgentState,
+    Harness,
+    HarnessState,
+    PluginRef,
+    SessionPointer,
+    SessionState,
+)
+from airas.infra.local_git import is_tracked
+
+POINTER_DIR = Path("~/.airas/sessions").expanduser()
+CLAUDE_HOME = Path("~/.claude").expanduser()
+CODEX_HOME = Path("~/.codex").expanduser()
+AGENT_STATE_FILENAME = "agent_state.json"
+
+_SECRET = re.compile(
+    r"(?i)(\"?[\w.-]*(?:key|token|secret|password)[\w.-]*\"?\s*[:=]\s*)(\"[^\"]*\"|\S+)"
+)
+
+
+# ---------------------------------------------------------------- pointer
+# airas hook session-start が書き、end_step が読む live セッションの所在。
+
+
+def _pointer_path(cwd: str) -> Path:
+    digest = hashlib.sha256(str(Path(cwd).resolve()).encode()).hexdigest()[:16]
+    return POINTER_DIR / f"{digest}.json"
+
+
+def write_pointer(pointer: SessionPointer) -> Path:
+    path = _pointer_path(pointer.cwd)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(pointer.model_dump_json(indent=2))
+    return path
+
+
+def read_pointer(cwd: str) -> SessionPointer | None:
+    path = _pointer_path(cwd)
+    if not path.is_file():
+        return None
+    return SessionPointer.model_validate_json(path.read_text())
+
+
+def pointer_from_hook(harness: Harness, payload: dict[str, Any]) -> SessionPointer:
+    # Both harnesses send session_id, transcript_path, cwd and model on
+    # SessionStart; the plugin root is Claude Code's hook environment.
+    return SessionPointer(
+        harness=harness,
+        session_id=payload["session_id"],
+        cwd=payload.get("cwd") or str(Path.cwd()),
+        transcript_path=payload.get("transcript_path"),
+        model=payload.get("model"),
+        plugin_root=payload.get("plugin_root"),
+    )
+
+
+# ---------------------------------------------------------------- capture
+# end_step が使う側。ポインタからトランスクリプトと設定を集め、
+# .research/sessions/<harness>/<session_id>/ に AgentState として書く。
+
+
+def _claude_project_dir(cwd: str) -> Path:
+    return CLAUDE_HOME / "projects" / re.sub(r"[^A-Za-z0-9]", "-", str(cwd))
+
+
+def transcript_files(pointer: SessionPointer) -> list[Path]:
+    if pointer.harness == "claude":
+        main = (
+            Path(pointer.transcript_path)
+            if pointer.transcript_path
+            else _claude_project_dir(pointer.cwd) / f"{pointer.session_id}.jsonl"
+        )
+        subagents = main.parent / pointer.session_id / "subagents"
+        return [p for p in [main, *sorted(subagents.glob("*.jsonl"))] if p.is_file()]
+    if pointer.transcript_path and Path(pointer.transcript_path).is_file():
+        return [Path(pointer.transcript_path)]
+    return sorted(
+        (CODEX_HOME / "sessions").glob(f"**/rollout-*-{pointer.session_id}.jsonl")
+    )
+
+
+def _mask(text: str) -> str:
+    return _SECRET.sub(r'\1"***"', text)
+
+
+def _read_files(paths: list[Path], root: Path | None = None) -> dict[str, str]:
+    # Files the repository already tracks are not copied again.
+    return {
+        str(p): _mask(p.read_text(errors="replace"))
+        for p in paths
+        if p.is_file() and not (root and is_tracked(root, p))
+    }
+
+
+def _plugin_ref(root: str | None) -> PluginRef | None:
+    if not root or not Path(root).is_dir():
+        return None
+    base = Path(root)
+    digest = hashlib.sha256()
+    for path in sorted(p for p in (base / "skills").rglob("*") if p.is_file()):
+        digest.update(str(path.relative_to(base)).encode())
+        digest.update(path.read_bytes())
+    manifest = base / ".claude-plugin" / "plugin.json"
+    version = (
+        json.loads(manifest.read_text()).get("version") if manifest.is_file() else None
+    )
+    return PluginRef(root=root, version=version, skills_sha256=digest.hexdigest())
+
+
+def _first_json(path: Path, predicate: Any) -> dict[str, Any]:
+    with path.open() as f:
+        for line in f:
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if predicate(obj):
+                return obj
+    return {}
+
+
+def harness_state(pointer: SessionPointer, transcripts: list[Path]) -> HarnessState:
+    repo = Path(pointer.cwd)
+    if pointer.harness == "claude":
+        first = (
+            _first_json(transcripts[0], lambda o: o.get("type") == "assistant")
+            if transcripts
+            else {}
+        )
+        project = _claude_project_dir(pointer.cwd)
+        return HarnessState(
+            kind="claude",
+            version=first.get("version"),
+            model=pointer.model or (first.get("message") or {}).get("model"),
+            files=_read_files(
+                [
+                    CLAUDE_HOME / "settings.json",
+                    CLAUDE_HOME / "CLAUDE.md",
+                    repo / ".claude" / "settings.json",
+                    repo / ".claude" / "settings.local.json",
+                    repo / "CLAUDE.md",
+                    repo / ".claude" / "CLAUDE.md",
+                    repo / ".claude" / "CLAUDE.local.md",
+                    *sorted((repo / ".claude" / "rules").glob("*.md")),
+                ],
+                repo,
+            ),
+            memory={
+                p.name: p.read_text() for p in sorted((project / "memory").glob("*.md"))
+            },
+            plugin=_plugin_ref(pointer.plugin_root),
+        )
+    meta = (
+        _first_json(transcripts[0], lambda o: o.get("type") == "session_meta")
+        if transcripts
+        else {}
+    )
+    turn = (
+        _first_json(transcripts[0], lambda o: o.get("type") == "turn_context")
+        if transcripts
+        else {}
+    )
+    return HarnessState(
+        kind="codex",
+        version=(meta.get("payload") or {}).get("cli_version"),
+        model=pointer.model or (turn.get("payload") or {}).get("model"),
+        files=_read_files(
+            [CODEX_HOME / "config.toml", CODEX_HOME / "AGENTS.md", repo / "AGENTS.md"],
+            repo,
+        ),
+        plugin=_plugin_ref(pointer.plugin_root),
+    )
+
+
+def _state_dir(local_path: str, harness: Harness, session_id: str) -> Path:
+    return Path(local_path).expanduser().resolve() / SESSIONS_DIR / harness / session_id
+
+
+def capture_agent_state(
+    local_path: str, pointer: SessionPointer
+) -> tuple[AgentState, str]:
+    """Copy the live session into the repository; returns the state and the
+    repo-relative path of agent_state.json."""
+    root = Path(local_path).expanduser().resolve()
+    target = _state_dir(local_path, pointer.harness, pointer.session_id)
+    target.mkdir(parents=True, exist_ok=True)
+    sources = transcript_files(pointer)
+    copied: list[str] = []
+    for source in sources:
+        dest = target / (
+            "subagents/" + source.name if "subagents" in source.parts else source.name
+        )
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, dest)
+        copied.append(str(dest.relative_to(root)))
+    state = AgentState(
+        harness=harness_state(pointer, sources),
+        session=SessionState(session_id=pointer.session_id, transcripts=copied),
+    )
+    state_path = target / AGENT_STATE_FILENAME
+    state_path.write_text(state.model_dump_json(indent=2, exclude_defaults=True))
+    return state, str(state_path.relative_to(root))
+
+
+# ---------------------------------------------------------------- diff
+# 派生後の最初の begin_step で、fork 点のハーネスと live のハーネスを比べる。
+
+
+def harness_diff(before: HarnessState, after: HarnessState) -> dict[str, Any]:
+    """What changed between two harness configurations, by field."""
+
+    def digest(files: dict[str, str]) -> dict[str, str]:
+        return {
+            k: hashlib.sha256(v.encode()).hexdigest()[:12] for k, v in files.items()
+        }
+
+    a = {
+        "kind": before.kind,
+        "version": before.version,
+        "model": before.model,
+        "plugin": before.plugin.model_dump() if before.plugin else None,
+        "files": digest(before.files),
+        "memory": digest(before.memory),
+    }
+    b = {
+        "kind": after.kind,
+        "version": after.version,
+        "model": after.model,
+        "plugin": after.plugin.model_dump() if after.plugin else None,
+        "files": digest(after.files),
+        "memory": digest(after.memory),
+    }
+    return {k: {"from": a[k], "to": b[k]} for k in a if a[k] != b[k]}
+
+
+# ---------------------------------------------------------------- restore
+# airas session import / export が使う側。clone の AgentState から
+# 中立形式の messages、handoff.md、Claude Code の resume 可能なセッションを作る。
+
+
+def _list_agent_states(local_path: str) -> list[Path]:
+    root = Path(local_path).expanduser().resolve() / SESSIONS_DIR
+    return sorted(
+        root.glob(f"*/*/{AGENT_STATE_FILENAME}"), key=lambda p: p.stat().st_mtime
+    )
+
+
+def load_agent_state(
+    local_path: str, session_id: str | None = None
+) -> tuple[AgentState, Path]:
+    """The named session's state, or the most recently written one."""
+    paths = _list_agent_states(local_path)
+    if session_id:
+        paths = [p for p in paths if p.parent.name == session_id]
+    if not paths:
+        raise FileNotFoundError(
+            f"no agent state under {SESSIONS_DIR} in {local_path}"
+            + (f" for session {session_id}" if session_id else "")
+        )
+    path = paths[-1]
+    return AgentState.model_validate_json(path.read_text()), path
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    out = []
+    for line in path.read_text().splitlines():
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def neutral_messages(local_path: str, state: AgentState) -> list[dict[str, Any]]:
+    """The session as a harness-neutral message list: role, content parts
+    (text / thinking / tool_use / tool_result), ids and timestamps."""
+    root = Path(local_path).expanduser().resolve()
+    messages: list[dict[str, Any]] = []
+    for rel in state.session.transcripts:
+        agent = Path(rel).stem if "/subagents/" in rel else None
+        for obj in _read_jsonl(root / rel):
+            parsed = (
+                _claude_message(obj)
+                if state.harness.kind == "claude"
+                else _codex_message(obj)
+            )
+            if parsed:
+                messages.append({**parsed, **({"agent_id": agent} if agent else {})})
+    return messages
+
+
+def _claude_message(obj: dict[str, Any]) -> dict[str, Any] | None:
+    if obj.get("type") not in ("user", "assistant"):
+        return None
+    message = obj.get("message") or {}
+    content = message.get("content")
+    parts = [{"type": "text", "text": content}] if isinstance(content, str) else content
+    return {
+        "role": message.get("role", obj["type"]),
+        "content": parts or [],
+        "id": obj.get("uuid"),
+        "parent_id": obj.get("parentUuid"),
+        "timestamp": obj.get("timestamp"),
+    }
+
+
+def _codex_message(obj: dict[str, Any]) -> dict[str, Any] | None:
+    if obj.get("type") != "response_item":
+        return None
+    p = obj.get("payload") or {}
+    kind = p.get("type")
+    base = {"id": p.get("id") or p.get("call_id"), "timestamp": obj.get("timestamp")}
+    if kind == "message":
+        parts = [
+            {"type": "text", "text": c.get("text", "")} for c in p.get("content") or []
+        ]
+        return {"role": p.get("role", "assistant"), "content": parts, **base}
+    if kind == "reasoning":
+        text = "\n".join(s.get("text", "") for s in p.get("summary") or [])
+        return {
+            "role": "assistant",
+            "content": [{"type": "thinking", "text": text}],
+            **base,
+        }
+    if kind in ("function_call", "custom_tool_call"):
+        raw = p.get("arguments") if kind == "function_call" else p.get("input")
+        try:
+            args = json.loads(raw) if isinstance(raw, str) else raw
+        except json.JSONDecodeError:
+            args = {"raw": raw}
+        part = {
+            "type": "tool_use",
+            "id": p.get("call_id"),
+            "name": p.get("name"),
+            "input": args,
+        }
+        return {"role": "assistant", "content": [part], **base}
+    if kind in ("function_call_output", "custom_tool_call_output"):
+        part = {
+            "type": "tool_result",
+            "tool_use_id": p.get("call_id"),
+            "content": p.get("output"),
+        }
+        return {"role": "user", "content": [part], **base}
+    return None
+
+
+def render_handoff(state: AgentState, messages: list[dict[str, Any]]) -> str:
+    """The neutral messages as one Markdown document, for a harness that
+    cannot resume the raw transcript."""
+    lines = [
+        f"# Session {state.session.session_id} ({state.harness.kind}, "
+        f"{state.harness.model or 'model unknown'})",
+        "",
+        "Continue this research from where the transcript below ends.",
+        "",
+    ]
+    for m in messages:
+        who = m["role"] + (f" [{m['agent_id']}]" if m.get("agent_id") else "")
+        for part in m["content"]:
+            kind = part.get("type")
+            if kind in ("text", "thinking"):
+                lines += [f"## {who} ({kind})", part.get("text", ""), ""]
+            elif kind == "tool_use":
+                lines += [
+                    f"## {who} (tool_use {part.get('name')})",
+                    "```json",
+                    json.dumps(part.get("input"), ensure_ascii=False, indent=2),
+                    "```",
+                    "",
+                ]
+            elif kind == "tool_result":
+                body = part.get("content")
+                text = (
+                    body
+                    if isinstance(body, str)
+                    else json.dumps(body, ensure_ascii=False)
+                )
+                lines += [f"## {who} (tool_result)", "```", text, "```", ""]
+    return "\n".join(lines)
+
+
+def restore_claude_session(local_path: str, state: AgentState) -> tuple[str, Path]:
+    """Write the transcripts back where Claude Code looks for them, bound to
+    this clone and a fresh session id; returns (session_id, project dir)."""
+    if state.harness.kind != "claude":
+        raise ValueError(
+            f"cannot resume a {state.harness.kind} transcript in Claude Code"
+        )
+    root = Path(local_path).expanduser().resolve()
+    project = _claude_project_dir(str(root))
+    project.mkdir(parents=True, exist_ok=True)
+    new_id = str(uuid.uuid4())
+    old_id = state.session.session_id
+    main = _read_jsonl(root / state.session.transcripts[0])
+    old_cwd = next((m["cwd"] for m in main if m.get("cwd")), None)
+    for rel in state.session.transcripts:
+        text = (root / rel).read_text().replace(old_id, new_id)
+        if old_cwd:
+            text = text.replace(old_cwd, str(root))
+        dest = (
+            project / new_id / "subagents" / Path(rel).name
+            if "/subagents/" in rel
+            else project / f"{new_id}.jsonl"
+        )
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(text)
+    memory = project / "memory"
+    memory.mkdir(exist_ok=True)
+    for name, body in state.harness.memory.items():
+        if not (memory / name).exists():
+            (memory / name).write_text(body)
+    return new_id, project

--- a/backend/src/airas/usecases/recording/agent_state.py
+++ b/backend/src/airas/usecases/recording/agent_state.py
@@ -30,7 +30,7 @@ _SECRET = re.compile(
 
 
 # ---------------------------------------------------------------- pointer
-# airas hook session-start が書き、end_step が読む live セッションの所在。
+# airas hook session-start が書き、airas hook capture が読む live セッションの所在。
 
 
 def _pointer_path(cwd: str) -> Path:
@@ -66,7 +66,7 @@ def pointer_from_hook(harness: Harness, payload: dict[str, Any]) -> SessionPoint
 
 
 # ---------------------------------------------------------------- capture
-# end_step が使う側。ポインタからトランスクリプトと設定を集め、
+# airas hook capture が使う側。ポインタからトランスクリプトと設定を集め、
 # .research/sessions/<harness>/<session_id>/ に AgentState として書く。
 
 
@@ -214,7 +214,7 @@ def capture_agent_state(
 
 
 # ---------------------------------------------------------------- diff
-# 派生後の最初の begin_step で、fork 点のハーネスと live のハーネスを比べる。
+# 派生後の最初の hook イベントで、fork 点のハーネスと live のハーネスを比べる。
 
 
 def harness_diff(before: HarnessState, after: HarnessState) -> dict[str, Any]:
@@ -419,6 +419,5 @@ def restore_claude_session(local_path: str, state: AgentState) -> tuple[str, Pat
     memory = project / "memory"
     memory.mkdir(exist_ok=True)
     for name, body in state.harness.memory.items():
-        if not (memory / name).exists():
-            (memory / name).write_text(body)
+        (memory / name).write_text(body)
     return new_id, project

--- a/backend/src/airas/usecases/recording/codex_hooks.py
+++ b/backend/src/airas/usecases/recording/codex_hooks.py
@@ -15,26 +15,28 @@ import tomli_w
 
 from airas.usecases.recording.agent_state import CODEX_HOME
 
-SESSION_START_COMMAND = "uvx --with 'mcp<2' airas hook session-start --harness codex"
+HOOK_COMMANDS = {
+    "SessionStart": "uvx --with 'mcp<2' airas hook session-start --harness codex",
+    "Stop": "uvx --with 'mcp<2' airas hook capture --harness codex",
+}
 
 
 def install_codex_hooks(home: Path = CODEX_HOME) -> str:
     home.mkdir(parents=True, exist_ok=True)
     hooks_path = home / "hooks.json"
     hooks = json.loads(hooks_path.read_text()) if hooks_path.is_file() else {}
-    groups = hooks.setdefault("hooks", {}).setdefault("SessionStart", [])
-    if not any(
-        h.get("command") == SESSION_START_COMMAND
-        for group in groups
-        for h in group.get("hooks", [])
-    ):
-        groups.append(
-            {"hooks": [{"type": "command", "command": SESSION_START_COMMAND}]}
-        )
+    for event, command in HOOK_COMMANDS.items():
+        groups = hooks.setdefault("hooks", {}).setdefault(event, [])
+        if not any(
+            h.get("command") == command
+            for group in groups
+            for h in group.get("hooks", [])
+        ):
+            groups.append({"hooks": [{"type": "command", "command": command}]})
     hooks_path.write_text(json.dumps(hooks, indent=2) + "\n")
 
     config_path = home / "config.toml"
     config = tomli.loads(config_path.read_text()) if config_path.is_file() else {}
     config.setdefault("features", {})["codex_hooks"] = True
     config_path.write_text(tomli_w.dumps(config))
-    return f"installed SessionStart hook in {hooks_path}; enabled features.codex_hooks in {config_path}"
+    return f"installed airas hooks in {hooks_path}; enabled features.codex_hooks in {config_path}"

--- a/backend/src/airas/usecases/recording/codex_hooks.py
+++ b/backend/src/airas/usecases/recording/codex_hooks.py
@@ -1,0 +1,40 @@
+"""Install the SessionStart hook for Codex CLI.
+
+Codex has no plugin that carries hooks, so the hook is written to the
+user's `~/.codex/hooks.json` (effective in every project) and the hooks
+feature is switched on in `~/.codex/config.toml`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import tomli
+import tomli_w
+
+from airas.usecases.recording.agent_state import CODEX_HOME
+
+SESSION_START_COMMAND = "uvx --with 'mcp<2' airas hook session-start --harness codex"
+
+
+def install_codex_hooks(home: Path = CODEX_HOME) -> str:
+    home.mkdir(parents=True, exist_ok=True)
+    hooks_path = home / "hooks.json"
+    hooks = json.loads(hooks_path.read_text()) if hooks_path.is_file() else {}
+    groups = hooks.setdefault("hooks", {}).setdefault("SessionStart", [])
+    if not any(
+        h.get("command") == SESSION_START_COMMAND
+        for group in groups
+        for h in group.get("hooks", [])
+    ):
+        groups.append(
+            {"hooks": [{"type": "command", "command": SESSION_START_COMMAND}]}
+        )
+    hooks_path.write_text(json.dumps(hooks, indent=2) + "\n")
+
+    config_path = home / "config.toml"
+    config = tomli.loads(config_path.read_text()) if config_path.is_file() else {}
+    config.setdefault("features", {})["codex_hooks"] = True
+    config_path.write_text(tomli_w.dumps(config))
+    return f"installed SessionStart hook in {hooks_path}; enabled features.codex_hooks in {config_path}"

--- a/backend/src/airas/usecases/recording/research_trace.py
+++ b/backend/src/airas/usecases/recording/research_trace.py
@@ -1,0 +1,140 @@
+"""Step boundaries: the research trace and the fork-point commit.
+
+`begin_step` records where a step starts; `end_step` captures the agent's
+state into the repository and commits everything, making that commit a
+fork point. The trace is advisory — never part of the record gate.
+
+begin_step が「研究の状態」側を書き、end_step が「エージェントの状態」側を埋めて commit する
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from airas.core.research_paths import DERIVED_FROM_PATH, STEPS_PATH
+from airas.core.types.agent_state import SessionPointer
+from airas.core.types.research_trace import DerivedFromRepository, ResearchTraceEvent
+from airas.infra.local_git import commit_paths, head_commit
+from airas.usecases.recording.agent_state import (
+    capture_agent_state,
+    harness_diff,
+    harness_state,
+    load_agent_state,
+    read_pointer,
+    transcript_files,
+)
+
+
+def _root(local_path: str) -> Path:
+    return Path(local_path).expanduser().resolve()
+
+
+def _read_trace(local_path: str) -> list[ResearchTraceEvent]:
+    path = _root(local_path) / STEPS_PATH
+    if not path.is_file():
+        return []
+    return [
+        ResearchTraceEvent.model_validate_json(line)
+        for line in path.read_text().splitlines()
+        if line.strip()
+    ]
+
+
+def _append(local_path: str, event: ResearchTraceEvent) -> None:
+    path = _root(local_path) / STEPS_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as f:
+        f.write(event.model_dump_json(exclude_defaults=True) + "\n")
+
+
+def _read_derived_from(local_path: str) -> DerivedFromRepository | None:
+    path = _root(local_path) / DERIVED_FROM_PATH
+    return (
+        DerivedFromRepository.model_validate_json(path.read_text())
+        if path.is_file()
+        else None
+    )
+
+
+def write_derived_from(local_path: str, origin: DerivedFromRepository) -> Path:
+    path = _root(local_path) / DERIVED_FROM_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(origin.model_dump_json(indent=2, exclude_defaults=True))
+    return path
+
+
+def _intervention(
+    local_path: str,
+    pointer: SessionPointer | None,
+    trace: list[ResearchTraceEvent],
+    reason: str | None,
+) -> dict[str, Any] | None:
+    # Only the first step this session takes in a forked repository compares
+    # the live harness with the one the fork point was captured from.
+    origin = _read_derived_from(local_path)
+    if origin is None or any(
+        e.session_id == (pointer and pointer.session_id) for e in trace
+    ):
+        return None
+    diff: dict[str, Any] = {}
+    if pointer is not None:
+        try:
+            source, _ = load_agent_state(local_path, origin.session_id)
+            diff = harness_diff(
+                source.harness, harness_state(pointer, transcript_files(pointer))
+            )
+        except FileNotFoundError:
+            pass
+    return {"agent": diff, "research": reason}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def begin_step(
+    local_path: str,
+    step: str,
+    run_ids: list[str] | None = None,
+    reason: str | None = None,
+) -> ResearchTraceEvent:
+    trace = _read_trace(local_path)
+    pointer = read_pointer(local_path)
+    event = ResearchTraceEvent(
+        kind="begin",
+        step=step,
+        iteration=sum(1 for e in trace if e.kind == "begin" and e.step == step) + 1,
+        timestamp=_now(),
+        head=head_commit(_root(local_path)),
+        run_ids=run_ids or [],
+        reason=reason,
+        session_id=pointer.session_id if pointer else None,
+        intervention=_intervention(local_path, pointer, trace, reason),
+    )
+    _append(local_path, event)
+    return event
+
+
+def end_step(
+    local_path: str, step: str, reason: str | None = None
+) -> tuple[ResearchTraceEvent, str | None]:
+    trace = _read_trace(local_path)
+    pointer = read_pointer(local_path)
+    state_path = capture_agent_state(local_path, pointer)[1] if pointer else None
+    event = ResearchTraceEvent(
+        kind="end",
+        step=step,
+        iteration=max((e.iteration for e in trace if e.step == step), default=1),
+        timestamp=_now(),
+        head=head_commit(_root(local_path)),
+        reason=reason,
+        session_id=pointer.session_id if pointer else None,
+        agent_state=state_path,
+    )
+    _append(local_path, event)
+    commit = commit_paths(
+        _root(local_path), ["."], f"step: end {step} #{event.iteration}"
+    )
+    return event, commit

--- a/backend/src/airas/usecases/recording/research_trace.py
+++ b/backend/src/airas/usecases/recording/research_trace.py
@@ -113,8 +113,8 @@ def capture(
     local_path: str, pointer: SessionPointer
 ) -> tuple[ResearchTraceEvent, str | None]:
     """Capture the agent state, record it and commit the whole working
-    tree; returns the event and the fork-point commit (None if nothing
-    changed or the commit failed)."""
+    tree; returns the event and the fork-point commit — HEAD if nothing
+    was left to commit, None only if the commit failed."""
     trace = _read_trace(local_path)
     event = ResearchTraceEvent(
         kind="capture",

--- a/backend/src/airas/usecases/recording/research_trace.py
+++ b/backend/src/airas/usecases/recording/research_trace.py
@@ -1,10 +1,11 @@
-"""Step boundaries: the research trace and the fork-point commit.
+"""The research trace and the fork-point commit, driven by harness hooks.
 
-`begin_step` records where a step starts; `end_step` captures the agent's
-state into the repository and commits everything, making that commit a
-fork point. The trace is advisory — never part of the record gate.
+SessionStart → session-start: where the live session is (SessionPointer)
+PostToolUse(Skill) → step: which step the agent entered
+Stop → capture: AgentState into the repository, then commit the tree —
+that commit is a fork point.
 
-begin_step が「研究の状態」側を書き、end_step が「エージェントの状態」側を埋めて commit する
+The trace is advisory — never part of the record gate.
 """
 
 from __future__ import annotations
@@ -22,13 +23,18 @@ from airas.usecases.recording.agent_state import (
     harness_diff,
     harness_state,
     load_agent_state,
-    read_pointer,
     transcript_files,
 )
 
 
 def _root(local_path: str) -> Path:
     return Path(local_path).expanduser().resolve()
+
+
+def is_experiment_repository(local_path: str) -> bool:
+    # Hooks fire in every session of the harness; only a clone with a
+    # .research/ directory is a research the trace belongs to.
+    return (_root(local_path) / ".research").is_dir()
 
 
 def _read_trace(local_path: str) -> list[ResearchTraceEvent]:
@@ -66,75 +72,60 @@ def write_derived_from(local_path: str, origin: DerivedFromRepository) -> Path:
 
 
 def _intervention(
-    local_path: str,
-    pointer: SessionPointer | None,
-    trace: list[ResearchTraceEvent],
-    reason: str | None,
+    local_path: str, pointer: SessionPointer, trace: list[ResearchTraceEvent]
 ) -> dict[str, Any] | None:
-    # Only the first step this session takes in a forked repository compares
-    # the live harness with the one the fork point was captured from.
+    # Only this session's first event in a forked repository compares the
+    # live harness with the one the fork point was captured from.
     origin = _read_derived_from(local_path)
-    if origin is None or any(
-        e.session_id == (pointer and pointer.session_id) for e in trace
-    ):
+    if origin is None or any(e.session_id == pointer.session_id for e in trace):
         return None
-    diff: dict[str, Any] = {}
-    if pointer is not None:
-        try:
-            source, _ = load_agent_state(local_path, origin.session_id)
-            diff = harness_diff(
-                source.harness, harness_state(pointer, transcript_files(pointer))
-            )
-        except FileNotFoundError:
-            pass
-    return {"agent": diff, "research": reason}
+    try:
+        source, _ = load_agent_state(local_path, origin.session_id)
+    except FileNotFoundError:
+        return {}
+    return harness_diff(
+        source.harness, harness_state(pointer, transcript_files(pointer))
+    )
 
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
-def begin_step(
-    local_path: str,
-    step: str,
-    run_ids: list[str] | None = None,
-    reason: str | None = None,
+def record_step(
+    local_path: str, pointer: SessionPointer, step: str
 ) -> ResearchTraceEvent:
     trace = _read_trace(local_path)
-    pointer = read_pointer(local_path)
     event = ResearchTraceEvent(
-        kind="begin",
-        step=step,
-        iteration=sum(1 for e in trace if e.kind == "begin" and e.step == step) + 1,
+        kind="step",
         timestamp=_now(),
+        session_id=pointer.session_id,
         head=head_commit(_root(local_path)),
-        run_ids=run_ids or [],
-        reason=reason,
-        session_id=pointer.session_id if pointer else None,
-        intervention=_intervention(local_path, pointer, trace, reason),
+        step=step,
+        iteration=sum(1 for e in trace if e.kind == "step" and e.step == step) + 1,
+        intervention=_intervention(local_path, pointer, trace),
     )
     _append(local_path, event)
     return event
 
 
-def end_step(
-    local_path: str, step: str, reason: str | None = None
+def capture(
+    local_path: str, pointer: SessionPointer
 ) -> tuple[ResearchTraceEvent, str | None]:
+    """Capture the agent state, record it and commit the whole working
+    tree; returns the event and the fork-point commit (None if nothing
+    changed or the commit failed)."""
     trace = _read_trace(local_path)
-    pointer = read_pointer(local_path)
-    state_path = capture_agent_state(local_path, pointer)[1] if pointer else None
     event = ResearchTraceEvent(
-        kind="end",
-        step=step,
-        iteration=max((e.iteration for e in trace if e.step == step), default=1),
+        kind="capture",
         timestamp=_now(),
+        session_id=pointer.session_id,
         head=head_commit(_root(local_path)),
-        reason=reason,
-        session_id=pointer.session_id if pointer else None,
-        agent_state=state_path,
+        agent_state=capture_agent_state(local_path, pointer)[1],
+        intervention=_intervention(local_path, pointer, trace),
     )
     _append(local_path, event)
     commit = commit_paths(
-        _root(local_path), ["."], f"step: end {step} #{event.iteration}"
+        _root(local_path), ["."], f"capture: session {pointer.session_id[:8]}"
     )
     return event, commit

--- a/backend/tests/unit/usecases/recording/test_fork_point.py
+++ b/backend/tests/unit/usecases/recording/test_fork_point.py
@@ -25,8 +25,9 @@ from airas.usecases.recording.agent_state import (
 )
 from airas.usecases.recording.codex_hooks import install_codex_hooks
 from airas.usecases.recording.research_trace import (
-    begin_step,
-    end_step,
+    capture,
+    is_experiment_repository,
+    record_step,
     write_derived_from,
 )
 
@@ -56,6 +57,8 @@ def repo(tmp_path: Path) -> Path:
     _git(repo, "config", "user.email", "t@example.com")
     _git(repo, "config", "user.name", "t")
     (repo / "CLAUDE.md").write_text("tracked instructions\n")
+    (repo / ".research").mkdir()
+    (repo / ".research" / "record.json").write_text("{}")
     _git(repo, "add", ".")
     _git(repo, "commit", "-q", "-m", "init")
     return repo
@@ -153,13 +156,14 @@ def test_hook_pointer_round_trips(homes: dict[str, Path], repo: Path) -> None:
     assert read_pointer(str(repo / "elsewhere")) is None
 
 
-def test_end_step_commits_the_agent_state(homes: dict[str, Path], repo: Path) -> None:
-    write_pointer(_claude_session(homes, repo))
-    begin_step(str(repo), "write-experiment-code", run_ids=["proposed"])
+def test_capture_commits_the_agent_state(homes: dict[str, Path], repo: Path) -> None:
+    pointer = _claude_session(homes, repo)
+    write_pointer(pointer)
+    record_step(str(repo), pointer, "write-experiment-code")
     (repo / "src.py").write_text("print(1)\n")
     before = _git(repo, "rev-parse", "HEAD")
 
-    event, commit = end_step(str(repo), "write-experiment-code")
+    event, commit = capture(str(repo), pointer)
 
     assert commit and commit != before and commit == _git(repo, "rev-parse", "HEAD")
     assert _git(repo, "status", "--porcelain") == ""
@@ -180,23 +184,28 @@ def test_end_step_commits_the_agent_state(homes: dict[str, Path], repo: Path) ->
     assert all((repo / t).is_file() for t in state.session.transcripts)
 
     events = [json.loads(line) for line in (repo / STEPS_PATH).read_text().splitlines()]
-    assert [(e["kind"], e["iteration"]) for e in events] == [("begin", 1), ("end", 1)]
-    assert events[0]["run_ids"] == ["proposed"] and events[0]["head"] == before
+    assert [e["kind"] for e in events] == ["step", "capture"]
+    assert events[0]["step"] == "write-experiment-code" and events[0]["head"] == before
 
 
-def test_repeating_a_step_counts_iterations(homes: dict[str, Path], repo: Path) -> None:
-    begin_step(str(repo), "run-experiments")
-    end_step(str(repo), "run-experiments")
-    event = begin_step(str(repo), "run-experiments", reason="run failed")
-    assert event.iteration == 2 and event.reason == "run failed"
-    assert event.session_id is None  # no hook ran: traced, no agent state
+def test_entering_a_step_again_counts_iterations(
+    homes: dict[str, Path], repo: Path
+) -> None:
+    pointer = _claude_session(homes, repo)
+    record_step(str(repo), pointer, "run-experiments")
+    capture(str(repo), pointer)
+    event = record_step(str(repo), pointer, "run-experiments")
+    assert event.iteration == 2
+
+
+def test_hooks_ignore_clones_without_research(tmp_path: Path) -> None:
+    assert not is_experiment_repository(str(tmp_path))
 
 
 def test_restore_rebinds_the_transcript_to_the_clone(
     homes: dict[str, Path], repo: Path, tmp_path: Path
 ) -> None:
-    write_pointer(_claude_session(homes, repo))
-    end_step(str(repo), "hypothesize-and-design")
+    capture(str(repo), _claude_session(homes, repo))
     clone = tmp_path / "clone"
     _git(repo, "clone", "-q", str(repo), str(clone))
 
@@ -211,8 +220,7 @@ def test_restore_rebinds_the_transcript_to_the_clone(
 
 
 def test_neutral_messages_and_handoff(homes: dict[str, Path], repo: Path) -> None:
-    write_pointer(_claude_session(homes, repo))
-    end_step(str(repo), "discover-papers")
+    capture(str(repo), _claude_session(homes, repo))
     state, _ = load_agent_state(str(repo))
     messages = neutral_messages(str(repo), state)
     assert [m["role"] for m in messages] == ["user", "assistant", "user", "assistant"]
@@ -267,9 +275,9 @@ def test_codex_rollout_reads_as_neutral_messages(
         },
     ]
     rollout.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
-    write_pointer(pointer_from_hook("codex", {"session_id": SESSION, "cwd": str(repo)}))
-
-    end_step(str(repo), "discover-papers")
+    capture(
+        str(repo), pointer_from_hook("codex", {"session_id": SESSION, "cwd": str(repo)})
+    )
     state, _ = load_agent_state(str(repo))
     assert state.harness.kind == "codex" and state.harness.version == "0.153.2"
     assert state.harness.model == "gpt-5.6-sol"
@@ -279,11 +287,10 @@ def test_codex_rollout_reads_as_neutral_messages(
         restore_claude_session(str(repo), state)
 
 
-def test_first_step_after_a_fork_records_the_intervention(
+def test_first_event_after_a_fork_records_the_intervention(
     homes: dict[str, Path], repo: Path, tmp_path: Path
 ) -> None:
-    write_pointer(_claude_session(homes, repo))
-    origin_commit = end_step(str(repo), "preregister-paper")[1]
+    origin_commit = capture(str(repo), _claude_session(homes, repo))[1]
     clone = tmp_path / "fork"
     _git(repo, "clone", "-q", str(repo), str(clone))
     write_derived_from(
@@ -294,16 +301,12 @@ def test_first_step_after_a_fork_records_the_intervention(
     forker = _claude_session(homes, clone).model_copy(
         update={"session_id": "s2", "model": "claude-opus-5"}
     )
-    write_pointer(forker)
 
-    first = begin_step(
-        str(clone), "write-experiment-code", reason="try a smaller model"
-    )
-    second = begin_step(str(clone), "run-experiments")
+    first = record_step(str(clone), forker, "write-experiment-code")
+    second = capture(str(clone), forker)[0]
 
     assert first.intervention == {
-        "agent": {"model": {"from": "claude-fable-5-1", "to": "claude-opus-5"}},
-        "research": "try a smaller model",
+        "model": {"from": "claude-fable-5-1", "to": "claude-opus-5"}
     }
     assert second.intervention is None
 
@@ -316,6 +319,7 @@ def test_install_codex_hooks_is_idempotent(tmp_path: Path) -> None:
     install_codex_hooks(home)
     hooks = json.loads((home / "hooks.json").read_text())
     assert len(hooks["hooks"]["SessionStart"]) == 1
+    assert len(hooks["hooks"]["Stop"]) == 1
     config = (home / "config.toml").read_text()
     assert "codex_hooks = true" in config and 'trust_level = "trusted"' in config
 

--- a/backend/tests/unit/usecases/recording/test_fork_point.py
+++ b/backend/tests/unit/usecases/recording/test_fork_point.py
@@ -1,0 +1,324 @@
+"""A fork point: a commit that carries the agent's state along with the
+research, so the same step can be resumed from a clone — by the same
+harness (Claude Code resume) or another one (neutral messages)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from airas.core.research_paths import SESSIONS_DIR, STEPS_PATH
+from airas.core.types.agent_state import SessionPointer
+from airas.core.types.research_trace import DerivedFromRepository
+from airas.usecases.recording import agent_state as agent_state_module
+from airas.usecases.recording.agent_state import (
+    load_agent_state,
+    neutral_messages,
+    pointer_from_hook,
+    read_pointer,
+    render_handoff,
+    restore_claude_session,
+    write_pointer,
+)
+from airas.usecases.recording.codex_hooks import install_codex_hooks
+from airas.usecases.recording.research_trace import (
+    begin_step,
+    end_step,
+    write_derived_from,
+)
+
+SESSION = "11111111-2222-3333-4444-555555555555"
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+@pytest.fixture
+def homes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    homes = {name: tmp_path / name for name in ("airas", "claude", "codex")}
+    monkeypatch.setattr(agent_state_module, "POINTER_DIR", homes["airas"] / "sessions")
+    monkeypatch.setattr(agent_state_module, "CLAUDE_HOME", homes["claude"])
+    monkeypatch.setattr(agent_state_module, "CODEX_HOME", homes["codex"])
+    return homes
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "exp"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+    (repo / "CLAUDE.md").write_text("tracked instructions\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+def _claude_session(homes: dict[str, Path], repo: Path) -> SessionPointer:
+    # A Claude Code session as the harness records it: the main transcript,
+    # one subagent, memory, settings holding a secret, and a plugin.
+    project = agent_state_module._claude_project_dir(str(repo))
+    lines = [
+        {
+            "type": "user",
+            "uuid": "u1",
+            "parentUuid": None,
+            "cwd": str(repo),
+            "sessionId": SESSION,
+            "message": {"role": "user", "content": "start"},
+        },
+        {
+            "type": "assistant",
+            "uuid": "a1",
+            "parentUuid": "u1",
+            "cwd": str(repo),
+            "sessionId": SESSION,
+            "version": "2.1.263",
+            "message": {
+                "role": "assistant",
+                "model": "claude-fable-5-1",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "t1",
+                        "name": "Bash",
+                        "input": {"command": "ls"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "uuid": "u2",
+            "parentUuid": "a1",
+            "cwd": str(repo),
+            "sessionId": SESSION,
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "t1", "content": "ok"}
+                ],
+            },
+        },
+    ]
+    main = project / f"{SESSION}.jsonl"
+    main.parent.mkdir(parents=True, exist_ok=True)
+    main.write_text("\n".join(json.dumps(x) for x in lines) + "\n")
+    sub = project / SESSION / "subagents" / "agent-abc.jsonl"
+    sub.parent.mkdir(parents=True, exist_ok=True)
+    sub.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "uuid": "s1",
+                "cwd": str(repo),
+                "message": {"role": "assistant", "content": "sub"},
+            }
+        )
+        + "\n"
+    )
+    (project / "memory").mkdir(exist_ok=True)
+    (project / "memory" / "note.md").write_text("remember this\n")
+    (homes["claude"] / "settings.json").write_text(
+        '{"env": {"OPENAI_API_KEY": "sk-secret"}}'
+    )
+    plugin = homes["claude"] / "plugin"
+    (plugin / "skills" / "s").mkdir(parents=True, exist_ok=True)
+    (plugin / "skills" / "s" / "SKILL.md").write_text("skill\n")
+    (plugin / ".claude-plugin").mkdir(exist_ok=True)
+    (plugin / ".claude-plugin" / "plugin.json").write_text('{"version": "0.3.1"}')
+    return pointer_from_hook(
+        "claude",
+        {
+            "session_id": SESSION,
+            "cwd": str(repo),
+            "transcript_path": str(main),
+            "model": "claude-fable-5-1",
+            "plugin_root": str(plugin),
+        },
+    )
+
+
+def test_hook_pointer_round_trips(homes: dict[str, Path], repo: Path) -> None:
+    pointer = _claude_session(homes, repo)
+    write_pointer(pointer)
+    assert read_pointer(str(repo)) == pointer
+    assert read_pointer(str(repo / "elsewhere")) is None
+
+
+def test_end_step_commits_the_agent_state(homes: dict[str, Path], repo: Path) -> None:
+    write_pointer(_claude_session(homes, repo))
+    begin_step(str(repo), "write-experiment-code", run_ids=["proposed"])
+    (repo / "src.py").write_text("print(1)\n")
+    before = _git(repo, "rev-parse", "HEAD")
+
+    event, commit = end_step(str(repo), "write-experiment-code")
+
+    assert commit and commit != before and commit == _git(repo, "rev-parse", "HEAD")
+    assert _git(repo, "status", "--porcelain") == ""
+    state, path = load_agent_state(str(repo))
+    assert event.agent_state and path == repo / event.agent_state
+    assert state.harness.model == "claude-fable-5-1"
+    assert state.harness.version == "2.1.263"
+    assert state.harness.plugin and state.harness.plugin.version == "0.3.1"
+    assert state.harness.memory == {"note.md": "remember this\n"}
+    assert (
+        "sk-secret" not in state.harness.files[str(homes["claude"] / "settings.json")]
+    )
+    assert str(repo / "CLAUDE.md") not in state.harness.files  # already tracked
+    assert [Path(t).name for t in state.session.transcripts] == [
+        f"{SESSION}.jsonl",
+        "agent-abc.jsonl",
+    ]
+    assert all((repo / t).is_file() for t in state.session.transcripts)
+
+    events = [json.loads(line) for line in (repo / STEPS_PATH).read_text().splitlines()]
+    assert [(e["kind"], e["iteration"]) for e in events] == [("begin", 1), ("end", 1)]
+    assert events[0]["run_ids"] == ["proposed"] and events[0]["head"] == before
+
+
+def test_repeating_a_step_counts_iterations(homes: dict[str, Path], repo: Path) -> None:
+    begin_step(str(repo), "run-experiments")
+    end_step(str(repo), "run-experiments")
+    event = begin_step(str(repo), "run-experiments", reason="run failed")
+    assert event.iteration == 2 and event.reason == "run failed"
+    assert event.session_id is None  # no hook ran: traced, no agent state
+
+
+def test_restore_rebinds_the_transcript_to_the_clone(
+    homes: dict[str, Path], repo: Path, tmp_path: Path
+) -> None:
+    write_pointer(_claude_session(homes, repo))
+    end_step(str(repo), "hypothesize-and-design")
+    clone = tmp_path / "clone"
+    _git(repo, "clone", "-q", str(repo), str(clone))
+
+    state, _ = load_agent_state(str(clone))
+    new_id, project = restore_claude_session(str(clone), state)
+
+    restored = (project / f"{new_id}.jsonl").read_text()
+    assert new_id != SESSION and SESSION not in restored
+    assert str(clone) in restored and str(repo) not in restored
+    assert (project / new_id / "subagents" / "agent-abc.jsonl").is_file()
+    assert (project / "memory" / "note.md").read_text() == "remember this\n"
+
+
+def test_neutral_messages_and_handoff(homes: dict[str, Path], repo: Path) -> None:
+    write_pointer(_claude_session(homes, repo))
+    end_step(str(repo), "discover-papers")
+    state, _ = load_agent_state(str(repo))
+    messages = neutral_messages(str(repo), state)
+    assert [m["role"] for m in messages] == ["user", "assistant", "user", "assistant"]
+    assert messages[1]["content"][0]["type"] == "tool_use"
+    assert messages[3]["agent_id"] == "agent-abc"
+    handoff = render_handoff(state, messages)
+    assert "tool_use Bash" in handoff and "remember" not in handoff
+
+
+def test_codex_rollout_reads_as_neutral_messages(
+    homes: dict[str, Path], repo: Path
+) -> None:
+    rollout = (
+        homes["codex"]
+        / "sessions"
+        / "2026"
+        / "09"
+        / "07"
+        / f"rollout-x-{SESSION}.jsonl"
+    )
+    rollout.parent.mkdir(parents=True)
+    rows = [
+        {
+            "type": "session_meta",
+            "payload": {"cli_version": "0.153.2", "cwd": str(repo)},
+        },
+        {"type": "turn_context", "payload": {"model": "gpt-5.6-sol"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "name": "exec",
+                "call_id": "c1",
+                "input": "ls",
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "c1",
+                "output": "ok",
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "done"}],
+            },
+        },
+    ]
+    rollout.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    write_pointer(pointer_from_hook("codex", {"session_id": SESSION, "cwd": str(repo)}))
+
+    end_step(str(repo), "discover-papers")
+    state, _ = load_agent_state(str(repo))
+    assert state.harness.kind == "codex" and state.harness.version == "0.153.2"
+    assert state.harness.model == "gpt-5.6-sol"
+    parts = [m["content"][0]["type"] for m in neutral_messages(str(repo), state)]
+    assert parts == ["tool_use", "tool_result", "text"]
+    with pytest.raises(ValueError):
+        restore_claude_session(str(repo), state)
+
+
+def test_first_step_after_a_fork_records_the_intervention(
+    homes: dict[str, Path], repo: Path, tmp_path: Path
+) -> None:
+    write_pointer(_claude_session(homes, repo))
+    origin_commit = end_step(str(repo), "preregister-paper")[1]
+    clone = tmp_path / "fork"
+    _git(repo, "clone", "-q", str(repo), str(clone))
+    write_derived_from(
+        str(clone),
+        DerivedFromRepository(commit=origin_commit or "", session_id=SESSION),
+    )
+    # The forker's harness: same transcript layout, a different model and session.
+    forker = _claude_session(homes, clone).model_copy(
+        update={"session_id": "s2", "model": "claude-opus-5"}
+    )
+    write_pointer(forker)
+
+    first = begin_step(
+        str(clone), "write-experiment-code", reason="try a smaller model"
+    )
+    second = begin_step(str(clone), "run-experiments")
+
+    assert first.intervention == {
+        "agent": {"model": {"from": "claude-fable-5-1", "to": "claude-opus-5"}},
+        "research": "try a smaller model",
+    }
+    assert second.intervention is None
+
+
+def test_install_codex_hooks_is_idempotent(tmp_path: Path) -> None:
+    home = tmp_path / "codex"
+    (home).mkdir()
+    (home / "config.toml").write_text('[projects."/x"]\ntrust_level = "trusted"\n')
+    install_codex_hooks(home)
+    install_codex_hooks(home)
+    hooks = json.loads((home / "hooks.json").read_text())
+    assert len(hooks["hooks"]["SessionStart"]) == 1
+    config = (home / "config.toml").read_text()
+    assert "codex_hooks = true" in config and 'trust_level = "trusted"' in config
+
+
+def test_sessions_dir_is_where_the_docs_say() -> None:
+    assert SESSIONS_DIR == ".research/sessions"

--- a/backend/tests/unit/usecases/recording/test_fork_point.py
+++ b/backend/tests/unit/usecases/recording/test_fork_point.py
@@ -149,6 +149,12 @@ def _claude_session(homes: dict[str, Path], repo: Path) -> SessionPointer:
     )
 
 
+def test_session_id_must_be_a_plain_name() -> None:
+    for bad in ("../x", "a/b", "..", ""):
+        with pytest.raises(ValueError):
+            pointer_from_hook("claude", {"session_id": bad, "cwd": "/tmp"})
+
+
 def test_hook_pointer_round_trips(homes: dict[str, Path], repo: Path) -> None:
     pointer = _claude_session(homes, repo)
     write_pointer(pointer)

--- a/docs/development/fork-point.mdx
+++ b/docs/development/fork-point.mdx
@@ -15,7 +15,7 @@ the same agent and a different method.
 |---|---|
 | `.research/sessions/<harness>/<session_id>/*.jsonl` | The harness's raw transcript, subagents included, copied verbatim |
 | `.research/sessions/<harness>/<session_id>/agent_state.json` | `AgentState`: the harness (kind, version, model, settings and instruction files, memory, plugin version and skills hash) and the session (which transcripts) |
-| `.research/trace/steps.jsonl` | One `ResearchTraceEvent` per step boundary: step, iteration, run ids, HEAD, the agent state written |
+| `.research/trace/steps.jsonl` | One `ResearchTraceEvent` per hook event: the step entered (and its iteration) or the agent state captured, with HEAD |
 | `.research/derived_from.json` | In a forked repository: the repository, commit and session it came from |
 
 Secrets in settings files are masked before they are copied. Everything else
@@ -24,22 +24,25 @@ repository. Credentials, platform executions and the local environment stay
 outside: bring your own credentials, results are referenced by execution id,
 and `uv.lock` plus the Dockerfile rebuild the environment.
 
-## Recording: `begin_step` and `end_step`
+## Recording: the harness's hooks
 
-The `auto-research` skill brackets every step with two MCP tools.
-`begin_step(local_path, step, run_ids, reason)` records where a step starts;
-`end_step(local_path, step)` captures the live session and harness into
-`.research/sessions/`, appends the boundary to the trace and commits the whole
-working tree. That commit is the fork point — push it.
+Nothing is asked of the agent. The harness's hooks record the trace and
+commit the fork points:
 
-The live session is known through the harness's `SessionStart` hook, which
-writes a pointer under `~/.airas/sessions/`:
+| Hook | Command | What it records |
+|---|---|---|
+| `SessionStart` | `airas hook session-start` | Where the live session is (a pointer under `~/.airas/sessions/`) |
+| `PostToolUse` on `Skill` (Claude Code) | `airas hook step` | Which step skill the agent entered, and how many times |
+| `Stop` (end of every turn) | `airas hook capture` | The session and harness into `.research/sessions/`, then a commit of the whole tree |
+
+Hooks only act in a clone that has a `.research/` directory. Every turn
+adds a commit: the transcript grew, and that is the state being kept.
 
 - **Claude Code** — the airas plugin ships `hooks/hooks.json`; nothing to set up.
 - **Codex CLI** — run `airas hook install` once. It writes `~/.codex/hooks.json`
-  and enables `features.codex_hooks` in `~/.codex/config.toml`.
-
-Without the hook, steps are still traced and committed, with no agent state.
+  (SessionStart and Stop) and enables `features.codex_hooks` in
+  `~/.codex/config.toml`. Codex has no skill event, so its trace holds
+  captures only.
 
 ## Restoring: `airas session import`
 
@@ -66,10 +69,10 @@ file. `airas session export` prints the same messages as JSON.
 ## Forking into a new repository
 
 Pass `--derived-from [REPOSITORY@]COMMIT` to `airas session import` in the new
-clone. It writes `.research/derived_from.json`, and the first `begin_step` in
-that repository records the **intervention**: how the live harness differs
-from the one the fork point was captured with (model, version, files,
-memory, plugin), and the `reason` given as what was changed on purpose.
+clone. It writes `.research/derived_from.json`, and the first hook event in that
+repository records the **intervention**: how the live harness differs from
+the one the fork point was captured with (model, version, files, memory,
+plugin).
 Forks of forks chain through their own `derived_from.json`.
 
 Within one research the history is a single line with steps repeated — the

--- a/docs/development/fork-point.mdx
+++ b/docs/development/fork-point.mdx
@@ -1,0 +1,77 @@
+---
+title: "Fork points"
+description: "Resume a research from any step — with the same agent, another model or harness, or another method"
+---
+
+A **fork point** is a commit in the experiment repository that holds, besides
+the research artifacts, the state of the agent that produced them. Anyone on
+the team can clone that commit and continue from the same step: with the same
+agent to measure run-to-run variance, with another model or harness, or with
+the same agent and a different method.
+
+## What a fork point contains
+
+| Path | Content |
+|---|---|
+| `.research/sessions/<harness>/<session_id>/*.jsonl` | The harness's raw transcript, subagents included, copied verbatim |
+| `.research/sessions/<harness>/<session_id>/agent_state.json` | `AgentState`: the harness (kind, version, model, settings and instruction files, memory, plugin version and skills hash) and the session (which transcripts) |
+| `.research/trace/steps.jsonl` | One `ResearchTraceEvent` per step boundary: step, iteration, run ids, HEAD, the agent state written |
+| `.research/derived_from.json` | In a forked repository: the repository, commit and session it came from |
+
+Secrets in settings files are masked before they are copied. Everything else
+is kept as is — fork points are for the team and yourself, not for a public
+repository. Credentials, platform executions and the local environment stay
+outside: bring your own credentials, results are referenced by execution id,
+and `uv.lock` plus the Dockerfile rebuild the environment.
+
+## Recording: `begin_step` and `end_step`
+
+The `auto-research` skill brackets every step with two MCP tools.
+`begin_step(local_path, step, run_ids, reason)` records where a step starts;
+`end_step(local_path, step)` captures the live session and harness into
+`.research/sessions/`, appends the boundary to the trace and commits the whole
+working tree. That commit is the fork point — push it.
+
+The live session is known through the harness's `SessionStart` hook, which
+writes a pointer under `~/.airas/sessions/`:
+
+- **Claude Code** — the airas plugin ships `hooks/hooks.json`; nothing to set up.
+- **Codex CLI** — run `airas hook install` once. It writes `~/.codex/hooks.json`
+  and enables `features.codex_hooks` in `~/.codex/config.toml`.
+
+Without the hook, steps are still traced and committed, with no agent state.
+
+## Restoring: `airas session import`
+
+Clone the fork-point commit, then:
+
+```bash
+airas session import --local-path <clone> --to claude
+# → cd <clone> && claude --resume <new session id>
+```
+
+For Claude Code the raw transcript is rebound to the clone (paths and session
+id rewritten) and placed where `claude --resume` finds it, memory included.
+Add `--model` to that resume to change only the model.
+
+```bash
+airas session import --local-path <clone> --to prompt
+```
+
+For another harness, the session is rendered to
+`.research/sessions/handoff.md` as harness-neutral messages (text, tool calls
+and tool results in full); start the harness in the clone and give it that
+file. `airas session export` prints the same messages as JSON.
+
+## Forking into a new repository
+
+Pass `--derived-from [REPOSITORY@]COMMIT` to `airas session import` in the new
+clone. It writes `.research/derived_from.json`, and the first `begin_step` in
+that repository records the **intervention**: how the live harness differs
+from the one the fork point was captured with (model, version, files,
+memory, plugin), and the `reason` given as what was changed on purpose.
+Forks of forks chain through their own `derived_from.json`.
+
+Within one research the history is a single line with steps repeated — the
+trace records iterations, not branches. A change of hypothesis is a new
+preregistration and therefore a new repository.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -19,7 +19,9 @@
         "groups": [
           {
             "group": "Get Started",
-            "pages": ["introduction"]
+            "pages": [
+              "introduction"
+            ]
           },
           {
             "group": "Components",
@@ -42,7 +44,8 @@
             "pages": [
               "development/api-key",
               "development/roadmap",
-              "development/MCP"
+              "development/MCP",
+              "development/fork-point"
             ]
           }
         ]
@@ -52,7 +55,9 @@
         "groups": [
           {
             "group": "Get Started",
-            "pages": ["ja/introduction"]
+            "pages": [
+              "ja/introduction"
+            ]
           },
           {
             "group": "Components",
@@ -75,7 +80,8 @@
             "pages": [
               "ja/development/local-setup",
               "ja/development/roadmap",
-              "ja/development/MCP"
+              "ja/development/MCP",
+              "ja/development/fork-point"
             ]
           }
         ]

--- a/docs/ja/development/fork-point.mdx
+++ b/docs/ja/development/fork-point.mdx
@@ -11,21 +11,25 @@ description: "任意の step から研究を再開する — 同じエージェ�
 |---|---|
 | `.research/sessions/<harness>/<session_id>/*.jsonl` | ハーネスの生トランスクリプト（サブエージェント含む）をそのままコピー |
 | `.research/sessions/<harness>/<session_id>/agent_state.json` | `AgentState`: ハーネス（種別、バージョン、モデル、設定と指示ファイル、メモリ、プラグインのバージョンと skills のハッシュ）とセッション（どのトランスクリプトか） |
-| `.research/trace/steps.jsonl` | step 境界ごとの `ResearchTraceEvent`: step、反復回数、run id、HEAD、書き出した agent state |
+| `.research/trace/steps.jsonl` | hook イベントごとの `ResearchTraceEvent`: 入った step（と反復回数）、または取り込んだ agent state、HEAD |
 | `.research/derived_from.json` | 派生リポジトリで、派生元のリポジトリ・commit・session |
 
 設定ファイル内の資格情報はコピー前に伏せます。それ以外はそのまま残るので、fork 点はチーム内と自分用であり、公開リポジトリ向けではありません。資格情報、プラットフォーム上の実行、ローカル環境はリポジトリの外に残ります。資格情報は各自のものを使い、結果は execution id で参照し、環境は `uv.lock` と Dockerfile から再構築します。
 
-## 記録: `begin_step` と `end_step`
+## 記録: ハーネスの hook
 
-`auto-research` スキルは各 step を 2 つの MCP ツールで挟みます。`begin_step(local_path, step, run_ids, reason)` が step の開始を記録し、`end_step(local_path, step)` が live セッションとハーネスを `.research/sessions/` に取り込み、trace に境界を追記して、作業ツリー全体を commit します。この commit が fork 点です。push してください。
+エージェントには何も求めません。ハーネスの hook が trace を記録し、fork 点を commit します。
 
-live セッションはハーネスの `SessionStart` hook が `~/.airas/sessions/` に書くポインタで特定します。
+| hook | コマンド | 記録するもの |
+|---|---|---|
+| `SessionStart` | `airas hook session-start` | live セッションの所在（`~/.airas/sessions/` のポインタ） |
+| `PostToolUse` の `Skill`（Claude Code） | `airas hook step` | どの step スキルに入ったか、何回目か |
+| `Stop`（ターン終了ごと） | `airas hook capture` | セッションとハーネスを `.research/sessions/` に取り込み、作業ツリー全体を commit |
+
+hook は `.research/` ディレクトリがある clone でだけ動きます。ターンごとに commit が 1 つ増えます。トランスクリプトが伸びており、それ自体が残したい状態だからです。
 
 - **Claude Code** — airas プラグインに `hooks/hooks.json` が同梱されているので設定不要です。
-- **Codex CLI** — 一度 `airas hook install` を実行します。`~/.codex/hooks.json` を書き、`~/.codex/config.toml` の `features.codex_hooks` を有効にします。
-
-hook が無くても step の trace と commit は行われ、agent state だけが無い状態になります。
+- **Codex CLI** — 一度 `airas hook install` を実行します。`~/.codex/hooks.json`（SessionStart と Stop）を書き、`~/.codex/config.toml` の `features.codex_hooks` を有効にします。Codex にはスキルのイベントが無いので、trace には capture だけが残ります。
 
 ## 復元: `airas session import`
 
@@ -46,6 +50,6 @@ airas session import --local-path <clone> --to prompt
 
 ## 新しいリポジトリへの派生
 
-新しい clone で `airas session import` に `--derived-from [REPOSITORY@]COMMIT` を渡します。`.research/derived_from.json` が書かれ、そのリポジトリでの最初の `begin_step` が**介入**を記録します。live ハーネスが fork 点のハーネスとどう違うか（モデル、バージョン、ファイル、メモリ、プラグイン）と、`reason` として渡した「意図して変えたこと」です。派生の派生も各自の `derived_from.json` でチェーンになります。
+新しい clone で `airas session import` に `--derived-from [REPOSITORY@]COMMIT` を渡します。`.research/derived_from.json` が書かれ、そのリポジトリでの最初の hook イベントが**介入**を記録します。live ハーネスが fork 点のハーネスとどう違うか（モデル、バージョン、ファイル、メモリ、プラグイン）です。派生の派生も各自の `derived_from.json` でチェーンになります。
 
 一つの研究の中では履歴は step を繰り返す一本線で、trace は反復を記録し、ブランチは記録しません。仮説を変えるなら新しい事前登録、つまり新しいリポジトリです。

--- a/docs/ja/development/fork-point.mdx
+++ b/docs/ja/development/fork-point.mdx
@@ -1,0 +1,51 @@
+---
+title: "Fork 点"
+description: "任意の step から研究を再開する — 同じエージェント、別のモデルやハーネス、別の手法で"
+---
+
+**fork 点**とは、研究の成果物に加えて、それを作ったエージェントの状態を含む実験リポジトリの commit です。チームの誰でもその commit を clone して同じ step から続けられます。同じエージェントで揺らぎを測る、別のモデルやハーネスで試す、同じエージェントで別の手法を試す、のいずれも同じ地点から始まります。
+
+## fork 点に含まれるもの
+
+| パス | 内容 |
+|---|---|
+| `.research/sessions/<harness>/<session_id>/*.jsonl` | ハーネスの生トランスクリプト（サブエージェント含む）をそのままコピー |
+| `.research/sessions/<harness>/<session_id>/agent_state.json` | `AgentState`: ハーネス（種別、バージョン、モデル、設定と指示ファイル、メモリ、プラグインのバージョンと skills のハッシュ）とセッション（どのトランスクリプトか） |
+| `.research/trace/steps.jsonl` | step 境界ごとの `ResearchTraceEvent`: step、反復回数、run id、HEAD、書き出した agent state |
+| `.research/derived_from.json` | 派生リポジトリで、派生元のリポジトリ・commit・session |
+
+設定ファイル内の資格情報はコピー前に伏せます。それ以外はそのまま残るので、fork 点はチーム内と自分用であり、公開リポジトリ向けではありません。資格情報、プラットフォーム上の実行、ローカル環境はリポジトリの外に残ります。資格情報は各自のものを使い、結果は execution id で参照し、環境は `uv.lock` と Dockerfile から再構築します。
+
+## 記録: `begin_step` と `end_step`
+
+`auto-research` スキルは各 step を 2 つの MCP ツールで挟みます。`begin_step(local_path, step, run_ids, reason)` が step の開始を記録し、`end_step(local_path, step)` が live セッションとハーネスを `.research/sessions/` に取り込み、trace に境界を追記して、作業ツリー全体を commit します。この commit が fork 点です。push してください。
+
+live セッションはハーネスの `SessionStart` hook が `~/.airas/sessions/` に書くポインタで特定します。
+
+- **Claude Code** — airas プラグインに `hooks/hooks.json` が同梱されているので設定不要です。
+- **Codex CLI** — 一度 `airas hook install` を実行します。`~/.codex/hooks.json` を書き、`~/.codex/config.toml` の `features.codex_hooks` を有効にします。
+
+hook が無くても step の trace と commit は行われ、agent state だけが無い状態になります。
+
+## 復元: `airas session import`
+
+fork 点の commit を clone してから:
+
+```bash
+airas session import --local-path <clone> --to claude
+# → cd <clone> && claude --resume <新しい session id>
+```
+
+Claude Code では生トランスクリプトを clone に結び直し（パスと session id を書き換え）、`claude --resume` が見つける場所に置きます。メモリも復元されます。モデルだけ変えるなら resume に `--model` を付けます。
+
+```bash
+airas session import --local-path <clone> --to prompt
+```
+
+別ハーネスの場合は、セッションをハーネス非依存の messages として `.research/sessions/handoff.md` に書き出します（テキスト、ツール呼び出し、ツール結果を全文）。clone 内でハーネスを起動し、このファイルを渡してください。`airas session export` は同じ messages を JSON で出力します。
+
+## 新しいリポジトリへの派生
+
+新しい clone で `airas session import` に `--derived-from [REPOSITORY@]COMMIT` を渡します。`.research/derived_from.json` が書かれ、そのリポジトリでの最初の `begin_step` が**介入**を記録します。live ハーネスが fork 点のハーネスとどう違うか（モデル、バージョン、ファイル、メモリ、プラグイン）と、`reason` として渡した「意図して変えたこと」です。派生の派生も各自の `derived_from.json` でチェーンになります。
+
+一つの研究の中では履歴は step を繰り返す一本線で、trace は反復を記録し、ブランチは記録しません。仮説を変えるなら新しい事前登録、つまり新しいリポジトリです。

--- a/plugins/airas/hooks/hooks.json
+++ b/plugins/airas/hooks/hooks.json
@@ -1,13 +1,36 @@
 {
-  "description": "Tell the airas MCP server which Claude Code session is live, so end_step can capture it into the fork point.",
+  "description": "Record the research trace and fork points: where the live session is, which step the agent entered, and the agent's state committed at the end of every turn.",
   "hooks": {
     "SessionStart": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "CLAUDE_PLUGIN_ROOT=\"${CLAUDE_PLUGIN_ROOT}\" uvx --with 'mcp<2' airas hook session-start --harness claude",
+            "command": "uvx --with 'mcp<2' airas hook session-start --harness claude",
             "timeout": 60
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uvx --with 'mcp<2' airas hook step --harness claude",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uvx --with 'mcp<2' airas hook capture --harness claude",
+            "timeout": 120
           }
         ]
       }

--- a/plugins/airas/hooks/hooks.json
+++ b/plugins/airas/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Tell the airas MCP server which Claude Code session is live, so end_step can capture it into the fork point.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CLAUDE_PLUGIN_ROOT=\"${CLAUDE_PLUGIN_ROOT}\" uvx --with 'mcp<2' airas hook session-start --harness claude",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/airas/skills/auto-research/SKILL.md
+++ b/plugins/airas/skills/auto-research/SKILL.md
@@ -82,13 +82,13 @@ These are the orchestrator's own rules; no step may relax them.
 - **State handoff is the repository.** Everything a later step needs
   must be committed, not held in conversation — a fresh session must
   be able to resume from the clone alone.
-- **Every step is bracketed by `begin_step` and `end_step`.** Call
-  `begin_step` on entering a step skill (with the run ids it works on
-  and, on a repeat, why) and `end_step` on leaving it. `end_step`
-  captures this session and harness into `.research/sessions/` and
-  commits the whole tree: that commit is a fork point anyone can
-  resume from with `airas session import` — same agent, another
-  model or harness, or another method. Push after it.
+- **Every turn ends in a fork point.** The harness's hooks, not the
+  agent, record the trace: entering a step skill is logged, and at the
+  end of every turn this session and harness are captured into
+  `.research/sessions/` and the whole tree is committed. That commit
+  is a fork point anyone can resume from with `airas session import`
+  — same agent, another model or harness, or another method. Push so
+  it is shared; never amend or rebase those commits away.
 
 ## The integrity model — why the gate holds
 
@@ -139,8 +139,8 @@ nothing is anchored yet, so nothing can be hidden.
 
 ## Resuming mid-flow
 
-`.research/trace/steps.jsonl` says which step last ended and how many
-times each has run; `.research/derived_from.json` says this clone was
+`.research/trace/steps.jsonl` says which step was entered last and how
+many times each has run; `.research/derived_from.json` says this clone was
 forked from another repository's fork point. Otherwise read the clone
 to find where it stands: a
 `.research/record.json` and preregistered main.tex with stub

--- a/plugins/airas/skills/auto-research/SKILL.md
+++ b/plugins/airas/skills/auto-research/SKILL.md
@@ -82,6 +82,13 @@ These are the orchestrator's own rules; no step may relax them.
 - **State handoff is the repository.** Everything a later step needs
   must be committed, not held in conversation — a fresh session must
   be able to resume from the clone alone.
+- **Every step is bracketed by `begin_step` and `end_step`.** Call
+  `begin_step` on entering a step skill (with the run ids it works on
+  and, on a repeat, why) and `end_step` on leaving it. `end_step`
+  captures this session and harness into `.research/sessions/` and
+  commits the whole tree: that commit is a fork point anyone can
+  resume from with `airas session import` — same agent, another
+  model or harness, or another method. Push after it.
 
 ## The integrity model — why the gate holds
 
@@ -132,7 +139,10 @@ nothing is anchored yet, so nothing can be hidden.
 
 ## Resuming mid-flow
 
-Read the clone to find where a repository stands: a
+`.research/trace/steps.jsonl` says which step last ended and how many
+times each has run; `.research/derived_from.json` says this clone was
+forked from another repository's fork point. Otherwise read the clone
+to find where it stands: a
 `.research/record.json` and preregistered main.tex with stub
 Results/Discussion and no
 `.research/results/` means `write-experiment-code` (or, with `src/`


### PR DESCRIPTION
Closes #1015

## 概要

**fork 点**とは、実験リポジトリの成果物に加えて、それを作ったエージェントの状態を含む commit です。チームの誰でもその commit を clone して同じ step から続けられます。同じエージェントで揺らぎを測る、別のモデルやハーネスで試す、同じエージェントで別の手法を試す、のいずれも同じ地点から始まります。

### 記録（ハーネスの hook。エージェントには何も求めない）
| hook | コマンド | 記録するもの |
|---|---|---|
| `SessionStart` | `airas hook session-start` | live セッションの所在（`~/.airas/sessions/` の `SessionPointer`） |
| `PostToolUse` の `Skill`（Claude Code のみ） | `airas hook step` | どの step スキルに入ったか、何回目か |
| `Stop`（ターン終了ごと） | `airas hook capture` | セッションとハーネスを `.research/sessions/<harness>/<session_id>/` に取り込み（生トランスクリプト、サブエージェント含む、`agent_state.json`: 種別・バージョン・モデル、資格情報を伏せた設定と指示ファイル、メモリ、プラグインのバージョンと skills のハッシュ）、`.research/trace/steps.jsonl` に `ResearchTraceEvent` を追記して、作業ツリー全体を commit |

- hook は `.research/` がある clone でだけ動く。ターンごとに commit が 1 つ増える（トランスクリプトが伸びるため）。
- Claude Code は `plugins/airas/hooks/hooks.json` で設定不要。Codex は `airas hook install`（`~/.codex/hooks.json` に SessionStart と Stop、`features.codex_hooks`）。
- `auto-research` SKILL: 「毎ターンが fork 点になる。amend や rebase で消さない」を不変条件に追加し、再開時に trace と `derived_from.json` を見る記述を追加。

### 復元
- `airas session import --to claude`: 生トランスクリプトを clone に結び直し（パスと session id を書き換え）、`claude --resume` が見つける場所に置く。メモリも fork 点の内容で上書き。
- `airas session import --to prompt`: ハーネス非依存の messages を `.research/sessions/handoff.md` に書き出す。`airas session export` は同じ messages を JSON で出力。
- `--derived-from [REPO@]COMMIT`: `.research/derived_from.json` を書き（commit が空ならエラー）、その clone での最初の hook イベントが**介入**（fork 点のハーネスとの差分）を記録する。

### スコープ外
可視化（#1011）、Compile / Replay（#1009）、公開リポジトリ向けのサニタイズ。trace は advisory で、record gate の対象にはしない。

## 型
- `core/types/agent_state.py`: `AgentState` = `HarnessState` + `SessionState`、`SessionPointer`
- `core/types/research_trace.py`: `ResearchTraceEvent`（`kind: step | capture`）、`DerivedFromRepository`

## 検証
- `pre-commit run ruff / mypy --all-files`: pass
- `uv run pytest tests/unit`: 292 passed、15 skipped（新規 10 件 `test_fork_point.py`: ポインタの往復、capture の commit と取り込んだ状態、step の反復回数、`.research/` の無い clone の無視、Claude の復元でのパス書き換え、Claude / Codex の中立形式 messages、派生時の介入記録、Codex hook インストールの冪等性）

docs: `docs/development/fork-point.mdx`（en / ja）

## 未確認
- Claude Code の `PostToolUse(Skill)` の `tool_input.skill` と、Codex hooks の実機動作は未確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013K4YqJ8V89nY2e7pm4hzcg
