### PR TITLE
chore: 0.4.0 リリース準備と README の更新

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,21 @@ jobs:
             exit 1
           fi
 
+      - name: Verify the plugin pins this version
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          PLUGIN_VERSION=$(jq -r .version plugins/airas/.claude-plugin/plugin.json)
+          if [ "$PLUGIN_VERSION" != "$VERSION" ]; then
+            echo "::error::plugins/airas/.claude-plugin/plugin.json version ${PLUGIN_VERSION} does not match tag v${VERSION}"
+            exit 1
+          fi
+          for f in plugins/airas/.mcp.json plugins/airas/hooks/hooks.json; do
+            if grep -q 'airas==' "$f" && ! grep -q "airas==${VERSION}\b" "$f"; then
+              echo "::error::${f} pins a different airas version than tag v${VERSION}"
+              exit 1
+            fi
+          done
+
       - name: Verify version is newer than PyPI
         run: |
           FILE_VERSION="${GITHUB_REF_NAME#v}"
@@ -38,38 +53,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          package_json_file: frontend/package.json
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: frontend/pnpm-lock.yaml
-
-      - name: Build dashboard frontend
-        working-directory: frontend
-        env:
-          # Empty base URL: the bundled dashboard is served same-origin
-          # by the FastAPI backend, so API calls use relative paths.
-          VITE_API_BASE_URL: ""
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm run build
-
-      - name: Bundle frontend into the package
-        run: |
-          rm -rf backend/src/airas/dashboard/static
-          cp -r frontend/dist backend/src/airas/dashboard/static
-
       - name: Build
         working-directory: backend
         run: uv build
 
-      - name: Smoke-test the wheel (console scripts, mcp extra, dashboard assets)
+      - name: Smoke-test the wheel (console scripts, mcp extra)
         working-directory: backend
         run: |
           uv venv /tmp/smoke
@@ -79,13 +67,6 @@ jobs:
           test -x /tmp/smoke/bin/airas-mcp
           /tmp/smoke/bin/python -c "from airas.mcp.server import mcp, main; print('wheel ok:', mcp.name)"
           /tmp/smoke/bin/python -c "from airas.cli import main; print('cli ok')"
-          /tmp/smoke/bin/python - <<'EOF'
-          from pathlib import Path
-          import airas.dashboard
-          static = Path(airas.dashboard.__file__).parent / "static"
-          assert (static / "index.html").is_file(), "dashboard static assets missing from wheel"
-          print("dashboard assets ok:", len(list(static.rglob('*'))), "files")
-          EOF
 
       - name: Publish to PyPI (Trusted Publishing)
         working-directory: backend

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
             exit 1
           fi
           for f in plugins/airas/.mcp.json plugins/airas/hooks/hooks.json; do
-            if grep -q 'airas==' "$f" && ! grep -q "airas==${VERSION}\b" "$f"; then
+            if grep -q 'airas==' "$f" && ! grep -Eq "airas==${VERSION}([\"[:space:]]|$)" "$f"; then
               echo "::error::${f} pins a different airas version than tag v${VERSION}"
               exit 1
             fi

--- a/README.md
+++ b/README.md
@@ -7,17 +7,11 @@
   <a href="https://pypi.org/project/airas/">
     <img src="https://img.shields.io/pypi/v/airas" alt="PyPI" />
   </a>
-  <a href="https://airas-org.github.io/airas/">
-    <img src="https://img.shields.io/badge/Documentation-%F0%9F%93%95-blue" alt="Documentation" />
-  </a>
   <a href="https://github.com/airas-org/airas/blob/main/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-green.svg" alt="MIT License" />
   </a>
   <a href="https://discord.gg/ktumZQP3Tp">
     <img src="https://img.shields.io/badge/Discord-Join%20Us-7289da?logo=discord&logoColor=white" alt="Discord" />
-  </a>
-  <a href="https://x.com/fuyu_quant">
-    <img src="https://img.shields.io/twitter/follow/fuyu_quant?style=social" alt="Twitter Follow" />
   </a>
 </p>
 
