### PR TITLE
feat(record): claims に criterion / prediction / rationale を持たせ、verdict を導出する

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Lint and type checks are wired through `pre-commit` (`pre-commit install` once p
 
 AIRAS is developed in stages. Reliability comes first: an automated research pipeline is only worth scaling once its outputs can be trusted and reproduced.
 
-**1. Reliability (in progress).** The record now guarantees that every number in the paper traces back to a declared run and its outputs, and CI enforces it. That covers the paper but not everything upstream of it: experiment code that games a benchmark, leaks test data, or deviates from the design still passes the gate. Closing that gap, from the experiment code and evaluation inputs back to the design, is the current focus.
+**1. Reliability (in progress).** The record now guarantees that every number in the paper traces back to a declared run and its outputs, that each claim's verdict is derived from the criterion it declared before running, and CI enforces it. That covers the paper but not everything upstream of it: experiment code that games a benchmark, leaks test data, or deviates from the design still passes the gate. Closing that gap, from the experiment code and evaluation inputs back to the design, is the current focus.
 
 - [x] Preregistration: claims, criteria, and predicted results frozen in git before any experiment runs
 - [x] Append-only research record with numbers realized from run outputs and verified in CI

--- a/backend/src/airas/core/types/research_record.py
+++ b/backend/src/airas/core/types/research_record.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from enum import StrEnum
 from typing import (
     Annotated,
@@ -7,13 +8,14 @@ from typing import (
     Generic,
     Iterator,
     Literal,
+    Mapping,
     Optional,
     Sequence,
     TypeVar,
     Union,
 )
 
-from pydantic import BaseModel, Discriminator, Field, Tag
+from pydantic import BaseModel, Discriminator, Field, Tag, model_validator
 
 from airas.core.types.map_record_to_publication import TableSpec
 
@@ -95,6 +97,12 @@ VerifierT = TypeVar("VerifierT", SeyvalVerifier, LeanVerifier, LlmJudgeVerifier)
 class ClaimBase(BaseModel, Generic[VerifierT, DesignT]):
     id: str = Field(pattern=CLAIM_ID_PATTERN)
     statement: str = Field(description="One assertive sentence")
+    rationale: str = Field(
+        min_length=1,
+        description="Why this claim holding is evidence for the hypothesis, "
+        "and for which part of it: what makes it a member of the set of "
+        "claims whose conjunction is meant to imply the hypothesis",
+    )
     verifier: VerifierT
     designs: list[DesignT] = Field(default_factory=list)
     verified: bool = Field(
@@ -167,8 +175,87 @@ class SeyvalRun(Run[dict[str, Any], SeyvalResult]):
 SeyvalDesign = Design[SeyvalRun]
 
 
+def walk_metric_path(node: Any, path: str) -> float:
+    """Get a number from nested metrics using a path like 'a.b.0.c'."""
+    for segment in path.split(".") if path else []:
+        try:
+            node = node[int(segment)] if isinstance(node, list) else node[segment]
+        except (KeyError, IndexError, ValueError, TypeError):
+            raise ValueError(f"nothing at '{segment}'") from None
+
+    if isinstance(node, bool) or not isinstance(node, (int, float)):
+        raise ValueError(f"not a number: {node!r}")
+
+    return float(node)
+
+
+CriterionOp = Literal[">=", "<=", ">", "<"]
+
+
+class Criterion(BaseModel):
+    """The falsification line: (subject.metric - reference) op margin.
+
+    `reference` is a run id (its same metric is subtracted) or a constant.
+    A difference exactly at the margin counts as meeting it.
+    """
+
+    metric: str = Field(
+        min_length=1, description="Path inside metrics.json, e.g. 'accuracy'"
+    )
+    subject: str = Field(description="run_id whose metric is judged")
+    reference: Union[str, float] = Field(
+        description="run_id compared against on the same metric, or a constant"
+    )
+    op: CriterionOp
+    margin: float = 0.0
+
+    @model_validator(mode="after")
+    def _subject_is_not_the_reference(self) -> Criterion:
+        if self.subject == self.reference:
+            raise ValueError("criterion compares a run to itself")
+        return self
+
+    def observed(self, metrics_by_run: Mapping[str, Any]) -> float:
+        """The difference the criterion judges; raises when a value is missing."""
+        subject = walk_metric_path(metrics_by_run[self.subject], self.metric)
+        if isinstance(self.reference, str):
+            return subject - walk_metric_path(
+                metrics_by_run[self.reference], self.metric
+            )
+        return subject - self.reference
+
+    def holds(self, difference: float) -> bool:
+        at_margin = math.isclose(difference, self.margin, rel_tol=1e-9, abs_tol=1e-12)
+        if self.op == ">=":
+            return at_margin or difference > self.margin
+        if self.op == "<=":
+            return at_margin or difference < self.margin
+        if self.op == ">":
+            return difference > self.margin and not at_margin
+        return difference < self.margin and not at_margin
+
+
+class Prediction(BaseModel):
+    """Where the difference is expected to land: a range, never a point."""
+
+    low: float
+    high: float
+    basis: str = Field(min_length=1, description="Prior work, pilot, ...")
+
+    @model_validator(mode="after")
+    def _is_a_range(self) -> Prediction:
+        if not self.low < self.high:
+            raise ValueError("prediction must be a range with low < high")
+        return self
+
+
 class SeyvalClaim(ClaimBase[SeyvalVerifier, SeyvalDesign]):
-    pass
+    criterion: Criterion = Field(
+        description="Frozen at declaration; the verdict derives from it"
+    )
+    prediction: Prediction = Field(
+        description="Predicted interval for the criterion's difference"
+    )
 
 
 # --------------------------------------------------------------------- lean
@@ -273,6 +360,13 @@ class ChartDeclaration(BaseModel):
 class Hypothesis(BaseModel):
     id: str = Field(pattern=HYPOTHESIS_ID_PATTERN)
     statement: str = Field(description="The hypothesis itself, in prose")
+    assumptions: list[str] = Field(
+        default_factory=list,
+        description="What must be granted for the claims together to imply "
+        "the hypothesis — the bridge from c1 ∧ … ∧ cn to H, each naming the "
+        "claims it concerns. Every claim supported leaves exactly these "
+        "unverified",
+    )
     claims: list[ClaimDeclaration] = Field(default_factory=list)
     tables: list[TableSpec] = Field(default_factory=list)
     charts: list[ChartDeclaration] = Field(default_factory=list)

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -145,11 +145,13 @@ from airas.usecases.publication.generate_latex_subgraph.generate_latex_subgraph 
 )
 from airas.usecases.publication.map_record_to_publication import (
     CHART_DIR,
+    CLAIMS_TEX_FILENAME,
     TABLES_DIR_NAME,
     VALUES_TEX_FILENAME,
     clip_zero_based_marks,
     record_link_commit,
     render_chart_bytes,
+    render_claims_tex,
     render_table_tex,
     render_values_tex,
     renderer_version,
@@ -2111,6 +2113,23 @@ def _commit_record_paths(local_path: str, paths: list[str], message: str) -> str
     return commit
 
 
+def _write_claims_tex(local_path: str, template: str, record: ResearchRecord) -> str:
+    """Render claims.tex from the record and whatever metrics exist.
+
+    Returns the repo-relative path, for the commit.
+    """
+    root = Path(local_path).expanduser().resolve()
+    try:
+        metrics_data = load_metrics_data(local_path)
+    except ValueError:
+        metrics_data = {}  # prereg stage: every claim renders as pending
+    relpath = f".research/latex/{template}/{CLAIMS_TEX_FILENAME}"
+    path = root / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_claims_tex(record, metrics_data), encoding="utf-8")
+    return relpath
+
+
 def _hypothesis(record: ResearchRecord, hypothesis_id: str) -> Hypothesis:
     for hypothesis in record.hypotheses:
         if hypothesis.id == hypothesis_id:
@@ -2125,6 +2144,7 @@ def _hypothesis(record: ResearchRecord, hypothesis_id: str) -> Hypothesis:
 async def preregister_record(
     local_path: str,
     hypotheses: list[dict[str, Any]],
+    latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
 ) -> dict[str, Any]:
     """Create the research record before any experiment has run.
 
@@ -2132,17 +2152,24 @@ async def preregister_record(
     verification system keys on — and commits it in the same step
     (`freeze_commit` in the result). That commit is the freeze point: every
     later revision must *contain* this one whole, so a claim cannot be
-    reworded, a run's conditions cannot be changed and a result cannot be
-    dropped once written.
+    reworded, its criterion cannot be moved, a run's conditions cannot be
+    changed and a result cannot be dropped once written.
 
     The record is a tree, read as "to support this hypothesis, these claims;
     to verify this claim, these designs; a design is these runs":
 
       hypotheses: [{
         "id": "h1", "statement": "the hypothesis, in prose",
+        "assumptions": ["what must be granted for the claims together to "
+                        "imply h1, naming the claims concerned", ...],
         "claims": [{
           "id": "c1", "statement": "one assertive sentence",
+          "rationale": "why c1 holding is evidence for h1, and for which part",
           "verifier": {"kind": "seyval"},
+          "criterion": {"metric": "accuracy", "subject": "proposed-...",
+                        "reference": "comparative-1-...", "op": ">=",
+                        "margin": 0.02},
+          "prediction": {"low": 0.02, "high": 0.04, "basis": "pilot run"},
           "designs": [{
             "id": "d1", "summary": "...",
             "runs": [{"run_id": "proposed-...", "description": "...",
@@ -2154,6 +2181,15 @@ async def preregister_record(
 
     `run_id` names the results directory the run will produce and must be
     unique across the whole record — a run belongs to exactly one claim.
+    (Not a bare number: `criterion.reference` reads a number as a constant.)
+
+    The claims are meant to imply the hypothesis together (c1 ∧ … ∧ cn ⇒
+    h1). `rationale` says why each claim is a member of that set; the
+    hypothesis's `assumptions` say what has to be granted for the
+    conjunction to reach h1 — a proxy metric standing for the property,
+    generalisation beyond the datasets run, and the like. Every claim
+    supported leaves exactly the assumptions unverified, so they are what
+    the paper states as such; claims.tex lists them under the claims.
 
     `verifier` says what verifies the claim and sets its `verified` and
     `verdict`; one per claim (a claim needing both a proof and an experiment
@@ -2161,8 +2197,15 @@ async def preregister_record(
     and what the gate re-derives:
 
       seyval    (experiment) params = dispatch conditions, e.g. {"mode":
-                "full"}, checked against what the platform recorded. No
-                verdict yet — the claim's condition is not modelled (TODO).
+                "full"}, checked against what the platform recorded.
+                `criterion` is the falsification line, required:
+                (subject.metric - reference) op margin, where reference is
+                a run under this claim (its same metric) or a constant;
+                exactly at the margin counts as met. `prediction` is the
+                interval the difference is expected to land in, required,
+                a range never a point, with where it comes from. Verdict:
+                supported/refuted by the criterion on the runs' metrics;
+                inconclusive when the metric cannot be resolved.
       lean      (theory) {"kind": "lean", "toolchain": "leanprover/lean4:
                 v4.12.0", "mathlib_rev": "...", "allowed_axioms": [...]};
                 params = {"module": "Airas.Thm1", "decl": "thm1",
@@ -2180,11 +2223,17 @@ async def preregister_record(
     The tools that execute lean and llm_judge, and the gate's re-execution
     of them, are not implemented yet.
 
+    Also renders `claims.tex` — the numbered claim list with each criterion,
+    prediction and (pending) verdict — into `.research/latex/{template}/`
+    and commits it with the record; `\\input{claims.tex}` where the paper
+    lists its claims. The gate regenerates and diffs it at every stage.
+
     Fails if record.json already exists (use `append_to_record`), if a claim
-    declares no run, or if the clone cannot commit. After this: write every
-    future experimental number in main.tex as `\\airasval{<run_id>.<metric>}`
-    or `\\airasval{<run_id>.params.<key>}`, compile, commit main.tex and
-    push to the staging ref — tell the user the freeze sha once it lands.
+    declares no run, if a seyval claim lacks its criterion or prediction, or
+    if the clone cannot commit. After this: write every future experimental
+    number in main.tex as `\\airasval{<run_id>.<metric>}` or
+    `\\airasval{<run_id>.params.<key>}`, compile, commit main.tex and push
+    to the staging ref — tell the user the freeze sha once it lands.
     """
     parsed = _parse_hypotheses(hypotheses)
 
@@ -2202,11 +2251,15 @@ async def preregister_record(
             raise ValueError("; ".join(problems))
 
         save_record(local_path, record)
+        claims_tex = _write_claims_tex(local_path, latex_template_name, record)
         freeze_commit = _commit_record_paths(
-            local_path, [RECORD_PATH], "prereg: declare the research record"
+            local_path,
+            [RECORD_PATH, claims_tex],
+            "prereg: declare the research record",
         )
         return {
             "record_path": str(path),
+            "claims_tex_path": claims_tex,
             "hypotheses": {
                 h.id: {
                     c.id: {d.id: [r.run_id for r in d.runs] for d in c.designs}
@@ -2217,7 +2270,8 @@ async def preregister_record(
             "freeze_commit": freeze_commit,
             "next": (
                 "this commit is the freeze point runs must descend from — "
-                "write the prereg main.tex, then push to the staging ref"
+                "write the prereg main.tex with \\input{claims.tex} where the "
+                "claims are listed, then push to the staging ref"
             ),
         }
 
@@ -2233,6 +2287,7 @@ async def append_to_record(
     tables: list[dict[str, Any]] | None = None,
     charts: list[dict[str, Any]] | None = None,
     notes: list[str] | None = None,
+    latex_template_name: LATEX_TEMPLATE_NAME = "mdpi",
 ) -> dict[str, Any]:
     """Add declarations to the record; nothing already in it ever changes.
 
@@ -2252,7 +2307,9 @@ async def append_to_record(
     The append is committed in the same step (`commit` in the result);
     anything a run should count as evidence for must be in that commit's
     history before the run executes, so a claim declared after its run stays
-    unverified forever.
+    unverified forever. A seyval claim appended here needs its criterion and
+    prediction like one preregistered; `claims.tex` is re-rendered and
+    committed alongside.
     """
     new_hypotheses = _parse_hypotheses(hypotheses)
     scoped = any(x for x in (claims, tables, charts, notes))
@@ -2285,11 +2342,13 @@ async def append_to_record(
         if problems:
             raise ValueError("; ".join(problems))
         save_record(local_path, record)
+        claims_tex = _write_claims_tex(local_path, latex_template_name, record)
         commit = _commit_record_paths(
-            local_path, [RECORD_PATH], "record: append declarations"
+            local_path, [RECORD_PATH, claims_tex], "record: append declarations"
         )
         return {
             "record_path": str(record_path(local_path)),
+            "claims_tex_path": claims_tex,
             "appended": counts,
             "commit": commit,
             "next": (
@@ -2323,11 +2382,14 @@ async def update_record(
 
     A claim's `verified` is set to true when every run under it has
     results — the data the claim rests on is in — and its `verdict` once
-    the verifier concludes (lean and llm_judge; seyval's claim condition
-    is not modelled yet, TODO). Whether the claim was declared before its
-    runs executed is not modelled yet either.
+    the verifier concludes: for seyval, the declared criterion applied to
+    the runs' metrics. Both
+    are written once and never back; a re-run that would flip the verdict
+    is reported by the gate as drift, and re-judging means appending the
+    claim again under the same id. Whether the claim was declared before
+    its runs executed is not modelled yet.
 
-    It then renders `values.tex` and `tables/<key>.tex` into
+    It then renders `values.tex`, `tables/<key>.tex` and `claims.tex` into
     `.research/latex/{template}/`; when the clone has an `origin` remote,
     every value macro is a hyperlink to record.json at the commit that
     wrote it.
@@ -2410,8 +2472,10 @@ async def update_record(
                     render_table_tex(spec, metrics_data), encoding="utf-8"
                 )
                 tables[spec.key] = str(table_path)
+        claims_tex = _write_claims_tex(local_path, latex_template_name, record)
         commit_targets = [
             f".research/latex/{latex_template_name}/{VALUES_TEX_FILENAME}",
+            claims_tex,
         ]
         # tables/ exists only once a table has been declared, and git add is
         # fatal on a pathspec that matches nothing.
@@ -2432,15 +2496,17 @@ async def update_record(
             "tables": tables,
             "record_path": str(record_path(local_path)),
             "values_tex_path": str(values_tex_path),
+            "claims_tex_path": claims_tex,
             "commit": commit,
         }
 
     result = await asyncio.to_thread(_run)
     result["usage"] = (
         "\\input{values.tex} in the preamble, \\input{tables/<key>.tex} where "
-        "each table belongs, then \\airasval{<key>} wherever the paper states "
-        "a number; the realized files are already committed — push to the "
-        "staging ref and let CI decide whether it may reach the protected branch"
+        "each table belongs, \\input{claims.tex} where the claims are listed, "
+        "then \\airasval{<key>} wherever the paper states a number; the "
+        "realized files are already committed — push to the staging ref and "
+        "let CI decide whether it may reach the protected branch"
     )
     return result
 
@@ -2460,8 +2526,10 @@ async def verify_paper_values(
     that decide `ok`: every declared value is recomputed from the run
     outputs under `.research/results/` and compared to the record's
     stored results (a tampered record surfaces as a mismatch),
-    `values.tex` is regenerated and diffed byte-for-byte, every
-    `\\airasval` key main.tex references must be declared, every table
+    `values.tex` and `claims.tex` are regenerated and diffed byte-for-byte
+    (`claims.tex` at the prereg stage too), every `\\airasval` key
+    main.tex references must be
+    declared, every table
     under `tables/` and every chart under `.research/results/chart/`
     must match a regeneration of its declaration (undeclared files fail),
     every results directory must belong to a declared run, the record's

--- a/backend/src/airas/usecases/publication/map_record_to_publication.py
+++ b/backend/src/airas/usecases/publication/map_record_to_publication.py
@@ -17,7 +17,12 @@ from pydantic import BaseModel
 
 from airas.core.research_paths import RECORD_PATH
 from airas.core.types.map_record_to_publication import PaperValue, TableSpec
-from airas.core.types.research_record import ResearchRecord, active
+from airas.core.types.research_record import (
+    ResearchRecord,
+    SeyvalClaim,
+    active,
+    walk_metric_path,
+)
 from airas.infra.local_git import commits_touching
 
 # ============================================================================
@@ -35,24 +40,16 @@ def match_run_id(metrics_data: dict[str, Any], ref: str) -> str | None:
     )
 
 
-def _walk(node: Any, remainder: str, ref: str, where: str) -> float:
-    for segment in remainder.split(".") if remainder else []:
-        try:
-            node = node[int(segment)] if isinstance(node, list) else node[segment]
-        except (KeyError, IndexError, ValueError, TypeError):
-            raise ValueError(f"'{ref}': nothing at '{segment}' in {where}") from None
-    if isinstance(node, bool) or not isinstance(node, (int, float)):
-        raise ValueError(f"'{ref}' is not a number: {node!r}")
-    return float(node)
-
-
 def resolve_ref(metrics_data: dict[str, Any], ref: str) -> float:
     """Resolve '<run_id>.<metric path>' against the committed results files."""
     run_id = match_run_id(metrics_data, ref)
     if run_id is None:
         available = ", ".join(sorted(metrics_data))
         raise ValueError(f"'{ref}' matches no run id (available: {available})")
-    return _walk(metrics_data[run_id], ref[len(run_id) + 1 :], ref, f"run '{run_id}'")
+    try:
+        return walk_metric_path(metrics_data[run_id], ref[len(run_id) + 1 :])
+    except ValueError as e:
+        raise ValueError(f"'{ref}': {e} in run '{run_id}'") from None
 
 
 def format_display(value: float, round_digits: int | None) -> str:
@@ -223,6 +220,66 @@ def render_table_tex(spec: TableSpec, metrics_data: dict[str, Any]) -> str:
             cells.append(format_display(value, column.round))
         lines.append(" & ".join(cells) + r" \\")
     lines += [r"\hline", r"\end{tabular}", r"\end{table}"]
+    return "\n".join(lines) + "\n"
+
+
+# ============================================================================
+# 3b. claims.tex
+# Verified: the numbered claim list regenerates byte for byte at both stages,
+# so a criterion, a prediction or a verdict in the PDF is the record's.
+# ============================================================================
+
+CLAIMS_TEX_FILENAME = "claims.tex"
+
+
+def _tt(text: str) -> str:
+    return rf"\texttt{{\detokenize{{{text}}}}}"
+
+
+def render_claims_tex(record: ResearchRecord, metrics_data: dict[str, Any]) -> str:
+    # Deterministic from (record, metrics) alone — no commit link — so the
+    # freeze commit can carry it before any run exists.
+    ops = {">=": r"\geq", "<=": r"\leq", ">": ">", "<": "<"}
+    lines = [_TABLES_TEX_HEADER]
+    for hypothesis in record.active_hypotheses():
+        lines += [
+            rf"\noindent\textbf{{{hypothesis.id.upper()}.}} {hypothesis.statement}",
+            r"\begin{enumerate}",
+        ]
+        for claim in active(hypothesis.claims, "id"):
+            lines.append(rf"\item[\textbf{{{claim.id.upper()}}}] {claim.statement}")
+            lines.append(rf"  \emph{{Rationale:}} {claim.rationale}")
+            if isinstance(claim, SeyvalClaim):
+                c = claim.criterion
+                reference = (
+                    f"{_tt(c.reference)}.{_tt(c.metric)}"
+                    if isinstance(c.reference, str)
+                    else format_display(c.reference, None)
+                )
+                lines.append(
+                    rf"  \emph{{Criterion:}} {_tt(c.subject)}.{_tt(c.metric)} $-$ "
+                    rf"{reference} ${ops[c.op]} {format_display(c.margin, None)}$."
+                )
+                p = claim.prediction
+                lines.append(
+                    rf"  \emph{{Prediction:}} $[{format_display(p.low, None)}, "
+                    rf"{format_display(p.high, None)}]$ ({p.basis})."
+                )
+                try:
+                    observed = format_display(c.observed(metrics_data), None)
+                except (KeyError, ValueError):
+                    observed = "pending"
+                lines.append(rf"  \emph{{Observed:}} {observed}.")
+            lines.append(rf"  \emph{{Verdict:}} {claim.verdict or 'pending'}.")
+        lines.append(r"\end{enumerate}")
+        if hypothesis.assumptions:
+            lines.append(
+                r"\noindent\emph{Assumed, so that the claims together imply "
+                rf"{hypothesis.id.upper()}:}}"
+            )
+            lines.append(r"\begin{itemize}")
+            lines += [rf"\item {a}" for a in hypothesis.assumptions]
+            lines.append(r"\end{itemize}")
     return "\n".join(lines) + "\n"
 
 

--- a/backend/src/airas/usecases/publication/verify_paper.py
+++ b/backend/src/airas/usecases/publication/verify_paper.py
@@ -26,10 +26,12 @@ from airas.infra.seyval_client import SeyvalClient, default_seyval_client
 from airas.usecases.publication.map_record_to_publication import (
     CHART_DIR,
     CHART_SUFFIXES,
+    CLAIMS_TEX_FILENAME,
     TABLES_DIR_NAME,
     VALUES_TEX_FILENAME,
     record_link_commit,
     render_chart_bytes,
+    render_claims_tex,
     render_table_tex,
     render_values_tex,
     renderer_version,
@@ -335,6 +337,21 @@ def scan_main_tex(main_tex: str) -> tuple[list[str], list[str]]:
     return unverified, used_keys
 
 
+def _verify_claims(
+    latex_dir: Path, record: ResearchRecord, metrics_data: dict[str, Any]
+) -> list[str]:
+    # The list in the PDF is the record's, at the prereg stage (pending) as
+    # after results.
+    claims_path = latex_dir / CLAIMS_TEX_FILENAME
+    if not claims_path.is_file():
+        return [f"{CLAIMS_TEX_FILENAME} is missing (preregister_record writes it)"]
+    if claims_path.read_text(encoding="utf-8") != render_claims_tex(
+        record, metrics_data
+    ):
+        return [f"{CLAIMS_TEX_FILENAME} differs from its regeneration (manual edit?)"]
+    return []
+
+
 def _verify_tables(
     latex_dir: Path, specs: list[TableSpec], metrics_data: dict[str, Any]
 ) -> list[str]:
@@ -520,6 +537,11 @@ def _verify_mapping(
     except (ValidationError, ValueError):
         # The record's own verification already reports this.
         return problems, unverified
+    try:
+        metrics_data = load_metrics_data(str(root))
+    except ValueError:
+        metrics_data = {}
+    problems += _verify_claims(latex_dir, record, metrics_data)
     if record_result.stage == "prereg":
         # A values.tex carried over without runs would put unverifiable
         # numbers in the PDF.
@@ -529,10 +551,6 @@ def _verify_mapping(
             problems.append(f"{TABLES_DIR_NAME}/ exists but no run outputs exist")
         return problems, unverified
 
-    try:
-        metrics_data = load_metrics_data(str(root))
-    except ValueError:
-        metrics_data = {}
     paper_values, undefined_keys = resolve_paper_values(record, metrics_data, used_keys)
     if undefined_keys:
         problems.append(

--- a/backend/src/airas/usecases/recording/update_or_load_record.py
+++ b/backend/src/airas/usecases/recording/update_or_load_record.py
@@ -67,15 +67,11 @@ def save_record(local_repo_path: str, record: ResearchRecord) -> Path:
 
 
 class _ClaimStatus(BaseModel):
-    """A claim's state as recomputed from the run outputs on disk."""
-
     id: str
     # Every run under the claim has its verifier's report in the results
     # directory: the data the claim rests on is in. Whether the claim was
     # declared before those runs executed is not modelled yet (TODO).
     verified: bool
-    # What the verifier concluded once verified; unset for seyval, whose
-    # claim condition is not modelled yet.
     verdict: Verdict | None = None
 
 
@@ -117,7 +113,9 @@ def compute_claim_statuses(
     for _, claim in record.active_claims():
         runs = [run for _, run in claim.runs()]
         verified = bool(runs) and all(run.run_id in present_run_ids for run in runs)
-        results = [r for r in (run.latest_result() for run in runs) if r is not None]
+        results = {
+            run.run_id: r for run in runs if (r := run.latest_result()) is not None
+        }
         statuses.append(
             _ClaimStatus(
                 id=claim.id,
@@ -277,18 +275,29 @@ def _read_json(path: Path) -> Any:
 _SORRY_AXIOM = "sorryAx"
 
 
-def _claim_verdict(claim: ClaimDeclaration, results: list[RunResult]) -> Verdict | None:
-    if any(r.errors for r in results if not isinstance(r, SeyvalResult)):
+def _claim_verdict(
+    claim: ClaimDeclaration, results: dict[str, RunResult]
+) -> Verdict | None:
+    if any(r.errors for r in results.values() if not isinstance(r, SeyvalResult)):
         return "inconclusive"
     if isinstance(claim, LeanClaim):
         # Lean cannot refute: a proof that did not go through shows nothing.
         return "supported"
     if isinstance(claim, LlmJudgeClaim):
-        verdicts = {r.verdict for r in results if isinstance(r, LlmJudgeResult)}
+        verdicts = {
+            r.verdict for r in results.values() if isinstance(r, LlmJudgeResult)
+        }
         if verdicts == {"supported"}:
             return "supported"
         return "refuted" if "refuted" in verdicts else "inconclusive"
-    return None  # seyval's claim condition is not modelled yet
+    metrics = {
+        rid: r.metrics for rid, r in results.items() if isinstance(r, SeyvalResult)
+    }
+    try:
+        difference = claim.criterion.observed(metrics)
+    except (KeyError, ValueError):
+        return "inconclusive"  # the criterion names a value the run did not produce
+    return "supported" if claim.criterion.holds(difference) else "refuted"
 
 
 def _lean_errors(claim: LeanClaim, run: LeanRun, payload: dict[str, Any]) -> list[str]:

--- a/backend/src/airas/usecases/recording/verify_record.py
+++ b/backend/src/airas/usecases/recording/verify_record.py
@@ -115,6 +115,20 @@ def _verify_consistency(record: ResearchRecord) -> list[str]:
         if not claim.runs()
     ]
 
+    for _, claim in record.active_claims():
+        if not isinstance(claim, SeyvalClaim):
+            continue
+        own = {run.run_id for _, run in claim.runs()}
+        named = [claim.criterion.subject]
+        if isinstance(claim.criterion.reference, str):
+            named.append(claim.criterion.reference)
+        problems += [
+            f"claim {claim.id}: criterion names run '{rid}', which this claim "
+            "does not declare"
+            for rid in named
+            if rid not in own
+        ]
+
     declared = set(record.run_index())
     problems += [
         f"table {spec.key}: row references run '{row.run_id}', which no design declares"
@@ -256,7 +270,7 @@ async def _verify_additions(
         drifted = _verified_problems(record, compute_claim_statuses(record, present))
         if drifted:
             problems.append(
-                "claims stored as verified that the recomputation finds otherwise "
+                "claims stored as verified, or with a verdict, that the recomputation finds otherwise "
                 f"({', '.join(drifted)})"
             )
         return problems

--- a/backend/tests/unit/usecases/publication/test_claims_tex.py
+++ b/backend/tests/unit/usecases/publication/test_claims_tex.py
@@ -1,0 +1,84 @@
+"""claims.tex: the paper's claim list is rendered from the record.
+
+Deterministic from (record, metrics) alone, so the freeze commit carries it
+with every outcome pending, and the same function regenerates it once the
+runs are in.
+"""
+
+from airas.core.types.research_record import (
+    Criterion,
+    Hypothesis,
+    Prediction,
+    ResearchRecord,
+    SeyvalClaim,
+    SeyvalDesign,
+    SeyvalRun,
+    SeyvalVerifier,
+    VerifierKind,
+)
+from airas.usecases.publication.map_record_to_publication import render_claims_tex
+
+SEYVAL = SeyvalVerifier(kind=VerifierKind.SEYVAL)
+
+
+def _record(verdict: str | None = None) -> ResearchRecord:
+    return ResearchRecord(
+        hypotheses=[
+            Hypothesis(
+                id="h1",
+                statement="Method X improves accuracy.",
+                assumptions=["Accuracy on this dataset stands for the property (c1)."],
+                claims=[
+                    SeyvalClaim(
+                        verifier=SEYVAL,
+                        id="c1",
+                        statement="X beats the baseline.",
+                        rationale="Head-to-head on the hypothesis's own metric.",
+                        verdict=verdict,
+                        criterion=Criterion(
+                            metric="accuracy",
+                            subject="run_2",
+                            reference="run_1",
+                            op=">=",
+                            margin=0.02,
+                        ),
+                        prediction=Prediction(low=0.02, high=0.04, basis="pilot"),
+                        designs=[
+                            SeyvalDesign(
+                                id="d1",
+                                runs=[
+                                    SeyvalRun(run_id="run_1"),
+                                    SeyvalRun(run_id="run_2"),
+                                ],
+                            )
+                        ],
+                    )
+                ],
+            )
+        ]
+    )
+
+
+def test_pending_before_any_run() -> None:
+    tex = render_claims_tex(_record(), {})
+    assert r"\textbf{H1.} Method X improves accuracy." in tex
+    assert r"\item[\textbf{C1}] X beats the baseline." in tex
+    assert r"\emph{Rationale:} Head-to-head on the hypothesis's own metric." in tex
+    assert r"\item Accuracy on this dataset stands for the property (c1)." in tex
+    assert r"\texttt{\detokenize{run_2}}.\texttt{\detokenize{accuracy}} $-$" in tex
+    assert r"$\geq 0.02$" in tex
+    assert r"\emph{Prediction:} $[0.02, 0.04]$ (pilot)." in tex
+    assert r"\emph{Observed:} pending." in tex
+    assert r"\emph{Verdict:} pending." in tex
+
+
+def test_observed_and_verdict_once_the_runs_are_in() -> None:
+    metrics = {"run_1": {"accuracy": 0.871}, "run_2": {"accuracy": 0.902}}
+    tex = render_claims_tex(_record("supported"), metrics)
+    assert r"\emph{Observed:} 0.031." in tex
+    assert r"\emph{Verdict:} supported." in tex
+
+
+def test_an_unresolvable_metric_stays_pending() -> None:
+    tex = render_claims_tex(_record(), {"run_1": {"f1": 0.5}, "run_2": {"f1": 0.6}})
+    assert r"\emph{Observed:} pending." in tex

--- a/backend/tests/unit/usecases/publication/test_map_record_to_publication.py
+++ b/backend/tests/unit/usecases/publication/test_map_record_to_publication.py
@@ -18,7 +18,9 @@ from airas.core.types.map_record_to_publication import (
     TableSpec,
 )
 from airas.core.types.research_record import (
+    Criterion,
     Hypothesis,
+    Prediction,
     ResearchRecord,
     SeyvalClaim,
     SeyvalDesign,
@@ -33,6 +35,7 @@ from airas.core.types.run_provenance import (
 )
 from airas.usecases.publication.map_record_to_publication import (
     record_blob_url,
+    render_claims_tex,
     render_values_tex,
     resolve_paper_ref,
     resolve_paper_values,
@@ -76,6 +79,15 @@ def _record() -> ResearchRecord:
                         verifier=SEYVAL,
                         id="c1",
                         statement="X beats the baseline.",
+                        rationale="Head-to-head on the hypothesis's own metric.",
+                        criterion=Criterion(
+                            metric="accuracy",
+                            subject="run-2",
+                            reference="run-1",
+                            op=">=",
+                            margin=0.02,
+                        ),
+                        prediction=Prediction(low=0.02, high=0.04, basis="pilot"),
                         designs=[
                             SeyvalDesign(
                                 id="d1",
@@ -159,6 +171,7 @@ def _generate(tmp_path: Path, mode: str = "full") -> Path:
     used_keys = scan_main_tex(MAIN_TEX)[1]
     values, _ = resolve_paper_values(record, metrics_data, used_keys)
     (latex_dir / "values.tex").write_text(render_values_tex(values, None))
+    (latex_dir / "claims.tex").write_text(render_claims_tex(record, metrics_data))
     from airas.usecases.publication.map_record_to_publication import render_table_tex
 
     tables_dir = latex_dir / "tables"

--- a/backend/tests/unit/usecases/publication/test_paper_tables_charts.py
+++ b/backend/tests/unit/usecases/publication/test_paper_tables_charts.py
@@ -18,7 +18,9 @@ from airas.core.types.map_record_to_publication import (
 )
 from airas.core.types.research_record import (
     ChartDeclaration,
+    Criterion,
     Hypothesis,
+    Prediction,
     RenderedChart,
     ResearchRecord,
     SeyvalClaim,
@@ -175,6 +177,14 @@ def _chart_record(*charts: ChartDeclaration) -> ResearchRecord:
                         verifier=SEYVAL,
                         id="c1",
                         statement="c",
+                        rationale="Head-to-head on the hypothesis's own metric.",
+                        criterion=Criterion(
+                            metric="accuracy",
+                            subject="run_2",
+                            reference="run_1",
+                            op=">=",
+                        ),
+                        prediction=Prediction(low=0.01, high=0.05, basis="pilot"),
                         designs=[
                             SeyvalDesign(
                                 id="d1",

--- a/backend/tests/unit/usecases/recording/test_claim_criterion.py
+++ b/backend/tests/unit/usecases/recording/test_claim_criterion.py
@@ -1,0 +1,149 @@
+"""A seyval claim's criterion: frozen at declaration, judged from the metrics.
+
+The verdict is a pure function of the declared criterion and the runs'
+metrics.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from airas.core.types.research_record import (
+    Criterion,
+    Hypothesis,
+    Prediction,
+    ResearchRecord,
+    SeyvalClaim,
+    SeyvalDesign,
+    SeyvalResult,
+    SeyvalRun,
+    SeyvalVerifier,
+    VerifierKind,
+)
+from airas.usecases.recording.update_or_load_record import compute_claim_statuses
+from airas.usecases.recording.verify_record import (
+    _containment_violations,
+    _verify_consistency,
+)
+
+SEYVAL = SeyvalVerifier(kind=VerifierKind.SEYVAL)
+PREDICTION = Prediction(low=0.02, high=0.04, basis="pilot")
+
+
+def _criterion(**kw: object) -> Criterion:
+    base = dict(metric="accuracy", subject="proposed", reference="baseline", op=">=")
+    return Criterion(**{**base, **kw})
+
+
+def _record(
+    criterion: Criterion,
+    proposed: dict[str, object],
+    baseline: dict[str, object] | None = None,
+) -> ResearchRecord:
+    def run(run_id: str, metrics: dict[str, object] | None) -> SeyvalRun:
+        results = [SeyvalResult(id=run_id, metrics=metrics)] if metrics else []
+        return SeyvalRun(run_id=run_id, results=results)
+
+    return ResearchRecord(
+        hypotheses=[
+            Hypothesis(
+                id="h1",
+                statement="Proposed beats baseline.",
+                claims=[
+                    SeyvalClaim(
+                        verifier=SEYVAL,
+                        id="c1",
+                        statement="Proposed beats baseline on accuracy.",
+                        rationale="Head-to-head on the hypothesis's own metric.",
+                        criterion=criterion,
+                        prediction=PREDICTION,
+                        designs=[
+                            SeyvalDesign(
+                                id="d1",
+                                runs=[
+                                    run("proposed", proposed),
+                                    run("baseline", baseline),
+                                ],
+                            )
+                        ],
+                    )
+                ],
+            )
+        ]
+    )
+
+
+def _verdict(record: ResearchRecord) -> str | None:
+    return compute_claim_statuses(record, {"proposed", "baseline"})[0].verdict
+
+
+# ------------------------------------------------------------------ verdict
+
+
+@pytest.mark.parametrize(
+    ("criterion", "proposed", "baseline", "verdict"),
+    [
+        (
+            _criterion(margin=0.02),
+            {"accuracy": 0.902},
+            {"accuracy": 0.871},
+            "supported",
+        ),
+        (_criterion(margin=0.05), {"accuracy": 0.902}, {"accuracy": 0.871}, "refuted"),
+        # exactly at the margin counts as met, float error notwithstanding
+        (_criterion(margin=0.03), {"accuracy": 0.93}, {"accuracy": 0.90}, "supported"),
+        (
+            _criterion(op=">", margin=0.03),
+            {"accuracy": 0.93},
+            {"accuracy": 0.90},
+            "refuted",
+        ),
+        (
+            _criterion(reference=0.9),
+            {"accuracy": 0.902},
+            {"accuracy": 0.5},
+            "supported",
+        ),
+        # a loss: lower by at least 0.1
+        (
+            _criterion(metric="loss.final", op="<=", margin=-0.1),
+            {"loss": {"final": 0.2}},
+            {"loss": {"final": 0.35}},
+            "supported",
+        ),
+        (_criterion(), {"f1": 0.9}, {"accuracy": 0.871}, "inconclusive"),
+        (_criterion(), {"accuracy": "n/a"}, {"accuracy": 0.871}, "inconclusive"),
+    ],
+)
+def test_the_verdict_follows_the_criterion(criterion, proposed, baseline, verdict):
+    assert _verdict(_record(criterion, proposed, baseline)) == verdict
+
+
+def test_no_verdict_until_every_run_has_a_result() -> None:
+    assert _verdict(_record(_criterion(), {"accuracy": 0.9}, None)) is None
+
+
+# -------------------------------------------------------------- declaration
+
+
+def test_a_criterion_must_be_a_range_apart_from_itself() -> None:
+    with pytest.raises(ValidationError, match="to itself"):
+        _criterion(reference="proposed")
+    with pytest.raises(ValidationError, match="low < high"):
+        Prediction(low=0.03, high=0.03, basis="pilot")
+
+
+def test_a_criterion_may_only_name_the_claims_own_runs() -> None:
+    record = _record(_criterion(reference="ghost"), {})
+    assert any("'ghost'" in p for p in _verify_consistency(record))
+    assert _verify_consistency(_record(_criterion(), {})) == []
+
+
+# -------------------------------------------------------------- containment
+
+
+def test_the_criterion_is_frozen_with_the_claim() -> None:
+    older, newer = _record(_criterion(), {}), _record(_criterion(margin=0.01), {})
+    assert any(
+        "criterion" in p
+        for p in _containment_violations(older.model_dump(), newer.model_dump())
+    )

--- a/backend/tests/unit/usecases/recording/test_containment.py
+++ b/backend/tests/unit/usecases/recording/test_containment.py
@@ -18,7 +18,9 @@ from airas.core.types.map_record_to_publication import (
 )
 from airas.core.types.research_record import (
     ClaimDeclaration,
+    Criterion,
     Hypothesis,
+    Prediction,
     ResearchRecord,
     SeyvalClaim,
     SeyvalDesign,
@@ -51,6 +53,15 @@ def _record() -> ResearchRecord:
                         verifier=SEYVAL,
                         id="c1",
                         statement="Proposed beats baseline on accuracy.",
+                        rationale="Head-to-head on the hypothesis's own metric.",
+                        criterion=Criterion(
+                            metric="accuracy",
+                            subject="proposed",
+                            reference="baseline",
+                            op=">=",
+                            margin=0.02,
+                        ),
+                        prediction=Prediction(low=0.02, high=0.04, basis="pilot"),
                         designs=[
                             SeyvalDesign(
                                 id="d1",
@@ -75,6 +86,9 @@ def _claim(claim_id: str = "c2", run_id: str = "ablation") -> ClaimDeclaration:
         verifier=SEYVAL,
         id=claim_id,
         statement="The ablation holds.",
+        rationale="Head-to-head on the hypothesis's own metric.",
+        criterion=Criterion(metric="accuracy", subject=run_id, reference=0.5, op=">="),
+        prediction=Prediction(low=0.1, high=0.3, basis="pilot"),
         designs=[SeyvalDesign(id="d1", runs=[SeyvalRun(run_id=run_id)])],
     )
 
@@ -198,7 +212,14 @@ def test_a_claim_with_no_run_is_caught() -> None:
     """A claim with no experiment cannot be verified."""
     record = _record()
     record.hypotheses[0].claims.append(
-        SeyvalClaim(verifier=SEYVAL, id="c2", statement="Untestable as declared.")
+        SeyvalClaim(
+            verifier=SEYVAL,
+            id="c2",
+            statement="Untestable as declared.",
+            rationale="Head-to-head on the hypothesis's own metric.",
+            criterion=Criterion(metric="accuracy", subject="x", reference=0.5, op=">="),
+            prediction=Prediction(low=0.1, high=0.3, basis="pilot"),
+        )
     )
     assert any("declares no run" in p for p in _verify_consistency(record))
 
@@ -223,7 +244,14 @@ def test_a_clean_record_has_no_problems() -> None:
 @pytest.mark.parametrize("bad_id", ["claim1", "C1", "c0"])
 def test_ids_follow_their_pattern(bad_id: str) -> None:
     with pytest.raises(ValueError):
-        SeyvalClaim(verifier=SEYVAL, id=bad_id, statement="x")
+        SeyvalClaim(
+            verifier=SEYVAL,
+            id=bad_id,
+            statement="x",
+            rationale="Head-to-head on the hypothesis's own metric.",
+            criterion=Criterion(metric="accuracy", subject="x", reference=0.5, op=">="),
+            prediction=Prediction(low=0.1, high=0.3, basis="pilot"),
+        )
 
 
 def test_active_keeps_order_and_takes_the_last_entry_per_id() -> None:

--- a/backend/tests/unit/usecases/recording/test_containment_history.py
+++ b/backend/tests/unit/usecases/recording/test_containment_history.py
@@ -14,7 +14,9 @@ from pathlib import Path
 from airas.core.research_paths import RECORD_PATH
 from airas.core.types.research_record import (
     ClaimDeclaration,
+    Criterion,
     Hypothesis,
+    Prediction,
     ResearchRecord,
     SeyvalClaim,
     SeyvalDesign,
@@ -62,6 +64,9 @@ def _claim(claim_id: str = "c1", run_id: str = "proposed") -> ClaimDeclaration:
         verifier=SEYVAL,
         id=claim_id,
         statement="Proposed beats baseline.",
+        rationale="Head-to-head on the hypothesis's own metric.",
+        criterion=Criterion(metric="accuracy", subject=run_id, reference=0.5, op=">="),
+        prediction=Prediction(low=0.1, high=0.3, basis="pilot"),
         designs=[SeyvalDesign(id="d1", runs=[SeyvalRun(run_id=run_id)])],
     )
 

--- a/backend/tests/unit/usecases/recording/test_verifiers.py
+++ b/backend/tests/unit/usecases/recording/test_verifiers.py
@@ -81,6 +81,7 @@ def _lean_claim() -> LeanClaim:
         {
             "id": "c1",
             "statement": "Zero is a right identity.",
+            "rationale": "The identity is the hypothesis's first case.",
             "verifier": {"kind": "lean", "toolchain": "leanprover/lean4:v4.12.0"},
             "designs": [
                 {
@@ -106,6 +107,7 @@ def _judge_claim() -> LlmJudgeClaim:
         {
             "id": "c1",
             "statement": "Participants preferred the new interface.",
+            "rationale": "Preference is the property the hypothesis is about.",
             "verifier": {
                 "kind": "llm_judge",
                 "model": "openai/gpt-x-20260101",

--- a/backend/tests/unit/usecases/recording/test_verify_record.py
+++ b/backend/tests/unit/usecases/recording/test_verify_record.py
@@ -19,7 +19,9 @@ from typing import Any
 from airas.core.research_paths import RECORD_PATH
 from airas.core.types.research_record import (
     ClaimDeclaration,
+    Criterion,
     Hypothesis,
+    Prediction,
     ResearchRecord,
     SeyvalClaim,
     SeyvalDesign,
@@ -34,6 +36,7 @@ from airas.core.types.run_provenance import (
     RunProvenanceManifest,
 )
 from airas.usecases.publication.map_record_to_publication import (
+    render_claims_tex,
     render_values_tex,
     resolve_paper_values,
 )
@@ -88,6 +91,15 @@ def _record() -> ResearchRecord:
                         verifier=SEYVAL,
                         id="c1",
                         statement="Proposed beats baseline on accuracy.",
+                        rationale="Head-to-head on the hypothesis's own metric.",
+                        criterion=Criterion(
+                            metric="accuracy",
+                            subject="proposed",
+                            reference="baseline",
+                            op=">=",
+                            margin=0.02,
+                        ),
+                        prediction=Prediction(low=0.02, high=0.04, basis="pilot"),
                         designs=[
                             SeyvalDesign(
                                 id="d1",
@@ -229,6 +241,11 @@ def test_a_claim_declared_after_its_run_is_allowed_for_now(tmp_path: Path) -> No
             verifier=SEYVAL,
             id="c2",
             statement="Post-hoc.",
+            rationale="Head-to-head on the hypothesis's own metric.",
+            criterion=Criterion(
+                metric="accuracy", subject="late", reference=0.5, op=">="
+            ),
+            prediction=Prediction(low=0.1, high=0.3, basis="pilot"),
             designs=[SeyvalDesign(id="d1", runs=[SeyvalRun(run_id="late")])],
         )
     )
@@ -487,6 +504,9 @@ def _write_paper(repo: Path) -> Path:
         record, load_metrics_data(str(repo)), scan_main_tex(MAIN_TEX)[1]
     )
     (latex_dir / "values.tex").write_text(render_values_tex(values, None))
+    (latex_dir / "claims.tex").write_text(
+        render_claims_tex(record, load_metrics_data(str(repo)))
+    )
     return latex_dir
 
 
@@ -540,3 +560,75 @@ def test_an_undeclared_airasval_key_fails(tmp_path: Path) -> None:
     result = _verify_paper(str(repo))
     assert not result.ok
     assert any("ghost.accuracy" in p for p in result.problems)
+
+
+# ------------------------------------------------- the claim's criterion
+
+
+def test_the_criterion_decides_the_verdict(tmp_path: Path) -> None:
+    repo = _realized_repo(tmp_path)
+    claim = _c1(load_record(str(repo)))
+    assert claim.verified and claim.verdict == "supported"  # 0.902 - 0.871 >= 0.02
+    assert _verify(str(repo)).ok
+
+
+def test_a_rerun_that_flips_the_outcome_is_drift_not_a_new_verdict(
+    tmp_path: Path,
+) -> None:
+    repo = _realized_repo(tmp_path)
+    record = load_record(str(repo))
+    (repo / ".research" / "results" / "proposed" / "metrics.json").write_text(
+        json.dumps({"accuracy": 0.875})
+    )
+    manifest = RunProvenanceManifest(
+        dirs={
+            "proposed": ResultsDirProvenance(
+                execution_id="run-a2", commit_hash=_git(repo, "rev-parse", "HEAD")
+            ),
+            "baseline": ResultsDirProvenance(execution_id="run-b"),
+        }
+    )
+    (repo / PROVENANCE_MANIFEST_PATH).write_text(manifest.model_dump_json())
+    statuses, _ = update_record_with_results(
+        repo, record, load_metrics_data(str(repo)), manifest
+    )
+    assert statuses[0].verdict == "refuted"
+    assert _c1(record).verdict == "supported"  # written once, never back
+    save_record(str(repo), record)
+    _commit(repo, "re-run")
+
+    result = _verify(str(repo))
+    assert not result.ok
+    assert any("with a verdict" in p for p in result.problems)
+
+
+def test_a_paper_may_list_its_claims_before_any_run(tmp_path: Path) -> None:
+    _init(tmp_path)
+    record = _record()
+    save_record(str(tmp_path), record)
+    latex_dir = tmp_path / ".research" / "latex" / "mdpi"
+    latex_dir.mkdir(parents=True)
+    (latex_dir / "main.tex").write_text(
+        MAIN_TEX.replace(r"\input{values.tex}", r"\input{claims.tex}")
+    )
+    (latex_dir / "claims.tex").write_text(render_claims_tex(record, {}))
+    _commit(tmp_path, "prereg")
+
+    result = _verify_paper(str(tmp_path))
+    assert result.ok, result.record.problems + result.problems
+    assert result.record.stage == "prereg"
+    assert "pending" in (latex_dir / "claims.tex").read_text()
+
+
+def test_a_missing_or_hand_edited_claims_tex_is_caught(tmp_path: Path) -> None:
+    repo = _realized_repo(tmp_path)
+    latex_dir = _write_paper(repo)
+    _commit(repo, "paper")
+    claims_tex = latex_dir / "claims.tex"
+    claims_tex.write_text(claims_tex.read_text().replace("supported", "refuted"))
+    result = _verify_paper(str(repo))
+    assert any("claims.tex differs" in p for p in result.problems)
+
+    claims_tex.unlink()
+    result = _verify_paper(str(repo))
+    assert any("claims.tex is missing" in p for p in result.problems)

--- a/docs/record-json-schema.md
+++ b/docs/record-json-schema.md
@@ -1,0 +1,256 @@
+# record.json の構造
+
+`.research/record.json` は「この仮説を支えるにはこれらの claims、この claim を検証するにはこれらの designs、design はこれらの runs」という木。エージェントが書くのは宣言（declaration）だけで、`verified` / `verdict` / `results[]` は機械が導出する。record は append-only で、宣言の書き換えは同 id の再 append として履歴に残る。
+
+## クラス図
+
+```mermaid
+classDiagram
+    direction LR
+
+    class ResearchRecord {
+        hypotheses: Hypothesis[]  仮説の一覧
+    }
+
+    class Hypothesis {
+        id: "h1"...
+        statement: str  仮説そのもの（散文）
+        assumptions: str[]  c1∧…∧cn ⇒ H を成り立たせる公理。全 claim 支持後も残る未検証
+        claims: ClaimDeclaration[]  verifier.kind で型が決まる
+        tables: TableSpec[]  論文の表の宣言
+        charts: ChartDeclaration[]  図の宣言
+        notes: str[]  自由記述
+    }
+
+    class ClaimBase {
+        id: "c1"...
+        statement: str  一文の主張。verdict が付く対象
+        rationale: str  この claim が H の証拠になる理由と、支える部分
+        verifier: Verifier  何が検証するか。claim に一つ
+        designs: Design[]  検証の構成。要素型は kind で決まる
+        verified: bool  全 run にレポートがあるか。false→true のみ
+        verdict: supported|refuted|inconclusive  一度だけ設定。反転は drift
+    }
+
+    class SeyvalClaim {
+        verifier: kind = seyval
+        criterion: Criterion  反証線。宣言時必須、凍結
+        prediction: Prediction  予測区間。宣言時必須、凍結
+        verdict  criterion を metrics に適用して導出
+    }
+    class LeanClaim {
+        verifier: kind = lean, toolchain, mathlib_rev, allowed_axioms
+        verdict  supported か inconclusive。反証しない
+    }
+    class LlmJudgeClaim {
+        verifier: kind = llm_judge, model, rubric, temperature, samples
+        verdict  全票一致で supported
+    }
+
+    class Criterion {
+        metric: str  metrics.json 内のパス
+        subject: run_id  判定対象
+        reference: run_id|float  比較対象（同じ metric）または定数
+        op: geq / leq / gt / lt
+        margin: float  既定 0。「subject − reference」op margin
+    }
+    class Prediction {
+        low: float  low < high。点は不可
+        high: float
+        basis: str  根拠。prior work や pilot
+    }
+
+
+    class SeyvalDesign {
+        id: "d1"...
+        summary: str
+        runs: SeyvalRun[]
+    }
+    class SeyvalRun {
+        run_id: str  .research/results/run_id/ を生む
+        description: str
+        params: dict  dispatch 条件。例 mode = full。基盤の記録と照合
+        results: SeyvalResult[]  機械が追記
+    }
+    class LeanDesign {
+        id: "d1"...
+        summary: str
+        runs: LeanRun[]
+    }
+    class LeanRun {
+        run_id: str  1 run = 1 宣言
+        description: str
+        params: LeanParams  module, decl, statement
+        results: LeanResult[]  lean.json から
+    }
+    class LlmJudgeDesign {
+        id: "d1"...
+        summary: str
+        runs: LlmJudgeRun[]
+    }
+    class LlmJudgeRun {
+        run_id: str  1 run = 1 判定
+        description: str
+        params: LlmJudgeParams  evidence[] リポジトリ内パス
+        results: LlmJudgeResult[]  judgment.json から
+    }
+
+    class SeyvalResult {
+        id: str  Seyval の実行 id
+        commit: str  実行したコミット
+        metrics: any  metrics.json そのまま
+        eval_inputs: InputRef  airas-eval への入力と sha256
+        eval_report: EvalReport  airas-eval の評価レポート
+    }
+    class LeanResult {
+        commit: str
+        statement: str  実際にビルドされた宣言の型
+        axioms: str[]  print axioms の結果
+        errors: str[]  ビルド失敗 / sorry / 不一致 / 許可外公理
+        warnings: str[]
+    }
+    class LlmJudgeResult {
+        id: str  provider 側の応答 id
+        commit: str
+        inputs_sha256: str  rubric+evidence+statement+model の hash
+        verdict: Verdict
+        errors: str[]
+        warnings: str[]
+    }
+
+    ResearchRecord "1" --> "*" Hypothesis
+    Hypothesis "1" --> "*" ClaimBase : claims
+    ClaimBase <|-- SeyvalClaim
+    ClaimBase <|-- LeanClaim
+    ClaimBase <|-- LlmJudgeClaim
+    SeyvalClaim --> Criterion
+    SeyvalClaim --> Prediction
+    SeyvalClaim "1" --> "*" SeyvalDesign : designs
+    SeyvalDesign "1" --> "*" SeyvalRun : runs
+    SeyvalRun "1" --> "*" SeyvalResult : results
+    LeanClaim "1" --> "*" LeanDesign : designs
+    LeanDesign "1" --> "*" LeanRun : runs
+    LeanRun "1" --> "*" LeanResult : results
+    LlmJudgeClaim "1" --> "*" LlmJudgeDesign : designs
+    LlmJudgeDesign "1" --> "*" LlmJudgeRun : runs
+    LlmJudgeRun "1" --> "*" LlmJudgeResult : results
+```
+
+## 論理構造
+
+- claims は集合として仮説を含意する: `c1 ∧ c2 ∧ … ∧ cn ⇒ H`
+- `claims[].rationale`: この claim がその集合の元である理由（H のどの部分を、なぜ支えるか）
+- `hypotheses[].assumptions`: 含意が成り立つために認める必要のある公理。全 claim が支持されても未検証として残るのはちょうどこれ
+- `claims[].verdict`: `c_i` を仮定として置いてよいか
+
+## 木構造
+
+- **hypotheses[]** 仮説の一覧
+  - `id` `"h1"`, `"h2"`, …
+  - `statement` 仮説そのもの（散文）
+  - `assumptions[]` `c1 ∧ … ∧ cn ⇒ H` を成り立たせる公理。各項目に関わる claim id を書く。既定は空
+  - **claims[]** 仮説を検証可能な主張に分解したもの。`verifier.kind` で型が決まる
+    - 共通（ClaimBase）
+      - `id` `"c1"`, `"c2"`, …
+      - `statement` 一文の主張。verdict が付く対象
+      - `rationale` この claim が成り立つと、なぜ・仮説のどの部分が支えられるか。必須
+      - `verifier` 何が検証するか。必須。一つの claim に一つ（証明と実験の両方が要るなら claim を二つに分ける）
+      - `designs[]` 実験・証明・判定の構成
+      - `verified` 配下の全 run に verifier のレポートがあるか。false → true のみ
+      - `verdict` `"supported"` / `"refuted"` / `"inconclusive"`。未設定 → 設定の一回限り。再実行で反転した場合は gate が drift として報告
+    - **[kind = seyval]** 実験
+      - `verifier` `{kind: "seyval"}`
+      - `criterion` 反証線。宣言時必須、凍結
+        - `metric` metrics.json 内のパス（例 `"accuracy"`, `"loss.final"`）
+        - `subject` 判定対象の run_id
+        - `reference` 比較対象の run_id（同じ metric）または定数
+        - `op` `">="` / `"<="` / `">"` / `"<"`
+        - `margin` 既定 0.0。意味は `(subject.metric − reference) op margin`。境界は一致扱い
+      - `prediction` 予測区間。宣言時必須、凍結
+        - `low` / `high` `low < high`（点は不可）
+        - `basis` 根拠（prior work, pilot など）
+      - `verdict` verified 時に criterion を runs の metrics に適用して導出。metric が解決できなければ `inconclusive`
+      - **designs[]**
+        - `id` / `summary`
+        - **runs[]** 実行単位。`.research/results/<run_id>/` を生む
+          - `run_id` / `description`
+          - `params` dispatch 条件（自由 dict、例 `{"mode": "full"}`）。基盤の記録と照合される
+          - **results[]** metrics.json と provenance manifest から機械が追記
+            - `id` Seyval の実行 id
+            - `commit` 実行したコミット
+            - `metrics` metrics.json そのまま
+            - `eval_inputs` `{path, sha256}` airas-eval への入力
+            - `eval_report` airas-eval の評価レポート（task_type, metrics, versions, skipped …）
+    - **[kind = lean]** 証明
+      - `verifier` `{kind: "lean", toolchain, mathlib_rev, allowed_axioms[]}`
+      - `verdict` `"supported"` / `"inconclusive"`。Lean は反証しない
+      - **designs[]**
+        - `id` / `summary`
+        - **runs[]** 1 run = 1 宣言
+          - `run_id` / `description`
+          - `params` `{module, decl, statement}`。statement は `#check @decl` が出す型
+          - **results[]** lean.json から
+            - `commit`
+            - `statement` 実際にビルドされた宣言の型
+            - `axioms[]` `#print axioms` の結果
+            - `errors[]` ビルド失敗 / sorry / statement 不一致 / 許可外公理
+            - `warnings[]`
+    - **[kind = llm_judge]** 判定
+      - `verifier` `{kind: "llm_judge", model, rubric, temperature, samples}`
+      - `verdict` `"supported"` / `"refuted"` / `"inconclusive"`。全票一致で supported
+      - **designs[]**
+        - `id` / `summary`
+        - **runs[]** 1 run = 1 判定
+          - `run_id` / `description`
+          - `params` `{evidence[]}` リポジトリ内パス
+          - **results[]** judgment.json から
+            - `id` provider 側の応答 id
+            - `commit`
+            - `inputs_sha256` rubric + evidence + statement + model の hash
+            - `verdict`
+            - `errors[]` / `warnings[]`
+  - **tables[]** 論文の表の宣言（`tables/<key>.tex` に描画）
+  - **charts[]** 図の宣言（Vega-Lite spec、`metric:` 参照のみ）
+  - `notes[]` 自由記述
+
+## 論文への描画
+
+| 生成物 | 元 | 段階 |
+| --- | --- | --- |
+| `claims.tex` | claims の statement / rationale / criterion / prediction / observed / verdict と hypothesis の assumptions | prereg から（未着は pending） |
+| `values.tex` | `\airasval{<run_id>.<metric>}` の値 | results 以降 |
+| `tables/<key>.tex` | tables[] | results 以降 |
+
+いずれも gate が record から再生成して byte 比較するため、手編集は検出される。
+
+## 例（seyval）
+
+```json
+{
+  "hypotheses": [{
+    "id": "h1",
+    "statement": "提案する正則化項は画像分類 CNN の汎化性能を改善する。",
+    "assumptions": [
+      "test accuracy の差が汎化性能の差を表す (c1, c2)",
+      "CIFAR-10 と CIFAR-100 で成り立てば画像分類 CNN 一般で成り立つ (c1, c2)",
+      "ResNet-18 が CNN の代表として十分 (c1, c2)"
+    ],
+    "claims": [{
+      "id": "c1",
+      "statement": "CIFAR-10 で提案手法の test accuracy が ResNet-18 を 1.0 pt 以上上回る。",
+      "rationale": "汎化性能の代理指標として test accuracy を、代表的 CNN として ResNet-18 を用いた直接比較。",
+      "verifier": {"kind": "seyval"},
+      "criterion": {"metric": "accuracy", "subject": "proposed-resnet18-cifar10",
+                    "reference": "comparative-1-resnet18-cifar10", "op": ">=", "margin": 0.01},
+      "prediction": {"low": 0.02, "high": 0.04, "basis": "pilot run on 10% of the data"},
+      "designs": [{
+        "id": "d1", "summary": "同一データ・同一予算での直接比較",
+        "runs": [
+          {"run_id": "proposed-resnet18-cifar10", "params": {"mode": "full"}},
+          {"run_id": "comparative-1-resnet18-cifar10", "params": {"mode": "full"}}
+        ]
+      }]
+    }]
+  }]
+}
+```

--- a/plugins/airas/skills/auto-research/SKILL.md
+++ b/plugins/airas/skills/auto-research/SKILL.md
@@ -106,13 +106,14 @@ steps don't cover comes up.
 under the claim has results. It goes from false to true once and never
 back; a stored true the results no longer bear out fails verification.
 
-**`verified` says the data is in, not that the claim held.** Whether a
-claim's condition was met, and whether the claim was declared before
-its runs executed, are not modelled in the record yet (TODO) — the
-criterion and predicted interval live in the paper's prose, and the
-order discipline is the agent's. A claim that was tested and missed its
-criterion is a negative result, reported as such; reading a column of
-`verified: true` as "the hypothesis held" is the misreading to avoid.
+**`verified` says the data is in, not that the claim held.** Whether
+the claim held is `verdict`, derived from the criterion the claim
+declared (supported / refuted; inconclusive when the metric cannot be
+resolved) and likewise written once. Whether the claim was declared
+before its runs executed is not modelled yet (TODO) — that order
+discipline is the agent's. A refuted claim is a negative result,
+reported as such; reading a column of `verified: true` as "the
+hypothesis held" is the misreading to avoid.
 
 Trust domains: local runs of the checks have **zero evidentiary
 value** — the local toolchain is in the agent's hands, and whatever a

--- a/plugins/airas/skills/hypothesize-and-design/SKILL.md
+++ b/plugins/airas/skills/hypothesize-and-design/SKILL.md
@@ -24,7 +24,12 @@ Needs a `research_study_list` (prior work to build on).
    so a design that leaves run naming open is not finished. State the
    expected magnitude of the effect as an interval (a range, not a
    point) and what outcome would refute the hypothesis — a hypothesis
-   without a refutation condition is not testable.
+   without a refutation condition is not testable. These become each
+   claim's `prediction` and `criterion` (a threshold on one named
+   metric, one run against another or a constant) at preregistration.
+   For each claim, say why its holding is evidence for the hypothesis
+   (its `rationale`), and list what the claims together still assume
+   in order to imply the hypothesis (the hypothesis's `assumptions`).
 
 **Output**: hypothesis + experimental design, written to
 `.research/research_history.json` in the experiment repository when one

--- a/plugins/airas/skills/preregister-paper/SKILL.md
+++ b/plugins/airas/skills/preregister-paper/SKILL.md
@@ -42,8 +42,16 @@ changes *when* the paper is written and how Results are stated.
    ```
    hypotheses: [{
      "id": "h1", "statement": "the hypothesis, in prose",
+     "assumptions": ["what must be granted for the claims together to
+                      imply h1, naming the claims concerned", ...],
      "claims": [{
        "id": "c1", "statement": "one assertive sentence",
+       "rationale": "why c1 holding is evidence for h1, and for which part",
+       "verifier": {"kind": "seyval"},
+       "criterion": {"metric": "accuracy", "subject": "proposed-...",
+                     "reference": "comparative-1-...", "op": ">=",
+                     "margin": 0.02},
+       "prediction": {"low": 0.02, "high": 0.04, "basis": "pilot run"},
        "designs": [{
          "id": "d1", "summary": "...",
          "runs": [{"run_id": "proposed-...", "description": "...",
@@ -63,12 +71,32 @@ changes *when* the paper is written and how Results are stated.
    the params is what makes "we said full and ran pilot" detectable
    later — the gate compares them with what the platform recorded.
 
-   What a claim's condition is, whether the numbers met it, and whether
-   the claim was declared before its runs executed are **not modelled in
-   the record yet** (TODO). The record tracks whether every run under
-   each claim has results (`verified`); the criterion and the predicted
-   interval live in the paper's prose for now, frozen by the same
-   commit. A second hypothesis is a second entry in `hypotheses`.
+   `criterion` is the falsification line, required for every seyval
+   claim: `(subject.metric - reference) op margin`, where `reference` is
+   another run under the claim (its same metric) or a constant. The
+   verdict — supported or refuted — is derived from it once the runs are
+   in, and it is frozen with the claim: moving the margin later fails
+   the gate like rewording the statement. `prediction` is the interval
+   the difference is expected to land in, required, a range never a
+   point, with where it comes from. Whether the claim was declared
+   before its runs executed is not modelled yet (TODO). A second
+   hypothesis is a second entry in `hypotheses`.
+
+   The claims are meant to imply the hypothesis together: c1 ∧ … ∧ cn
+   ⇒ h1. `rationale` (required on every claim) says why the claim is a
+   member of that set — which part of the hypothesis it carries and why
+   its holding is evidence for it. `assumptions` (on the hypothesis)
+   say what has to be granted for the conjunction to reach h1: that the
+   metric stands for the property, that the datasets run generalise,
+   that the baseline is representative, and so on, each naming the
+   claims it concerns. These are exactly what every claim being
+   supported still leaves unverified, so state them as assumptions, not
+   as findings; an assumption that can be turned into a measurement is
+   a missing claim.
+
+   The tool also writes `claims.tex` — the numbered claim list with each
+   criterion, prediction and (pending) verdict — next to main.tex and
+   commits it with the record.
 
 2. **Write `.research/latex/{template}/main.tex` in two parts.**
    The *frozen part* — title, abstract, introduction, related work,
@@ -79,20 +107,17 @@ changes *when* the paper is written and how Results are stated.
    so the diff at publish time is confined to a region a reviewer can
    find.
 
-   The **hypothesis and predictions section is a numbered list of
-   claims** (C1, C2, ... — the same ids as in record.json, which is the
-   canonical form; the paper prose is its human rendering). Each claim
-   is one assertive sentence plus,
-   in prose: the criterion (the threshold on a named run metric that
-   counts as support — below it the claim is refuted) and the
-   **predicted interval** — a range, never a point ("we predict an
-   improvement of 2–4 points"), with where the range comes from (prior
-   work, pilot). The criterion is the falsification line, the interval
-   is what you expect; an outcome outside the interval in either
-   direction must be discussed later. A range too wide to miss is a
-   criterion, not a prediction. Until the record models them, the
-   prose *is* their frozen form — the freeze commit fixes it as it does
-   the record. Every experimental number is
+   The **hypothesis and predictions section is the numbered list of
+   claims**: `\input{claims.tex}` where it belongs. The file is rendered
+   from record.json (C1, C2, ... with each claim's rationale, criterion,
+   predicted interval and verdict, then the hypothesis's assumptions),
+   so the list in the PDF is the record's, not a
+   transcription; the gate regenerates and diffs it at every stage.
+   Prose around it may explain why each criterion and interval was
+   chosen. The criterion is the falsification line, the interval is
+   what you expect; an outcome outside the interval in either direction
+   must be discussed later. A range too wide to miss is a criterion,
+   not a prediction. Every experimental number is
    `\airasval{key}` and appears only in the post-experiment part —
    never a literal, not even an expected one presented as measured.
 

--- a/plugins/airas/skills/publish-paper/SKILL.md
+++ b/plugins/airas/skills/publish-paper/SKILL.md
@@ -84,8 +84,9 @@ local stage.
    `unverified_claims` — claims some of whose declared runs have no
    results may still be published, but say so honestly in the paper and
    to the user. `verified: true` says the claim's data is in, not that
-   it held: a claim that was tested and missed the criterion stated in
-   the paper is a **negative result**, reported as such. Never read the
+   it held — `verdict` does, derived from the declared criterion: a
+   claim that was tested and refuted is a **negative result**, reported
+   as such, and `claims.tex` already says so. Never read the
    verified flags alone as support for the hypothesis, and never reword
    a claim to fit what the data did.
 


### PR DESCRIPTION
## 概要

record.json の claim を具体化します。これまで支持の閾値と予測区間はスキルの散文にしかなく、seyval claim は `verdict` を得られませんでした（3 か所の TODO）。本 PR で claim に構造化フィールドを追加し、verdict を機械導出し、claim 一覧を record から `claims.tex` として生成します。

## 変更

**データモデル（`research_record.py`）**
- `ClaimBase.rationale`（必須）: この claim が成り立つと、なぜ・仮説のどの部分が支えられるか。claims 集合の元である理由。
- `Hypothesis.assumptions[]`: `c1 ∧ … ∧ cn ⇒ H` を成り立たせるために認める公理。全 claim が支持されても未検証として残るのはちょうどこれ。
- `SeyvalClaim.criterion`（必須）: `(subject.metric − reference) op margin`。reference は claim 配下の run_id（同じ metric）または定数。境界は一致扱い。
- `SeyvalClaim.prediction`（必須）: `low < high` の区間と `basis`。
- 共通の `walk_metric_path` を追加し、`resolve_ref` から直接呼ぶ（`_walk` は削除）。

**verdict（`update_or_load_record.py`）**
- seyval claim の verdict を criterion から導出。metric が解決できなければ `inconclusive`。
- 一度書いた verdict は変えない既存方針を踏襲し、再実行で反転した場合は `verify_record` が drift として報告（メッセージを「verified, or with a verdict」に拡張）。

**整合検査（`verify_record.py`）**
- criterion の subject / reference が claim 配下の run であることを検査。criterion / prediction の事後変更は既存の containment 検査でそのまま違反になる。

**論文（`map_record_to_publication.py`, `verify_paper.py`, `server.py`）**
- `render_claims_tex`: 仮説ごとに claim の statement / rationale / criterion / prediction / observed / verdict を列挙し、末尾に assumptions を描画。
- `preregister_record` / `append_to_record` / `update_record` が `claims.tex` を書いてコミットに含める（前二者に `latex_template_name` を追加）。
- `verify_paper` は prereg / results の両段階で `claims.tex` を再生成して byte 比較する。
- docstring の TODO を verdict 規則に置換。

**スキル・ドキュメント**
- `preregister-paper` / `hypothesize-and-design` / `auto-research` / `publish-paper` の record 形と説明を更新。claim 一覧は `\input{claims.tex}`。
- `docs/record-json-schema.md`: record.json の構造（Mermaid クラス図、木構造、例）。
- README の roadmap 1 行。

## 後方互換

なし。`rationale` / `criterion` / `prediction` は必須で、既存の record.json は parse で拒否されます。

## テスト

- 新規 `test_claim_criterion.py`: verdict 8 ケース（境界、定数参照、`<=` と負 margin、metric 欠落）、宣言検査、凍結。
- 新規 `test_claims_tex.py`: prereg での pending 描画、results での observed / verdict、rationale / assumptions。
- `test_verify_record.py`: repo レベルで verdict の導出、反転再実行の drift、prereg 段階の `claims.tex`、手編集・欠落の検出。
- 既存フィクスチャに criterion / prediction / rationale を追加。

```
uv run pytest tests/unit   # 312 passed, 15 skipped
pre-commit run ruff / mypy # Passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDMdeHwTqrwkm3cCm9bEgy
