### PR TITLE
fix(gate): 必須検証の検査ロジックの穴を塞ぐ — paper 必須化・record 不在・履歴隠蔽 (#1021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,11 @@ See the [MCP documentation](docs/development/MCP.mdx) for descriptions, credenti
 ```bash
 uvx airas                 # MCP server on stdio (default)
 uvx airas verify-record   # check .research/record.json against run outputs, git history, and the platform
-uvx airas verify-paper    # verify the paper's values and provenance and build its PDF (the CI gate)
+uvx airas verify-paper    # verify the paper's values and provenance against the record — no PDF build (the CI gate)
+uvx airas publish-paper   # build the paper's PDF for publishing (values already verified by the gate)
 ```
 
-`verify-record` and `verify-paper` are what the experiment repository's CI runs as the required check on the protected branch.
+`verify-record` and `verify-paper` are the two required checks the experiment repository's CI runs on the protected branch; `publish-paper` builds the PDF in the separate, non-required publish workflow.
 
 ## Development
 

--- a/backend/src/airas/cli.py
+++ b/backend/src/airas/cli.py
@@ -8,7 +8,11 @@ import webbrowser
 from pathlib import Path
 
 from airas.core.types.research_trace import DerivedFromRepository
-from airas.usecases.publication.verify_paper import detect_templates, verify_paper
+from airas.usecases.publication.verify_paper import (
+    build_paper,
+    detect_templates,
+    verify_paper,
+)
 from airas.usecases.recording.agent_state import (
     load_agent_state,
     neutral_messages,
@@ -53,19 +57,16 @@ def _run_dashboard(host: str, port: int, open_browser: bool) -> None:
 def _run_verify_paper(args: argparse.Namespace) -> None:
     templates = args.template or detect_templates(args.local_path)
     if not templates:
-        print(
-            "No paper found: no known template under .research/latex/ has a main.tex",
-            file=sys.stderr,
-        )
-        sys.exit(2)
+        # The paper gate runs on every commit; before preregister-paper writes
+        # main.tex there is nothing to verify — a pass.
+        print("No paper yet: nothing to verify.")
+        sys.exit(0)
 
-    out = Path(args.output_dir).expanduser().resolve()
     results = [
         asyncio.run(
             verify_paper(
                 args.local_path,
                 template,
-                pdf_path=str(out / f"{template}.pdf"),
                 check_provenance=not args.no_provenance,
                 require_record=not args.no_require_paper_values,
                 require_provenance=not (
@@ -78,6 +79,21 @@ def _run_verify_paper(args: argparse.Namespace) -> None:
     ]
     print(json.dumps([r.model_dump() for r in results], indent=2, ensure_ascii=False))
     sys.exit(0 if all(r.ok for r in results) else 1)
+
+
+def _run_publish_paper(args: argparse.Namespace) -> None:
+    templates = args.template or detect_templates(args.local_path)
+    if not templates:
+        print("No paper to build: nothing under .research/latex/ has a main.tex")
+        sys.exit(0)
+
+    out = Path(args.output_dir).expanduser().resolve()
+    reports = [
+        build_paper(args.local_path, template, str(out / f"{template}.pdf"))
+        for template in templates
+    ]
+    print(json.dumps([r.model_dump() for r in reports], indent=2, ensure_ascii=False))
+    sys.exit(0 if all(r.ok for r in reports) else 1)
 
 
 def _run_verify_record(args: argparse.Namespace) -> None:
@@ -219,8 +235,8 @@ def main() -> None:
     verify = subparsers.add_parser(
         "verify-paper",
         help=(
-            "Verify a paper's values and provenance in an experiment "
-            "repository and build its PDF (the CI gate)"
+            "Verify a paper's values and provenance against the record — no "
+            "PDF build. Meant to be the required check on the protected branch"
         ),
     )
     verify.add_argument(
@@ -235,11 +251,6 @@ def main() -> None:
             "LaTeX template to verify (repeatable); default: every known "
             "template under .research/latex/ that has a main.tex"
         ),
-    )
-    verify.add_argument(
-        "--output-dir",
-        default="paper-artifact",
-        help="Where the built PDFs go",
     )
     verify.add_argument(
         "--no-provenance",
@@ -303,6 +314,32 @@ def main() -> None:
         ),
     )
 
+    publish = subparsers.add_parser(
+        "publish-paper",
+        help=(
+            "Build the paper's PDF for publishing — the paper gate "
+            "(verify-paper) already verified its values"
+        ),
+    )
+    publish.add_argument(
+        "--local-path",
+        default=".",
+        help="Experiment repository checkout to build (default: .)",
+    )
+    publish.add_argument(
+        "--template",
+        action="append",
+        help=(
+            "LaTeX template to build (repeatable); default: every known "
+            "template under .research/latex/ that has a main.tex"
+        ),
+    )
+    publish.add_argument(
+        "--output-dir",
+        default="paper-artifact",
+        help="Where the built PDFs go",
+    )
+
     args = parser.parse_args()
 
     if args.command == "hook":
@@ -313,6 +350,8 @@ def main() -> None:
         _run_dashboard(args.host, args.port, open_browser=not args.no_browser)
     elif args.command == "verify-paper":
         _run_verify_paper(args)
+    elif args.command == "publish-paper":
+        _run_publish_paper(args)
     elif args.command == "verify-record":
         _run_verify_record(args)
     else:

--- a/backend/src/airas/cli.py
+++ b/backend/src/airas/cli.py
@@ -6,7 +6,9 @@ import sys
 import threading
 import webbrowser
 from pathlib import Path
+from typing import get_args
 
+from airas.core.types.latex import LATEX_TEMPLATE_NAME
 from airas.core.types.research_trace import DerivedFromRepository
 from airas.usecases.publication.verify_paper import (
     build_paper,
@@ -55,16 +57,22 @@ def _run_dashboard(host: str, port: int, open_browser: bool) -> None:
     uvicorn.run("airas.dashboard.api.main:app", host=host, port=port)
 
 
+def _paper_templates(args: argparse.Namespace) -> list[str]:
+    # A main.tex under a template this version cannot handle must never be
+    # ignored — not as "no paper", and not because a known template sits
+    # beside it: the gate would wave through a paper it never read. Only a
+    # repository with no main.tex at all has nothing to do yet.
+    known = detect_templates(args.local_path)
+    unknown = [d for d in paper_directories(args.local_path) if d not in known]
+    if unknown:
+        print(f"Unsupported LaTeX template: {', '.join(unknown)}", file=sys.stderr)
+        sys.exit(1)
+    return args.template or known
+
+
 def _run_verify_paper(args: argparse.Namespace) -> None:
-    templates = args.template or detect_templates(args.local_path)
+    templates = _paper_templates(args)
     if not templates:
-        # A main.tex under a template this version cannot verify must not pass
-        # as "no paper" — the gate would wave through a paper it never read.
-        # Only a repository with no main.tex at all has nothing to verify yet.
-        unknown = paper_directories(args.local_path)
-        if unknown:
-            print(f"Unsupported LaTeX template: {', '.join(unknown)}", file=sys.stderr)
-            sys.exit(1)
         print("No paper yet: nothing to verify.")
         sys.exit(0)
 
@@ -88,12 +96,8 @@ def _run_verify_paper(args: argparse.Namespace) -> None:
 
 
 def _run_publish_paper(args: argparse.Namespace) -> None:
-    templates = args.template or detect_templates(args.local_path)
+    templates = _paper_templates(args)
     if not templates:
-        unknown = paper_directories(args.local_path)
-        if unknown:
-            print(f"Unsupported LaTeX template: {', '.join(unknown)}", file=sys.stderr)
-            sys.exit(1)
         print("No paper to build: nothing under .research/latex/ has a main.tex")
         sys.exit(0)
 
@@ -257,6 +261,7 @@ def main() -> None:
     verify.add_argument(
         "--template",
         action="append",
+        choices=get_args(LATEX_TEMPLATE_NAME),
         help=(
             "LaTeX template to verify (repeatable); default: every known "
             "template under .research/latex/ that has a main.tex"
@@ -339,6 +344,7 @@ def main() -> None:
     publish.add_argument(
         "--template",
         action="append",
+        choices=get_args(LATEX_TEMPLATE_NAME),
         help=(
             "LaTeX template to build (repeatable); default: every known "
             "template under .research/latex/ that has a main.tex"

--- a/backend/src/airas/cli.py
+++ b/backend/src/airas/cli.py
@@ -11,6 +11,7 @@ from airas.core.types.research_trace import DerivedFromRepository
 from airas.usecases.publication.verify_paper import (
     build_paper,
     detect_templates,
+    paper_directories,
     verify_paper,
 )
 from airas.usecases.recording.agent_state import (
@@ -57,8 +58,13 @@ def _run_dashboard(host: str, port: int, open_browser: bool) -> None:
 def _run_verify_paper(args: argparse.Namespace) -> None:
     templates = args.template or detect_templates(args.local_path)
     if not templates:
-        # The paper gate runs on every commit; before preregister-paper writes
-        # main.tex there is nothing to verify — a pass.
+        # A main.tex under a template this version cannot verify must not pass
+        # as "no paper" — the gate would wave through a paper it never read.
+        # Only a repository with no main.tex at all has nothing to verify yet.
+        unknown = paper_directories(args.local_path)
+        if unknown:
+            print(f"Unsupported LaTeX template: {', '.join(unknown)}", file=sys.stderr)
+            sys.exit(1)
         print("No paper yet: nothing to verify.")
         sys.exit(0)
 
@@ -84,6 +90,10 @@ def _run_verify_paper(args: argparse.Namespace) -> None:
 def _run_publish_paper(args: argparse.Namespace) -> None:
     templates = args.template or detect_templates(args.local_path)
     if not templates:
+        unknown = paper_directories(args.local_path)
+        if unknown:
+            print(f"Unsupported LaTeX template: {', '.join(unknown)}", file=sys.stderr)
+            sys.exit(1)
         print("No paper to build: nothing under .research/latex/ has a main.tex")
         sys.exit(0)
 

--- a/backend/src/airas/infra/local_git.py
+++ b/backend/src/airas/infra/local_git.py
@@ -67,6 +67,25 @@ def commits_touching(repo_root: Path, repo_path: str) -> list[str] | None:
     return [line for line in log.splitlines() if line]
 
 
+def commits_with_parents(
+    repo_root: Path, repo_path: str
+) -> list[tuple[str, list[str]]] | None:
+    # --full-history: the default path walk follows one parent of a merge that
+    # is treesame to it and never lists the other, so a version reached only
+    # through that parent drops out (git merge -s ours). Keep every merge with
+    # all its parents; the caller compares along those edges.
+    log = _text(repo_root, "log", "--full-history", "--format=%H %P", "--", repo_path)
+    if log is None:
+        return None
+
+    edges = []
+    for line in log.splitlines():
+        if line:
+            commit, *parents = line.split()
+            edges.append((commit, parents))
+    return edges
+
+
 def commit_paths(repo_root: Path, paths: list[str], message: str) -> str | None:
     # Commits exactly `paths` (anything else staged is left alone); None on
     # failure. Unchanged paths return the current HEAD — already committed

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -949,7 +949,7 @@ async def prepare_repository(
                 github_owner,
                 repository_name,
                 protected_branch,
-                [RECORD_GATE_CHECK_NAME],
+                [RECORD_GATE_CHECK_NAME, PAPER_GATE_CHECK_NAME],
             )
         except Exception as e:
             warnings.append(
@@ -1004,6 +1004,9 @@ async def set_github_actions_secrets(
 
 
 RECORD_GATE_CHECK_NAME = "Verify the record"
+# Values only, no PDF build: the build commits back onto the protected branch,
+# so requiring it would deadlock. It stays in the non-required publish workflow.
+PAPER_GATE_CHECK_NAME = "Verify the paper"
 
 
 async def _apply_secrets(
@@ -1085,7 +1088,7 @@ async def protect_branch(
 
     Requires GH_PERSONAL_ACCESS_TOKEN with admin rights on the repository.
     """
-    contexts = required_check_names or [RECORD_GATE_CHECK_NAME]
+    contexts = required_check_names or [RECORD_GATE_CHECK_NAME, PAPER_GATE_CHECK_NAME]
     protected, merge_settings = await _apply_branch_protection(
         github_owner, repository_name, branch_name, contexts
     )

--- a/backend/src/airas/mcp/server.py
+++ b/backend/src/airas/mcp/server.py
@@ -1069,8 +1069,9 @@ async def protect_branch(
 
     Sets three things on `branch_name`:
 
-    - the record gate as a **required status check**, so a commit whose
-      check is missing or red cannot land, by push or by merge;
+    - the record and paper gates as **required status checks** — always;
+      `required_check_names` can add checks, never drop these — so a commit
+      whose check is missing or red cannot land, by push or by merge;
     - `enforce_admins`, because the default exempts exactly the person who
       configured the rule — usually the repository's own owner, and so the
       one whose work most needs to be held to it;
@@ -1088,7 +1089,12 @@ async def protect_branch(
 
     Requires GH_PERSONAL_ACCESS_TOKEN with admin rights on the repository.
     """
-    contexts = required_check_names or [RECORD_GATE_CHECK_NAME, PAPER_GATE_CHECK_NAME]
+    contexts = list(
+        dict.fromkeys(
+            (required_check_names or [])
+            + [RECORD_GATE_CHECK_NAME, PAPER_GATE_CHECK_NAME]
+        )
+    )
     protected, merge_settings = await _apply_branch_protection(
         github_owner, repository_name, branch_name, contexts
     )
@@ -2231,7 +2237,8 @@ async def preregister_record(
     and commits it with the record; `\\input{claims.tex}` where the paper
     lists its claims. The gate regenerates and diffs it at every stage.
 
-    Fails if record.json already exists (use `append_to_record`), if a claim
+    Fails if record.json already holds declarations (use `append_to_record`;
+    the empty record a repository ships is initialised in place), if a claim
     declares no run, if a seyval claim lacks its criterion or prediction, or
     if the clone cannot commit. After this: write every future experimental
     number in main.tex as `\\airasval{<run_id>.<metric>}` or
@@ -2242,10 +2249,15 @@ async def preregister_record(
 
     def _run() -> dict[str, Any]:
         path = record_path(local_path)
-        if path.is_file():
+        if (
+            path.is_file()
+            and ResearchRecord.model_validate_json(
+                path.read_text(encoding="utf-8")
+            ).hypotheses
+        ):
             raise ValueError(
-                f"{path} already exists — the record only ever grows; add "
-                "declarations with append_to_record"
+                f"{path} already holds declarations — the record only ever "
+                "grows; add declarations with append_to_record"
             )
 
         record = ResearchRecord(hypotheses=parsed)

--- a/backend/src/airas/usecases/publication/verify_paper.py
+++ b/backend/src/airas/usecases/publication/verify_paper.py
@@ -471,6 +471,7 @@ async def verify_paper(
             check_provenance=check_provenance,
             require_provenance=require_provenance,
             require_history=require_history,
+            require_record=require_record,
             seyval_client_factory=seyval_client_factory,
         )
     root = Path(local_path).expanduser().resolve()

--- a/backend/src/airas/usecases/publication/verify_paper.py
+++ b/backend/src/airas/usecases/publication/verify_paper.py
@@ -486,7 +486,7 @@ async def verify_paper(
         )
     build: LatexBuildReport | None = None
     if pdf_path is not None:
-        build = await asyncio.to_thread(_verify_build, local_path, template, pdf_path)
+        build = await asyncio.to_thread(build_paper, local_path, template, pdf_path)
         if not build.ok:
             problems.append("the LaTeX build failed (see build)")
 
@@ -573,9 +573,11 @@ def _verify_mapping(
     return problems, unverified
 
 
-def _verify_build(
+def build_paper(
     local_path: str, template: LATEX_TEMPLATE_NAME, pdf_path: str
 ) -> LatexBuildReport:
+    # Build only, no value check: the paper gate (verify-paper) already
+    # verified the numbers, so publish just compiles and commits.
     latex_files = collect_latex_project_files_local(local_path, template)
     return verify_latex_build(latex_files, "main.tex", pdf_path)
 

--- a/backend/src/airas/usecases/publication/verify_paper.py
+++ b/backend/src/airas/usecases/publication/verify_paper.py
@@ -597,3 +597,12 @@ def detect_templates(local_path: str) -> list[str]:
             continue
         found.append(path.name)
     return found
+
+
+def paper_directories(local_path: str) -> list[str]:
+    # Every directory holding a main.tex, known template or not — so a caller
+    # can tell "no paper yet" from "a paper this version cannot verify".
+    latex_root = Path(local_path).expanduser().resolve() / ".research" / "latex"
+    if not latex_root.is_dir():
+        return []
+    return sorted(p.name for p in latex_root.iterdir() if (p / "main.tex").is_file())

--- a/backend/src/airas/usecases/recording/verify_record.py
+++ b/backend/src/airas/usecases/recording/verify_record.py
@@ -44,13 +44,25 @@ async def verify_record(
     check_provenance: bool = True,
     require_provenance: bool = True,
     require_history: bool = True,
+    require_record: bool = True,
     seyval_client_factory: Callable[[], SeyvalClient] = default_seyval_client,
 ) -> RecordVerification:
-    # A repository with no record has made no claim to contradict; requiring
-    # one is the paper's concern (verify_paper), which knows a paper exists.
     root = Path(local_path).expanduser().resolve()
     if not (root / RECORD_PATH).is_file():
-        return RecordVerification(ok=True, stage="prereg")
+        # An AIRAS repository ships record.json (empty at first), so its
+        # absence is not an initial state — it was deleted, taking the
+        # declarations the gate reads with it. The gate requires it;
+        # verify_paper's preview (require_record=False) tolerates a paper that
+        # opts out of the record system.
+        problems = (
+            [
+                "record.json is missing: every AIRAS repository ships one "
+                "(empty at first), so its absence means it was deleted"
+            ]
+            if require_record
+            else []
+        )
+        return RecordVerification(ok=not problems, stage="prereg", problems=problems)
 
     try:
         record = load_record(str(root))

--- a/backend/src/airas/usecases/recording/verify_record.py
+++ b/backend/src/airas/usecases/recording/verify_record.py
@@ -19,7 +19,11 @@ from airas.core.types.run_provenance import (
     PROVENANCE_MANIFEST_PATH,
     RunProvenanceManifest,
 )
-from airas.infra.local_git import commits_touching, file_bytes_at_commit, is_shallow
+from airas.infra.local_git import (
+    commits_with_parents,
+    file_bytes_at_commit,
+    is_shallow,
+)
 from airas.infra.seyval_client import SeyvalClient, default_seyval_client
 from airas.usecases.recording._seyval_provenance import (
     _ProvenanceCheckResult,
@@ -176,28 +180,44 @@ def _verify_append_only(
     )
     if is_shallow(root):
         return unavailable
-    commit_hashes = commits_touching(root, RECORD_PATH)
-    if commit_hashes is None:
+    edges = commits_with_parents(root, RECORD_PATH)
+    if edges is None:
         return unavailable
 
-    versions: list[tuple[str, ResearchRecord]] = []
-    for commit_hash in reversed(commit_hashes):  # oldest first
+    # The record as of each commit involved. Absent counts as empty, so a
+    # deletion is a shrink and a first creation contains nothing to lose.
+    versions: dict[str, ResearchRecord] = {}
+    for commit_hash in {h for commit, parents in edges for h in (commit, *parents)}:
         raw = file_bytes_at_commit(root, commit_hash, RECORD_PATH)
         if raw is None:
-            continue  # the commit deleted the file
+            versions[commit_hash] = ResearchRecord()
+            continue
         try:
-            versions.append((commit_hash, ResearchRecord.model_validate_json(raw)))
+            versions[commit_hash] = ResearchRecord.model_validate_json(raw)
         except ValidationError:
             return [f"record.json at {commit_hash[:12]} is not a valid record"]
-    versions.append(("worktree", record))
 
-    return [
-        f"{older_hash[:12]} -> {newer_hash[:12]}: {problem}"
-        for (older_hash, older), (newer_hash, newer) in zip(
-            versions, versions[1:], strict=False
+    # Each commit against each of its parents — not against its neighbour in
+    # a linear list, which would set two sibling branches against each other.
+    problems = [
+        f"{parent[:12]} -> {commit[:12]}: {problem}"
+        for commit, parents in edges
+        for parent in parents
+        for problem in _containment_violations(
+            versions[parent].model_dump(), versions[commit].model_dump()
         )
-        for problem in _containment_violations(older.model_dump(), newer.model_dump())
     ]
+    head = file_bytes_at_commit(root, "HEAD", RECORD_PATH)
+    committed = (
+        ResearchRecord() if head is None else ResearchRecord.model_validate_json(head)
+    )
+    problems += [
+        f"HEAD -> worktree: {problem}"
+        for problem in _containment_violations(
+            committed.model_dump(), record.model_dump()
+        )
+    ]
+    return problems
 
 
 def _containment_violations(older: Any, newer: Any, path: str = "") -> list[str]:

--- a/backend/tests/unit/mcp/test_preregister_record.py
+++ b/backend/tests/unit/mcp/test_preregister_record.py
@@ -1,0 +1,96 @@
+"""preregister_record initialises the empty record a repository ships in
+place, and still refuses to overwrite declarations."""
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from airas.core.research_paths import RECORD_PATH
+from airas.core.types.research_record import (
+    Criterion,
+    Hypothesis,
+    Prediction,
+    SeyvalClaim,
+    SeyvalDesign,
+    SeyvalRun,
+    SeyvalVerifier,
+    VerifierKind,
+)
+from airas.mcp import server
+from airas.usecases.recording.update_or_load_record import load_record
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def _repo_with_record(tmp_path: Path, record_json: str) -> Path:
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "test")
+    (tmp_path / RECORD_PATH).parent.mkdir(parents=True)
+    (tmp_path / RECORD_PATH).write_text(record_json)
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "template")
+    return tmp_path
+
+
+def _hypotheses() -> list[dict[str, Any]]:
+    return [
+        Hypothesis(
+            id="h1",
+            statement="The proposed method beats the baseline.",
+            claims=[
+                SeyvalClaim(
+                    verifier=SeyvalVerifier(kind=VerifierKind.SEYVAL),
+                    id="c1",
+                    statement="Proposed beats baseline on accuracy.",
+                    rationale="Head-to-head on the hypothesis's own metric.",
+                    criterion=Criterion(
+                        metric="accuracy",
+                        subject="proposed",
+                        reference="baseline",
+                        op=">=",
+                        margin=0.02,
+                    ),
+                    prediction=Prediction(low=0.02, high=0.04, basis="pilot"),
+                    designs=[
+                        SeyvalDesign(
+                            id="d1",
+                            summary="Head-to-head on one dataset.",
+                            runs=[
+                                SeyvalRun(run_id="proposed"),
+                                SeyvalRun(run_id="baseline"),
+                            ],
+                        )
+                    ],
+                )
+            ],
+        ).model_dump(mode="json")
+    ]
+
+
+async def test_the_shipped_empty_record_is_initialised_in_place(tmp_path: Path) -> None:
+    repo = _repo_with_record(tmp_path, "{}")
+
+    result = await server.preregister_record(str(repo), _hypotheses(), "mdpi")
+
+    assert result["record_path"] == str(repo / RECORD_PATH)
+    assert [h.id for h in load_record(str(repo)).hypotheses] == ["h1"]
+    assert _git(repo, "rev-list", "--count", "HEAD") == "2"  # the freeze commit
+
+
+async def test_a_record_that_already_declares_is_not_overwritten(
+    tmp_path: Path,
+) -> None:
+    declared = server.ResearchRecord(
+        hypotheses=[Hypothesis.model_validate(h) for h in _hypotheses()]
+    )
+    repo = _repo_with_record(tmp_path, declared.model_dump_json())
+
+    with pytest.raises(ValueError, match="already holds declarations"):
+        await server.preregister_record(str(repo), _hypotheses(), "mdpi")

--- a/backend/tests/unit/mcp/test_repository_setup.py
+++ b/backend/tests/unit/mcp/test_repository_setup.py
@@ -67,10 +67,17 @@ async def test_setup_configures_secrets_and_protection(recorder: _Recorder) -> N
     assert result["merge_settings_updated"] is True
     assert result["warnings"] == []
     assert recorder.secrets == [("o", "r", "main")]
-    # The required check is the record gate's job name in the template
-    # workflow: a different string would be required forever and never
-    # reported, which blocks the branch instead of guarding it.
-    assert recorder.protection == [("o", "r", "main", [server.RECORD_GATE_CHECK_NAME])]
+    # The required checks are the gates' job names in the template workflows: a
+    # different string would be required forever and never reported, which
+    # blocks the branch instead of guarding it.
+    assert recorder.protection == [
+        (
+            "o",
+            "r",
+            "main",
+            [server.RECORD_GATE_CHECK_NAME, server.PAPER_GATE_CHECK_NAME],
+        )
+    ]
 
 
 async def test_the_protected_branch_can_differ_from_the_working_branch(
@@ -136,5 +143,6 @@ async def test_standalone_tools_reach_the_same_code(recorder: _Recorder) -> None
 
     protect = await server.protect_branch("o", "r")
     assert protect["branch_protected"] is True
-    assert protect["required_checks"] == [server.RECORD_GATE_CHECK_NAME]
-    assert recorder.protection[0][3] == [server.RECORD_GATE_CHECK_NAME]
+    checks = [server.RECORD_GATE_CHECK_NAME, server.PAPER_GATE_CHECK_NAME]
+    assert protect["required_checks"] == checks
+    assert recorder.protection[0][3] == checks

--- a/backend/tests/unit/mcp/test_repository_setup.py
+++ b/backend/tests/unit/mcp/test_repository_setup.py
@@ -146,3 +146,15 @@ async def test_standalone_tools_reach_the_same_code(recorder: _Recorder) -> None
     checks = [server.RECORD_GATE_CHECK_NAME, server.PAPER_GATE_CHECK_NAME]
     assert protect["required_checks"] == checks
     assert recorder.protection[0][3] == checks
+
+
+async def test_protect_branch_cannot_drop_a_gate(recorder: _Recorder) -> None:
+    """A caller naming only the record gate still gets both: the paper gate
+    is part of the guarantee, not an option."""
+    await server.protect_branch(
+        "o", "r", required_check_names=[server.RECORD_GATE_CHECK_NAME]
+    )
+    assert recorder.protection[0][3] == [
+        server.RECORD_GATE_CHECK_NAME,
+        server.PAPER_GATE_CHECK_NAME,
+    ]

--- a/backend/tests/unit/test_cli_verify_paper_gate.py
+++ b/backend/tests/unit/test_cli_verify_paper_gate.py
@@ -1,30 +1,83 @@
+"""verify-paper is the required values gate and never builds; publish-paper
+only builds. The two must not drift back into one command."""
+
 import argparse
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from airas import cli
 
 
-def test_paper_gate_passes_when_there_is_no_paper(tmp_path):
-    args = argparse.Namespace(
-        local_path=str(tmp_path),
+def _verify_args(local_path: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        local_path=local_path,
         template=None,
         no_provenance=False,
         allow_unavailable_provenance=False,
         no_require_paper_values=False,
         allow_unavailable_history=False,
     )
-    with pytest.raises(SystemExit) as exit:
-        cli._run_verify_paper(args)
-    assert exit.value.code == 0
 
 
-def test_publish_is_a_noop_when_there_is_no_paper(tmp_path):
-    args = argparse.Namespace(
-        local_path=str(tmp_path),
-        template=None,
-        output_dir=str(tmp_path / "out"),
+def _publish_args(local_path: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        local_path=local_path, template=None, output_dir=f"{local_path}/out"
     )
+
+
+def _exit_code(fn, args) -> int:
     with pytest.raises(SystemExit) as exit:
-        cli._run_publish_paper(args)
-    assert exit.value.code == 0
+        fn(args)
+    return exit.value.code
+
+
+def test_paper_gate_passes_when_there_is_no_paper(tmp_path: Path) -> None:
+    assert _exit_code(cli._run_verify_paper, _verify_args(str(tmp_path))) == 0
+
+
+def test_publish_is_a_noop_when_there_is_no_paper(tmp_path: Path) -> None:
+    assert _exit_code(cli._run_publish_paper, _publish_args(str(tmp_path))) == 0
+
+
+def test_a_paper_under_an_unsupported_template_is_not_no_paper(
+    tmp_path: Path,
+) -> None:
+    # A main.tex the gate cannot verify must fail, not pass as "no paper yet".
+    (tmp_path / ".research" / "latex" / "homebrew").mkdir(parents=True)
+    (tmp_path / ".research" / "latex" / "homebrew" / "main.tex").write_text("x")
+    assert _exit_code(cli._run_verify_paper, _verify_args(str(tmp_path))) == 1
+    assert _exit_code(cli._run_publish_paper, _publish_args(str(tmp_path))) == 1
+
+
+@pytest.mark.parametrize("ok", [True, False])
+def test_publish_builds_and_reports_the_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, ok: bool
+) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def build(*args: str) -> SimpleNamespace:
+        calls.append(args)
+        return SimpleNamespace(ok=ok, model_dump=dict)
+
+    monkeypatch.setattr(cli, "detect_templates", lambda _p: ["mdpi"])
+    monkeypatch.setattr(cli, "build_paper", build)
+    code = _exit_code(cli._run_publish_paper, _publish_args(str(tmp_path)))
+    assert code == (0 if ok else 1)
+    assert calls == [(str(tmp_path), "mdpi", str(tmp_path / "out" / "mdpi.pdf"))]
+
+
+def test_the_gate_verifies_without_building(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(cli, "detect_templates", lambda _p: ["mdpi"])
+    monkeypatch.setattr(
+        cli, "build_paper", lambda *a: pytest.fail("the gate must not build")
+    )
+
+    async def verified(*_a, **_k):
+        return SimpleNamespace(ok=True, model_dump=dict)
+
+    monkeypatch.setattr(cli, "verify_paper", verified)
+    assert _exit_code(cli._run_verify_paper, _verify_args(str(tmp_path))) == 0

--- a/backend/tests/unit/test_cli_verify_paper_gate.py
+++ b/backend/tests/unit/test_cli_verify_paper_gate.py
@@ -1,0 +1,30 @@
+import argparse
+
+import pytest
+
+from airas import cli
+
+
+def test_paper_gate_passes_when_there_is_no_paper(tmp_path):
+    args = argparse.Namespace(
+        local_path=str(tmp_path),
+        template=None,
+        no_provenance=False,
+        allow_unavailable_provenance=False,
+        no_require_paper_values=False,
+        allow_unavailable_history=False,
+    )
+    with pytest.raises(SystemExit) as exit:
+        cli._run_verify_paper(args)
+    assert exit.value.code == 0
+
+
+def test_publish_is_a_noop_when_there_is_no_paper(tmp_path):
+    args = argparse.Namespace(
+        local_path=str(tmp_path),
+        template=None,
+        output_dir=str(tmp_path / "out"),
+    )
+    with pytest.raises(SystemExit) as exit:
+        cli._run_publish_paper(args)
+    assert exit.value.code == 0

--- a/backend/tests/unit/test_cli_verify_paper_gate.py
+++ b/backend/tests/unit/test_cli_verify_paper_gate.py
@@ -81,3 +81,14 @@ def test_the_gate_verifies_without_building(
 
     monkeypatch.setattr(cli, "verify_paper", verified)
     assert _exit_code(cli._run_verify_paper, _verify_args(str(tmp_path))) == 0
+
+
+def test_an_unsupported_template_fails_even_beside_a_known_one(
+    tmp_path: Path,
+) -> None:
+    # A known template must not hide a paper the gate cannot verify.
+    for name in ("mdpi", "homebrew"):
+        (tmp_path / ".research" / "latex" / name).mkdir(parents=True)
+        (tmp_path / ".research" / "latex" / name / "main.tex").write_text("x")
+    assert _exit_code(cli._run_verify_paper, _verify_args(str(tmp_path))) == 1
+    assert _exit_code(cli._run_publish_paper, _publish_args(str(tmp_path))) == 1

--- a/backend/tests/unit/usecases/recording/test_verify_record.py
+++ b/backend/tests/unit/usecases/recording/test_verify_record.py
@@ -652,3 +652,24 @@ def test_deleting_the_record_after_declaring_it_fails(tmp_path: Path) -> None:
     result = _verify(str(tmp_path))
     assert not result.ok
     assert any("record.json is missing" in p for p in result.problems)
+
+
+def test_a_merge_cannot_hide_a_landed_declaration(tmp_path: Path) -> None:
+    # git merge -s ours makes the protected tip an ancestor while keeping the
+    # rewritten record; git's simplified path walk never listed that tip.
+    _init(tmp_path)
+    save_record(str(tmp_path), ResearchRecord())
+    base = _commit(tmp_path, "initial empty record")
+    save_record(str(tmp_path), _record())
+    _commit(tmp_path, "frozen original claim")
+    _git(tmp_path, "branch", "protected-main")
+    _git(tmp_path, "checkout", "-qb", "side", base)
+    modified = _record()
+    modified.hypotheses[0].claims[0].statement = "CHANGED AFTER FREEZE"
+    save_record(str(tmp_path), modified)
+    _commit(tmp_path, "rewrite claim on side")
+    _git(tmp_path, "merge", "-s", "ours", "--no-edit", "protected-main")
+
+    result = _verify(str(tmp_path))
+    assert not result.ok
+    assert any("statement" in p for p in result.problems)

--- a/backend/tests/unit/usecases/recording/test_verify_record.py
+++ b/backend/tests/unit/usecases/recording/test_verify_record.py
@@ -673,3 +673,94 @@ def test_a_merge_cannot_hide_a_landed_declaration(tmp_path: Path) -> None:
     result = _verify(str(tmp_path))
     assert not result.ok
     assert any("statement" in p for p in result.problems)
+
+
+def _record_with(claim_ids: list[str]) -> ResearchRecord:
+    # One hypothesis with the given claims, run ids unique across claims.
+    return ResearchRecord(
+        hypotheses=[
+            Hypothesis(
+                id="h1",
+                statement="The proposed method beats the baseline.",
+                claims=[
+                    SeyvalClaim(
+                        verifier=SEYVAL,
+                        id=cid,
+                        statement=f"{cid}: proposed beats baseline.",
+                        rationale="Head-to-head on the hypothesis's own metric.",
+                        criterion=Criterion(
+                            metric="accuracy",
+                            subject=f"{cid}-proposed",
+                            reference=f"{cid}-baseline",
+                            op=">=",
+                            margin=0.02,
+                        ),
+                        prediction=Prediction(low=0.02, high=0.04, basis="pilot"),
+                        designs=[
+                            SeyvalDesign(
+                                id="d1",
+                                summary="Head-to-head on one dataset.",
+                                runs=[
+                                    SeyvalRun(run_id=f"{cid}-proposed"),
+                                    SeyvalRun(run_id=f"{cid}-baseline"),
+                                ],
+                            )
+                        ],
+                    )
+                    for cid in claim_ids
+                ],
+            )
+        ]
+    )
+
+
+def _fork(tmp_path: Path) -> str:
+    """c1 on the base; `trunk` appends c2; `side` branches from the base."""
+    _init(tmp_path)
+    save_record(str(tmp_path), _record_with(["c1"]))
+    base = _commit(tmp_path, "c1")
+    _git(tmp_path, "branch", "trunk")
+    _git(tmp_path, "checkout", "-q", "trunk")
+    save_record(str(tmp_path), _record_with(["c1", "c2"]))
+    _commit(tmp_path, "trunk appends c2")
+    _git(tmp_path, "checkout", "-qb", "side", base)
+    return base
+
+
+def test_merging_main_into_a_branch_that_did_not_touch_the_record_passes(
+    tmp_path: Path,
+) -> None:
+    """The realistic update-merge: main appended a claim, the branch only
+    changed code. The merge equals main's record and extends the branch's."""
+    _fork(tmp_path)
+    (tmp_path / "README.md").write_text("code only\n")
+    _commit(tmp_path, "side: code only")
+    _git(tmp_path, "merge", "--no-edit", "trunk")
+
+    result = _verify(str(tmp_path))
+    assert result.ok, result.problems
+
+
+def test_a_merge_of_two_concurrent_appends_is_an_append_only_conflict(
+    tmp_path: Path,
+) -> None:
+    """Append-only lists grow at the end: every revision keeps the prior one
+    as a prefix (reordering fails too). Two branches that each append a
+    claim cannot both be prefixes of one merge, so the merge fails against
+    one parent. Declarations are serialised — the fast-forward-only flow
+    never produces this — and such a merge must be redone as a linear
+    append."""
+    _fork(tmp_path)
+    save_record(str(tmp_path), _record_with(["c1", "c3"]))
+    _commit(tmp_path, "side appends c3")
+    subprocess.run(  # conflicts on record.json; resolved below as the union
+        ["git", "-C", str(tmp_path), "merge", "--no-commit", "--no-edit", "trunk"],
+        capture_output=True,
+    )
+    save_record(str(tmp_path), _record_with(["c1", "c2", "c3"]))
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "merge: union of both appends")
+
+    result = _verify(str(tmp_path))
+    assert not result.ok
+    assert any("changed" in p for p in result.problems)

--- a/backend/tests/unit/usecases/recording/test_verify_record.py
+++ b/backend/tests/unit/usecases/recording/test_verify_record.py
@@ -170,13 +170,12 @@ def _realized_repo(tmp_path: Path, proposed_mode: str = "full") -> Path:
 # --------------------------------------------------- the states that pass
 
 
-def test_a_repository_with_no_record_passes(tmp_path: Path) -> None:
-    """A repository that has made no claim is not contradicting one."""
+def test_a_repository_with_no_record_fails(tmp_path: Path) -> None:
+    """record.json is mandatory: every repository ships one, so its absence is a deletion."""
     _init(tmp_path)
     report = _verify(str(tmp_path))
-    assert report.ok
-    assert report.stage == "prereg"
-    assert report.problems == []
+    assert not report.ok
+    assert any("record.json is missing" in p for p in report.problems)
 
 
 def test_a_preregistered_record_with_no_runs_passes(tmp_path: Path) -> None:
@@ -449,11 +448,10 @@ def test_a_reworded_claim_is_reported_as_violated_history(tmp_path: Path) -> Non
     assert any("statement" in p for p in result.problems)
 
 
-def test_a_repository_without_a_record_is_not_demanded_one(tmp_path: Path) -> None:
+def test_a_missing_record_is_tolerated_when_not_required(tmp_path: Path) -> None:
+    # The escape hatch for a paper that opts out of the record system.
     _init(tmp_path)
-    result = _verify(
-        str(tmp_path), require_history=True, seyval_client_factory=_no_seyval
-    )
+    result = _verify(str(tmp_path), require_record=False)
     assert result.ok
     assert result.stage == "prereg"
 
@@ -632,3 +630,25 @@ def test_a_missing_or_hand_edited_claims_tex_is_caught(tmp_path: Path) -> None:
     claims_tex.unlink()
     result = _verify_paper(str(repo))
     assert any("claims.tex is missing" in p for p in result.problems)
+
+
+def test_an_empty_record_verifies(tmp_path: Path) -> None:
+    # The state every repository ships in: record.json present but empty.
+    (tmp_path / RECORD_PATH).parent.mkdir(parents=True)
+    (tmp_path / RECORD_PATH).write_text("{}")
+    _init(tmp_path)
+
+    result = _verify(str(tmp_path))
+    assert result.ok
+
+
+def test_deleting_the_record_after_declaring_it_fails(tmp_path: Path) -> None:
+    _init(tmp_path)
+    save_record(str(tmp_path), _record())
+    _commit(tmp_path, "preregister")
+    (tmp_path / RECORD_PATH).unlink()
+    _commit(tmp_path, "delete the record")
+
+    result = _verify(str(tmp_path))
+    assert not result.ok
+    assert any("record.json is missing" in p for p in result.problems)

--- a/plugins/airas/skills/publish-paper/SKILL.md
+++ b/plugins/airas/skills/publish-paper/SKILL.md
@@ -98,12 +98,13 @@ shortcut that settles the question.
 ## Official: CI verifies, its artifact is the record
 
 4. **Commit the main.tex edits and push to the staging ref** — not to
-   the protected branch (`git push origin main:verify`). The required
-   check, `Verify Record`, runs there. It is the whole integrity
-   verdict: the record's checks (recomputation, containment history,
-   provenance cross-check) **and the paper's numbers** — values.tex
+   the protected branch (`git push origin main:verify`). The two
+   required checks, `Verify the record` and `Verify the paper`, run
+   there. Together they are the whole integrity verdict: the record's
+   checks (recomputation, containment history, provenance cross-check)
+   in one, **and the paper's numbers** in the other — values.tex
    against its regeneration, declared tables, every `\airasval` key
-   declared. None of that needs LaTeX, so it is fast, and a
+   declared. Neither builds LaTeX, so they are fast, and a
    hand-edited number is caught here, before the sha can land. The
    report is uploaded even when red, so a failure is readable rather
    than merely reported.
@@ -128,8 +129,8 @@ shortcut that settles the question.
 
    The workflow then commits the PDF it built, byte for byte, as
    `.research/latex/{template}/paper.pdf` on the protected branch —
-   through the gate like any other commit (scratch ref, `Verify the
-   record` dispatched on it, fast-forward on green), under the
+   through the gate like any other commit (scratch ref, both required
+   checks dispatched on it, fast-forward on green), under the
    `github-actions[bot]` author. So the paper of record is in the
    repository, not only in an expiring artifact, and it is never a
    PDF built on the agent's machine: **do not commit a locally built


### PR DESCRIPTION
## 概要

#1021 のうち、必須検証の検査ロジックの穴 3 件（項目 4・5・6）を塞ぐ。監査 `docs/ci-gate-audit-2026-09-08.md` で「管理権限も workflow 更新権限も使わず、通常のコミットだけで必須検証を通せる」と再現された抜け道。項目 8（PDF 照合）は本 PR の範囲外で保留、項目 9 は #1029 に分離済み。

## 変更

### 項目 4: paper 検査を required status check にする（deadlock なし）
- 保護ブランチの必須チェックを `Verify the record` ＋ **`Verify the paper`** の 2 本に（`PAPER_GATE_CHECK_NAME`）
- `verify-paper` は**値検査のみ**に（`--no-pdf` は廃止、常に PDF をビルドしない）。paper が無ければ pass（prereg 前を詰まらせない）
- PDF ビルドは新設の **`publish-paper`** に分離（`_verify_build` → 公開 `build_paper`）。ビルドは保護ブランチへ commit し返すため、required にすると deadlock する——だから publish は required にせず verify と分ける
- `verify_paper()` usecase の `pdf_path` は MCP プレビューが使うので維持

### 項目 5: record.json 不在を「初期状態」ではなく「削除」として扱う
- `verify_record` に `require_record`（既定 True）を追加。不在なら fail
- `verify_paper` は自分の `require_record` を透過 → `--no-require-paper-values` と MCP プレビューの escape hatch は維持
- テンプレは commit 1 から空の `record.json` を同梱する前提（下記の同時リリース参照）

### 項目 6: `git merge -s ours` で過去の宣言を隠せる穴
- 履歴取得を `git log -- record.json`（path 簡略化で merge の片親を落とす）から **`git log --full-history --format="%H %P"`** に変更（`commits_with_parents`）
- 比較を「一覧の隣同士」から **「各コミット vs その全ての親」** に。兄弟ブランチは親子でないので比較せず、正当な merge を誤検知しない。線形履歴では親＝隣なので挙動は不変
- 不在は空 record として扱い、途中の削除も縮みとして検出
- `-s ours` で保護 tip の宣言を隠したコミットが赤になる回帰テストを追加

## テスト

`tests/unit/usecases/recording` / `publication` / `mcp` / `test_cli_verify_paper_gate.py`: **212 passed, 15 skipped**（skip は LaTeX ツールチェーン依存）。#1019（claim criterion）の追記テストと共存済み。

## ⚠ airas-template と同時リリース必須

| 本 PR の変更 | 必要な airas-template ブランチ | 欠けた場合 |
|---|---|---|
| 項目 4（paper ゲート必須化） | `feat/decompose-paper-verify-gate`（`verify_paper.yml` 追加、`publish_paper.yml` を `publish-paper` に） | `Verify the paper` が永久 pending で新規リポジトリが詰まる |
| 項目 5（record 不在=fail） | `feat/ship-empty-record`（`.research/record.json` = `{}` 同梱） | prereg 前の全コミットが赤 |

airas 側を先に出すと上記が起きるため、template 側を先に（または同時に）マージすること。

## 関連

- Closes の対象は #1021 の項目 4・5・6（項目 8 は残る）
- 項目 9 → #1029、実験コード側 → #1027 / #1025 / #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fNvXRcLfUxYAHe8MMMdvk