@@ -25,7 +19,7 @@ AIRAS is open-source software for automated research. It gives a coding agent (C
 
 AIRAS ships as one PyPI package (`airas`) that provides:
 
-- an **MCP server** with 40+ research tools (paper search, hypothesis and experimental design, experiment execution on GitHub Actions or Seyval, figure rendering, LaTeX, Overleaf, paper reproduction, and the record/verification tools),
+- an **MCP server** with the research tools the flow needs (paper search, hypothesis and experimental design, experiment results, figure rendering, LaTeX, Overleaf, and the record/verification tools),
 - a **Claude Code plugin** that bundles the server with the `auto-research` workflow skills,
 - a small **CLI** (`airas verify-record`, `airas verify-paper`) that the experiment repository's CI uses as the verification gate.
 
@@ -37,20 +31,20 @@ No clone, no Docker. Only [uv](https://docs.astral.sh/uv/) is required; `uvx` fe
 
 ### 1. Install
 
-**Claude Code plugin (recommended).** Installs the MCP server and the research-workflow skills in one step:
+AIRAS is meant to be driven from **Claude Code** through its plugin. The plugin installs the MCP server together with the `auto-research` workflow skills and the hooks that record the agent's state:
 
 ```
 /plugin marketplace add airas-org/airas
 /plugin install airas@airas
 ```
 
-**Claude Code, MCP server only:**
+The MCP server can also be used on its own, without the skills and hooks. In Claude Code:
 
 ```bash
 claude mcp add airas -- uvx airas
 ```
 
-**Other MCP clients.** Add the server to your client's MCP configuration (e.g. `.mcp.json`):
+In any other MCP client, add it to the client's MCP configuration (e.g. `.mcp.json`):
 
 ```json
 {
@@ -63,6 +57,8 @@ claude mcp add airas -- uvx airas
 }
 ```
 
+**Upgrading.** `uvx` keeps the version it fetched the first time, so an existing install does not move to a new release on its own. Run `uv cache clean airas` (or `uvx airas@latest`) once to pick up the latest version.
+
 ### 2. Configure credentials
 
 Credentials live in `~/.airas/credentials.json` and are re-read on every tool call, so you can create or edit the file at any time:
@@ -72,7 +68,7 @@ mkdir -p ~/.airas
 cat > ~/.airas/credentials.json <<'EOF'
 {
   "GH_PERSONAL_ACCESS_TOKEN": "ghp_...",
-  "ANTHROPIC_API_KEY": "sk-ant-..."
+  "SEYVAL_API_KEY": "..."
 }
 EOF
 chmod 600 ~/.airas/credentials.json
@@ -81,8 +77,8 @@ chmod 600 ~/.airas/credentials.json
 | Key | Purpose |
 | --- | --- |
 | `GH_PERSONAL_ACCESS_TOKEN` | Required. Creates and drives the experiment repository (`repo` + `workflow` scopes, admin on the repository). |
-| One of `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `OPENROUTER_API_KEY` / `AWS_BEARER_TOKEN_BEDROCK` / `VERCEL_AI_GATEWAY_API_KEY` / `RIKYU_API_KEY` | Backend-LLM generation tools. Optional: the same steps can be authored by the MCP host itself via `get_generation_prompt`. |
-| `SEYVAL_API_KEY` (+ optional `SEYVAL_COMPUTE_ID`) | Run experiments on the Seyval compute platform and enable the provenance cross-check. |
+| `SEYVAL_API_KEY` (+ optional `SEYVAL_COMPUTE_ID`) | Needed to run experiments on the Seyval compute platform and for the provenance cross-check. See [Execution platforms](#execution-platforms-and-llms). |
+| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `OPENROUTER_API_KEY` / `AWS_BEARER_TOKEN_BEDROCK` / `VERCEL_AI_GATEWAY_API_KEY` | Not needed for the flow. The agent driving AIRAS authors every generated artifact itself via `get_generation_prompt`. A key is only used when you call the backend-LLM generation tools directly. |
 
 ### 3. Start a research project
 
@@ -105,7 +101,7 @@ It walks through the flow below, asking you to settle the operational choices (r
 | 3 | `hypothesize-and-design` | A falsifiable hypothesis and an experimental design that fixes run ids, metrics, models, datasets, and the compute environment. |
 | 4 | `preregister-paper` | The full paper, written **before any experiment**, as numbered claims with criteria and predicted intervals. Its commit is the freeze point; `.research/record.json` is created here. |
 | 5 | `write-experiment-code` | Experiment code against a fixed execution contract (Hydra entrypoint, `sanity` / `pilot` / `full` modes), environment fixed by lockfile and Dockerfile. Metrics are produced by [airas-eval](https://github.com/airas-org/airas-eval), not by the code itself. |
-| 6 | `run-experiments` | Runs executed on GitHub Actions or Seyval, outputs brought back under `.research/results/` with provenance. |
+| 6 | `run-experiments` | Runs executed on the compute platform, outputs brought back under `.research/results/` with provenance. **Under construction**: see [Execution platforms](#execution-platforms-and-llms). |
 | 7 | `analyze-results` | The analysis and verifiable figures (Vega-Lite charts, text-defined diagrams). |
 | 8 | `publish-paper` | Every stated number realized from the record, compile and verification green locally, then pushed. CI re-runs the verification and commits `paper.pdf` to the protected branch: the paper of record. |
 
@@ -119,9 +115,9 @@ It walks through the flow below, asking you to settle the operational choices (r
 
 ### Execution platforms and LLMs
 
-Experiments run on **GitHub Actions** (the runner repository's own workflows) or on the **Seyval** compute platform (managed or bring-your-own compute); `dispatch_experiment` selects the backend. Long-running steps return immediately and are polled with `get_workflow_runs` / `get_experiment_run_status`.
+**Experiment execution is under construction.** The `run-experiments` skill currently drives the **Seyval** compute platform (bring-your-own Slurm compute) through Seyval's own MCP server, and the MCP tools for **GitHub Actions** execution (`dispatch_experiment`, `get_workflow_runs`, `get_experiment_run_status`) are not yet wired into the flow. Every other step, including the record and verification gate, works independently of the execution backend.
 
-Generation steps are dual-mode. With a provider key they run on the backend LLM (`get_available_llms` lists the models your keys allow). Without one, `get_generation_prompt` hands the MCP host the same curated prompt and output schema so it can author the artifact itself. Supported providers: OpenAI, Anthropic, Google Gemini, OpenRouter, Amazon Bedrock, Vercel AI Gateway, and RIKEN R-CCS's Rikyu.
+Generation steps need no LLM key: `get_generation_prompt` hands the agent the curated prompt and output schema, and the agent authors the artifact itself. The same steps also exist as backend-LLM tools (`generate_hypothesis`, `generate_paper`, ...) for use outside the flow; those need a provider key (`get_available_llms` lists the models your keys allow). Supported providers: OpenAI, Anthropic, Google Gemini, OpenRouter, Amazon Bedrock, and Vercel AI Gateway.
 
 ## Companion repositories
 
@@ -135,14 +131,18 @@ AIRAS relies on three sibling repositories under the `airas-org` organization. E
 
 ## MCP tools
 
-The server exposes tools for every phase; the skills above are thin contracts over them.
+The `auto-research` flow uses the following tools; the skills above are thin contracts over them. The server exposes more, but these are the ones a research project goes through.
 
-- **Discovery and design:** `generate_research_queries`, `search_papers`, `fetch_paper_fulltext`, `retrieve_papers`, `generate_hypothesis`, `generate_experimental_design`, `retrieve_models`, `retrieve_datasets`, `search_huggingface_hub`, `get_library_docs`
-- **Repository and execution:** `prepare_repository`, `set_github_actions_secrets`, `protect_branch`, `dispatch_experiment`, `get_workflow_runs`, `get_experiment_run_status`, `fetch_experiment_results`, `import_run_outputs`, `download_workflow_artifacts`, `analyze_experiment`
-- **Record and verification:** `preregister_record`, `append_to_record`, `update_record`, `verify_paper_values`
-- **Figures and paper:** `render_chart`, `render_diagram`, `generate_bibfile`, `generate_paper`, `generate_latex`, `verify_latex`, `compile_latex`, `open_in_overleaf`
-- **Paper reproduction:** `dispatch_paper_reproduction_generate`, `dispatch_paper_reproduction_run`, `fetch_paper_reproduction_results`, `dispatch_parameter_tuning_run`, `fetch_parameter_tuning_results`
-- **Session and meta:** `upload_research_history`, `download_research_history`, `get_available_llms`, `get_generation_prompt`, `get_input_schema`
+| Step | Tools |
+| --- | --- |
+| `setup-repository` | `prepare_repository`, `set_github_actions_secrets`, `protect_branch`, `upload_research_history` |
+| `discover-papers` | `search_papers`, `fetch_paper_fulltext`, `get_input_schema` |
+| `hypothesize-and-design` | `retrieve_models`, `retrieve_datasets`, `get_generation_prompt` |
+| `preregister-paper` | `preregister_record`, `append_to_record`, `update_record`, `verify_latex` |
+| `write-experiment-code` | `get_library_docs` |
+| `run-experiments` | `fetch_experiment_results`, `import_run_outputs`, `verify_paper_values` (execution itself goes through the Seyval MCP server; see above) |
+| `analyze-results` | `fetch_experiment_results`, `render_chart`, `render_diagram`, `append_to_record`, `update_record` |
+| `publish-paper` | `generate_bibfile`, `verify_latex`, `open_in_overleaf`, `get_workflow_runs`, `download_research_history` |
 
 See the [MCP documentation](docs/development/MCP.mdx) for descriptions, credentials per tool, and configuration options.
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "airas"
-version = "0.3.1"
-description = "Add your description here"
+version = "0.4.0"
+description = "Automated research toolkit: an MCP server, a Claude Code plugin, and a CLI that take a research topic through survey, hypothesis, experiments, and a verifiable paper"
 readme = "README.md"
 authors = [
     {name="Toma Tanaka", email="ulti4929@gmail.com"}
@@ -25,7 +25,8 @@ dependencies = [
     "typing-extensions>=4.12.2",
     "pymupdf>=1.25.5",
     "pandas>=2.3.0",
-    "bibtexparser>=1.4.3",
+    # bibtexparser 2.x (2026-09) removed bibtexparser.bibdatabase, which generate_bibfile depends on
+    "bibtexparser>=1.4.3,<2",
     "anthropic>=0.66.0",
     "toml>=0.10.2",
     "pynacl>=1.6.0",
@@ -47,7 +48,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://www.autores.one/english"
-Issues = "https://github.com/auto-res/airas/issues"
+Issues = "https://github.com/airas-org/airas/issues"
 
 [dependency-groups]
 dev = [
@@ -104,9 +105,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/airas"]
-# Built frontend assets (copied in by CI before `uv build`); gitignored,
-# so they must be re-included explicitly.
-artifacts = ["src/airas/dashboard/static/"]
 
 [[tool.uv.index]]
 name = "testpypi"

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import os
-import webbrowser
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Literal
@@ -48,12 +47,8 @@ from airas.core.types.research_record import (
 from airas.core.types.research_study import ResearchStudy
 from airas.dashboard.launcher import (
     dashboard_url,
-    has_bundled_ui,
     is_dashboard_running,
     start_dashboard,
-)
-from airas.dashboard.launcher import (
-    stop_dashboard as stop_dashboard_process,
 )
 from airas.infra.arxiv_client import ArxivClient
 from airas.infra.github_client import GithubClient
@@ -2552,48 +2547,6 @@ def open_in_overleaf(
             "a new editable project there."
         ),
     }
-
-
-@mcp.tool()
-def open_dashboard(
-    port: int = DEFAULT_DASHBOARD_PORT, open_browser: bool = True
-) -> dict[str, Any]:
-    """Launch the AIRAS web dashboard on localhost and return its URL.
-
-    Starts the dashboard server (API + web UI) as a background process,
-    or reuses one that is already running on the port. By default the URL
-    is also opened in the user's browser. The dashboard keeps running
-    after the MCP session ends; stop it with `stop_dashboard`.
-    No API keys required to launch.
-    """
-    # The dashboard process inherits credentials from ~/.airas/credentials.json
-    # via the environment, so its API endpoints can call LLM/GitHub APIs.
-    refresh_environment()
-
-    url = dashboard_url(port)
-    if is_dashboard_running(port):
-        status = "already_running"
-    else:
-        start_dashboard(port)
-        status = "started"
-
-    if open_browser:
-        webbrowser.open(url)
-
-    result: dict[str, Any] = {"status": status, "url": url}
-    if not has_bundled_ui():
-        result["warning"] = (
-            "This installation has no bundled web UI (development checkout?), "
-            "so only the API is served. Install the published package "
-            "(`uvx airas`) for the full dashboard."
-        )
-    return result
-
-
-@mcp.tool()
-def stop_dashboard() -> dict[str, Any]:
-    """Stop the AIRAS web dashboard started by `open_dashboard`."""
-    return stop_dashboard_process()
 
 
 # --- Paper reproduction ---

--- a/backend/src/airas/usecases/recording/codex_hooks.py
+++ b/backend/src/airas/usecases/recording/codex_hooks.py
@@ -8,6 +8,7 @@ feature is switched on in `~/.codex/config.toml`.
 from __future__ import annotations
 
 import json
+from importlib.metadata import version
 from pathlib import Path
 
 import tomli
@@ -15,9 +16,13 @@ import tomli_w
 
 from airas.usecases.recording.agent_state import CODEX_HOME
 
+# Pin the installed version: `uvx airas` keeps whatever it fetched first, so an
+# unpinned hook would silently stay on an old release.
+_AIRAS = f"airas=={version('airas')}"
+
 HOOK_COMMANDS = {
-    "SessionStart": "uvx --with 'mcp<2' airas hook session-start --harness codex",
-    "Stop": "uvx --with 'mcp<2' airas hook capture --harness codex",
+    "SessionStart": f"uvx {_AIRAS} hook session-start --harness codex",
+    "Stop": f"uvx {_AIRAS} hook capture --harness codex",
 }
 
 

--- a/backend/src/airas/usecases/recording/codex_hooks.py
+++ b/backend/src/airas/usecases/recording/codex_hooks.py
@@ -8,7 +8,7 @@ feature is switched on in `~/.codex/config.toml`.
 from __future__ import annotations
 
 import json
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 import tomli
@@ -16,21 +16,30 @@ import tomli_w
 
 from airas.usecases.recording.agent_state import CODEX_HOME
 
-# Pin the installed version: `uvx airas` keeps whatever it fetched first, so an
-# unpinned hook would silently stay on an old release.
-_AIRAS = f"airas=={version('airas')}"
 
-HOOK_COMMANDS = {
-    "SessionStart": f"uvx {_AIRAS} hook session-start --harness codex",
-    "Stop": f"uvx {_AIRAS} hook capture --harness codex",
-}
+def _airas_requirement() -> str:
+    """Pin the installed version: `uvx airas` keeps whatever it fetched first,
+    so an unpinned hook would silently stay on an old release. A checkout
+    without distribution metadata falls back to the unpinned name."""
+    try:
+        return f"airas=={version('airas')}"
+    except PackageNotFoundError:
+        return "airas"
+
+
+def hook_commands() -> dict[str, str]:
+    airas = _airas_requirement()
+    return {
+        "SessionStart": f"uvx {airas} hook session-start --harness codex",
+        "Stop": f"uvx {airas} hook capture --harness codex",
+    }
 
 
 def install_codex_hooks(home: Path = CODEX_HOME) -> str:
     home.mkdir(parents=True, exist_ok=True)
     hooks_path = home / "hooks.json"
     hooks = json.loads(hooks_path.read_text()) if hooks_path.is_file() else {}
-    for event, command in HOOK_COMMANDS.items():
+    for event, command in hook_commands().items():
         groups = hooks.setdefault("hooks", {}).setdefault(event, [])
         if not any(
             h.get("command") == command

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'linux'",
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "airas"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -161,7 +161,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.66.0" },
-    { name = "bibtexparser", specifier = ">=1.4.3" },
+    { name = "bibtexparser", specifier = ">=1.4.3,<2" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "dependency-injector", specifier = ">=4.48.2" },
     { name = "fastapi", specifier = ">=0.120.4" },
@@ -848,7 +848,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1266,17 +1266,17 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/31/10ac88f3357fc276dc8a64e8880c82e80e7459326ae1d0a211b40abf6665/ipython-8.37.0.tar.gz", hash = "sha256:ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216", size = 5606088, upload-time = "2025-05-31T16:39:09.613Z" }
 wheels = [
@@ -1294,17 +1294,17 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/e6/48c74d54039241a456add616464ea28c6ebf782e4110d419411b83dae06f/ipython-9.7.0.tar.gz", hash = "sha256:5f6de88c905a566c6a9d6c400a8fed54a638e1f7543d17aae2551133216b1e4e", size = 4422115, upload-time = "2025-11-05T12:18:54.646Z" }
 wheels = [
@@ -1316,7 +1316,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [

--- a/docs/development/MCP.mdx
+++ b/docs/development/MCP.mdx
@@ -14,7 +14,7 @@ No installation is required — `uvx` fetches the package on first run. The only
 
 Credentials live in `~/.airas/credentials.json`. The file is re-read on every tool call, so you can create or edit it at any time — even after the server is already registered and running.
 
-The easiest way to manage it is the dashboard's **API Keys** page (`uvx airas dashboard`, or the `open_dashboard` MCP tool). You can also edit the file by hand:
+Create or edit the file by hand:
 
 ```bash
 mkdir -p ~/.airas

--- a/docs/ja/development/MCP.mdx
+++ b/docs/ja/development/MCP.mdx
@@ -14,7 +14,7 @@ AIRASは、Claude CodeやClaude DesktopなどのMCPクライアントから研�
 
 認証情報は `~/.airas/credentials.json` に置きます。このファイルは**ツール呼び出しのたびに読み込まれる**ので、サーバー登録後・起動後にいつでも作成・編集できます。
 
-最も簡単な管理方法はダッシュボードの **APIキー** ページです（`uvx airas dashboard`、または MCP ツール `open_dashboard` で起動）。手動でファイルを編集することもできます：
+ファイルを手動で作成・編集します：
 
 ```bash
 mkdir -p ~/.airas

--- a/plugins/airas/.claude-plugin/plugin.json
+++ b/plugins/airas/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "airas",
   "description": "Automated research with AIRAS: paper search, hypothesis generation, experiment execution on GitHub Actions/Seyval, figure rendering, and paper writing — bundles the AIRAS MCP server (uvx airas) and research-workflow skills.",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": {
     "name": "airas-org",
     "url": "https://github.com/airas-org"

--- a/plugins/airas/.claude-plugin/plugin.json
+++ b/plugins/airas/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "airas",
-  "description": "Automated research with AIRAS: paper search, hypothesis generation, experiment execution on GitHub Actions/Seyval, figure rendering, and paper writing — bundles the AIRAS MCP server (uvx airas) and research-workflow skills.",
+  "description": "Automated research with AIRAS: paper search, hypothesis and experimental design, preregistered and verifiable papers, figure rendering, and LaTeX — bundles the AIRAS MCP server (uvx airas) with the auto-research workflow skills.",
   "version": "0.4.0",
   "author": {
     "name": "airas-org",

--- a/plugins/airas/.mcp.json
+++ b/plugins/airas/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "airas": {
       "command": "uvx",
-      "args": ["--with", "mcp<2", "airas"]
+      "args": ["airas==0.4.0"]
     }
   }
 }

--- a/plugins/airas/hooks/hooks.json
+++ b/plugins/airas/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uvx --with 'mcp<2' airas hook session-start --harness claude",
+            "command": "uvx airas==0.4.0 hook session-start --harness claude",
             "timeout": 60
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uvx --with 'mcp<2' airas hook step --harness claude",
+            "command": "uvx airas==0.4.0 hook step --harness claude",
             "timeout": 60
           }
         ]
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uvx --with 'mcp<2' airas hook capture --harness claude",
+            "command": "uvx airas==0.4.0 hook capture --harness claude",
             "timeout": 120
           }
         ]

--- a/plugins/airas/skills/setup-repository/SKILL.md
+++ b/plugins/airas/skills/setup-repository/SKILL.md
@@ -8,7 +8,7 @@ description: Create an AIRAS experiment repository from the template and clone i
 1. `prepare_repository` — pass the visibility settled at the start of
    the flow (`is_private` defaults to true); returns `clone_url`;
    clone it locally with git. Requires `GH_PERSONAL_ACCESS_TOKEN`
-   (`~/.airas/credentials.json`, editable via `open_dashboard`) with
+   (`~/.airas/credentials.json`) with
    admin rights on the repository.
 
    It also provisions the Actions secrets and protects `main` in the

--- a/server.json
+++ b/server.json
@@ -14,12 +14,12 @@
       "sizes": ["1563x1563"]
     }
   ],
-  "version": "0.2.2",
+  "version": "0.4.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "airas",
-      "version": "0.2.2",
+      "version": "0.4.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content
- Something else!

#### Description

0.4.0 リリースの準備と README の更新です。PyPI の最新（0.3.1、2026-07-16）は main から 222 コミット遅れており、README が説明する `verify-record` / `verify-paper` CLI、record 系ツール、plugin の hooks（`airas hook`）がいずれも PyPI 版に存在しないため、plugin の hooks は現状すべてのユーザーで毎セッション失敗しています。

**リリース準備**
- `backend/pyproject.toml`: 0.3.1 → 0.4.0。PyPI に表示される description（「Add your description here」のままだった）と Issues URL（旧 org）を修正。`uv.lock` 再生成。
- `bibtexparser<2` を追加。2026-09-08 公開の bibtexparser 2.0.0 が `bibtexparser.bibdatabase` を削除しており、fresh install で MCP サーバの import が失敗する（PyPI の 0.3.1 も同じ状態）。
- `server.json` / `plugins/airas/.claude-plugin/plugin.json`: 0.4.0。
- `plugins/airas/.mcp.json` / `hooks/hooks.json` / `codex_hooks.py`: `uvx airas==0.4.0` に固定。uvx は初回に取得したバージョンを使い続けるため、固定しないと既存ユーザーが新リリースに移らない。`mcp<2` の `--with` は pyproject 側で要求済みのため削除。
- `publish.yml`: タグと plugin.json / pin のバージョン一致を検証するステップを追加。frontend のビルドと dashboard static の同梱、そのスモークテストを削除（frontend は使用していないため）。

**dashboard ツールの削除**
- `open_dashboard` / `stop_dashboard` を MCP サーバから削除。`open_in_overleaf` が使う launcher は残しています。
- docs（英・日）と `setup-repository` skill から `open_dashboard` への言及を削除。

**README**
- Quick Start: Claude Code plugin を主経路として記述し、MCP 単体は skills / hooks なしの別形態として続ける。uvx のアップグレード方法を追記。
- Credentials 表: `RIKYU_API_KEY` を削除。LLM キーはフローでは不要（agent が `get_generation_prompt` で自分で書く）と明記。Seyval キーは実験実行時に必要。
- 実験実行を under construction と明記（現状の skill は Seyval MCP を直接叩き、GitHub Actions 経路は未接続。#1017 参照）。
- MCP tools 一覧を skill が実際に参照する 24 ツールに絞り、step ごとの表に変更。
- バッジの整理（Documentation、Twitter を削除）。

**確認したこと**
- 手元でビルドした 0.4.0 wheel を隔離環境で起動し、44 ツールと `start_research` プロンプト、`airas hook` サブコマンドが動作すること（dashboard ツール削除前に実施）。
- ruff / mypy パス。`test_fork_point.py` 11 件パス。
- `claude plugin validate` が marketplace / plugin の両方で pass。

**マージ後**: main に `v0.4.0` タグを push すると publish workflow が PyPI と MCP レジストリに公開します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANKeE9HYiVs3ZzDqwZfpcn
